### PR TITLE
Override addCompletionBlock to provide deterministic completion blocks.

### DIFF
--- a/Sources/Core/Shared/ResultInjection.swift
+++ b/Sources/Core/Shared/ResultInjection.swift
@@ -214,13 +214,13 @@ extension AutomaticInjectionOperationType where Self: Operation {
 /// Protocol for non-Operation types to conform to yet enjoy scheduling in Operation
 public protocol Executor: ResultOperationType, AutomaticInjectionOperationType {
 
-    /** 
+    /**
      Will be called to execute the _work_. When the work is finished, the
-     finish block should be invoked. If any errors were encounted pass 
-     them into the finish block. If the work produces a result, the value 
+     finish block should be invoked. If any errors were encounted pass
+     them into the finish block. If the work produces a result, the value
      should be made available at the `result` property before invoking the
      finish block.
-     
+
      - parameter finish: a closure which receives an ErrorType?
     */
     func execute(finish: ErrorType? -> Void)


### PR DESCRIPTION
In `Operation` we can override `addCompletionBlock(: dispatch_block_t)` to instead add a `DidFinishObserver` instead.

Something like this:

```swift
override func addCompletionBlock(completion: () -> Void) {
    addObserver(DidFinishObserver { _, _ in
        completion()
    }
}
``` 