### PR TITLE
Swift 2.3 - support for new CloudKit operations in iOS 10 / macOS 10.12

### DIFF
--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -337,6 +337,25 @@ public protocol CKFetchRecordZoneChangesOperationType: CKDatabaseOperationType, 
     var fetchRecordZoneChangesCompletionBlock: ((NSError?) -> Void)? { get set }
 }
 
+/// A generic protocol which exposes the properties used by Apple's CKFetchShareMetadataOperation.
+public protocol CKFetchShareMetadataOperationType: CKOperationType {
+
+    /// - returns: the share URLs
+    var shareURLs: [NSURL] { get set }
+
+    /// - returns: whether to fetch the share root record
+    var shouldFetchRootRecord: Bool { get set }
+
+    /// - returns: the share root record desired keys
+    var rootRecordDesiredKeys: [String]? { get set }
+
+    /// - returns: the per share metadata block
+    var perShareMetadataBlock: ((NSURL, ShareMetadata?, NSError?) -> Void)? { get set }
+
+    /// - returns: the fetch share metadata completion block
+    var fetchShareMetadataCompletionBlock: ((NSError?) -> Void)? { get set }
+}
+
 /// A generic protocol which exposes the properties used by Apple's CKFetchSubscriptionsOperation.
 public protocol CKFetchSubscriptionsOperationType: CKDatabaseOperationType {
 
@@ -609,6 +628,13 @@ extension CKFetchRecordZoneChangesOperation: CKFetchRecordZoneChangesOperationTy
 
     /// The type of the CloudKit FetchRecordZoneChangesOptions
     public typealias FetchRecordZoneChangesOptions = CKFetchRecordZoneChangesOptions
+}
+
+@available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+extension CKFetchShareMetadataOperation: CKFetchShareMetadataOperationType, AssociatedErrorType {
+
+    // The associated error type
+    public typealias Error = CloudKitError
 }
 
 extension CKFetchSubscriptionsOperation: CKFetchSubscriptionsOperationType, AssociatedErrorType {

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -185,6 +185,16 @@ public protocol CKAcceptSharesOperationType: CKOperationType {
     var acceptSharesCompletionBlock: ((NSError?) -> Void)? { get set }
 }
 
+/// A generic protocol which exposes the properties used by Apple's CKDiscoverAllUserIdentitiesOperation.
+public protocol CKDiscoverAllUserIdentitiesOperationType: CKOperationType {
+
+    /// - returns: a block for when a user identity is discovered
+    var userIdentityDiscoveredBlock: ((UserIdentity) -> Void)? { get set }
+
+    /// - returns: the completion block used for discovering all user identities
+    var discoverAllUserIdentitiesCompletionBlock: ((NSError?) -> Void)? { get set }
+}
+
 /// A generic protocol which exposes the properties used by Apple's CKDiscoverUserInfosOperation.
 public protocol CKDiscoverUserInfosOperationType: CKOperationType {
 
@@ -465,6 +475,13 @@ extension CKDiscoverAllContactsOperation: CKDiscoverAllContactsOperationType, As
     public typealias Error = DiscoverAllContactsError<DiscoveredUserInfo>
 }
 #endif
+
+@available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+extension CKDiscoverAllUserIdentitiesOperation: CKDiscoverAllUserIdentitiesOperationType, AssociatedErrorType {
+
+    // The associated error type
+    public typealias Error = CloudKitError
+}
 
 extension CKDiscoverUserInfosOperation: CKDiscoverUserInfosOperationType, AssociatedErrorType {
 

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -54,8 +54,57 @@ public protocol CKOperationType: class {
     /// The type of the CloudKit RecordID
     associatedtype RecordID: Hashable
 
+    /// The type of the CloudKit UserIdentity
+    associatedtype UserIdentity
+
+    /// The type of the CloudKit UserIdentityLookupInfo
+    associatedtype UserIdentityLookupInfo
+
+    /// The type of the CloudKit Share
+    associatedtype Share
+
+    /// The type of the CloudKit ShareMetadata
+    associatedtype ShareMetadata
+
+    /// The type of the CloudKit ShareParticipant
+    associatedtype ShareParticipant
+
     /// - returns the CloudKit Container
     var container: Container? { get set }
+
+    /// - returns whether to use cellular data access, if WiFi is unavailable (CKOperation default is true)
+    var allowsCellularAccess: Bool { get set }
+
+    /// - returns a unique identifier for a long-lived CKOperation
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    var operationID: String { get }
+
+    /// - returns whether the operation is long-lived
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    var longLived: Bool { get set }
+
+    /// The type of the CKOperation longLivedOperationWasPersistedBlock
+    associatedtype CKOperationLongLivedOperationWasPersistedBlock
+
+    #if swift(>=3.0) // TEMPORARY FIX: Swift 2.3 compiler crash
+        // The Swift 2.3 compiler (as of Xcode 8 beta 4) crashes with a fatal error caused by
+        // the following declaration & the extension CKOperation: CKOperationType { }
+        // The Swift 3.0 compiler has no issue. As of now, no workaround is available besides using Swift 3.0.
+        //
+        /// - returns the block to execute when the server starts storing callbacks for this long-lived CKOperation
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        var longLivedOperationWasPersistedBlock: CKOperationLongLivedOperationWasPersistedBlock { get set }
+    #endif
+
+    /// If non-zero, overrides the timeout interval for any network requests issued by this operation.
+    /// See NSURLSessionConfiguration.timeoutIntervalForRequest
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    var timeoutIntervalForRequest: NSTimeInterval { get set }
+
+    /// If non-zero, overrides the timeout interval for any network resources retrieved by this operation.
+    /// See NSURLSessionConfiguration.timeoutIntervalForResource
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    var timeoutIntervalForResource: NSTimeInterval { get set }
 }
 
 /**
@@ -315,6 +364,10 @@ extension CKOperation: CKOperationType {
     public typealias ServerChangeToken = CKServerChangeToken
 
     /// The DiscoveredUserInfo is a CKDiscoveredUserInfo
+    @available(iOS, introduced=8.0, deprecated=10.0, message="Replaced by CKUserIdentity")
+    @available(OSX, introduced=10.10, deprecated=10.12, message="Replaced by CKUserIdentity")
+    @available(tvOS, introduced=8.0, deprecated=10.0, message="Replaced by CKUserIdentity")
+    @available(watchOS, introduced=2.0, deprecated=3.0, message="Replaced by CKUserIdentity")
     public typealias DiscoveredUserInfo = CKDiscoveredUserInfo
 
     /// The RecordZone is a CKRecordZone
@@ -346,6 +399,29 @@ extension CKOperation: CKOperationType {
 
     /// The QueryCursor is a CKQueryCursor
     public typealias QueryCursor = CKQueryCursor
+
+    /// The UserIdentity is a CKUserIdentity
+    @available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+    public typealias UserIdentity = CKUserIdentity
+
+    /// The UserIdentityLookupInfo is a CKUserIdentityLookupInfo
+    @available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+    public typealias UserIdentityLookupInfo = CKUserIdentityLookupInfo
+
+    /// The Share is a CKShare
+    @available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+    public typealias Share = CKShare
+
+    /// The ShareMetadata is a CKShareMetadata
+    @available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+    public typealias ShareMetadata = CKShareMetadata
+
+    /// The ShareParticipant is a CKShareParticipant
+    @available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+    public typealias ShareParticipant = CKShareParticipant
+
+    /// The CKOperationLongLivedOperationWasPersistedBlock is () -> Void
+    public typealias CKOperationLongLivedOperationWasPersistedBlock = () -> Void
 }
 
 extension CKDatabaseOperation: CKDatabaseOperationType {

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -251,6 +251,22 @@ public protocol CKModifyBadgeOperationType: CKOperationType {
     var modifyBadgeCompletionBlock: ((NSError?) -> Void)? { get set }
 }
 
+/// A generic protocol which exposes the properties used by Apple's CKFetchDatabaseChangesOperationType.
+public protocol CKFetchDatabaseChangesOperationType: CKDatabaseOperationType, CKFetchAllChanges, CKPreviousServerChangeToken, CKResultsLimit {
+
+    /// - returns: a block for when a the changeToken is updated
+    var changeTokenUpdatedBlock: ((ServerChangeToken) -> Void)? { get set }
+
+    /// - returns: a block for when a recordZone was changed
+    var recordZoneWithIDChangedBlock: ((RecordZoneID) -> Void)? { get set }
+
+    /// - returns: a block for when a recordZone was deleted
+    var recordZoneWithIDWasDeletedBlock: ((RecordZoneID) -> Void)? { get set }
+
+    /// - returns: the completion for fetching database changes
+    var fetchDatabaseChangesCompletionBlock: ((ServerChangeToken?, Bool, NSError?) -> Void)? { get set }
+}
+
 /// A generic protocol which exposes the properties used by Apple's CKFetchRecordChangesOperation.
 public protocol CKFetchRecordChangesOperationType: CKDatabaseOperationType, CKFetchOperationType, CKDesiredKeys {
 
@@ -530,6 +546,13 @@ extension CKModifyBadgeOperation: CKModifyBadgeOperationType, AssociatedErrorTyp
 
     // The associated error type
     public typealias Error = CloudKitError
+}
+
+@available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+extension CKFetchDatabaseChangesOperation: CKFetchDatabaseChangesOperationType, AssociatedErrorType {
+
+    // The associated error type
+    public typealias Error = FetchDatabaseChangesError<ServerChangeToken>
 }
 
 extension CKFetchRecordChangesOperation: CKFetchRecordChangesOperationType, AssociatedErrorType {

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -507,8 +507,13 @@ extension CKOperation: CKOperationType {
     /// The RecordID is a CKRecordID
     public typealias RecordID = CKRecordID
 
-    /// The Subscription is a CKSubscription
-    public typealias Subscription = CKSubscription
+    #if !os(watchOS)
+        /// The Subscription is a CKSubscription
+        public typealias Subscription = CKSubscription
+    #else
+        // CKSubscription is unsupported on watchOS
+        public typealias Subscription = Void
+    #endif
 
     /// The RecordSavePolicy is a CKRecordSavePolicy
     public typealias RecordSavePolicy = CKRecordSavePolicy
@@ -668,11 +673,13 @@ extension CKFetchShareParticipantsOperation: CKFetchShareParticipantsOperationTy
     public typealias Error = CloudKitError
 }
 
+#if !os(watchOS)
 extension CKFetchSubscriptionsOperation: CKFetchSubscriptionsOperationType, AssociatedErrorType {
 
     // The associated error type
     public typealias Error = FetchSubscriptionsError<Subscription>
 }
+#endif
 
 extension CKModifyRecordZonesOperation: CKModifyRecordZonesOperationType, AssociatedErrorType, BatchModifyOperationType {
 
@@ -706,6 +713,7 @@ extension CKModifyRecordsOperation: CKModifyRecordsOperationType, AssociatedErro
     }
 }
 
+#if !os(watchOS)
 extension CKModifySubscriptionsOperation: CKModifySubscriptionsOperationType, AssociatedErrorType, BatchModifyOperationType {
 
     // The associated error type
@@ -721,6 +729,7 @@ extension CKModifySubscriptionsOperation: CKModifySubscriptionsOperationType, As
         set { subscriptionIDsToDelete = newValue }
     }
 }
+#endif
 
 extension CKQueryOperation: CKQueryOperationType, AssociatedErrorType {
 

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -558,6 +558,9 @@ extension CKAcceptSharesOperation: CKAcceptSharesOperationType, AssociatedErrorT
 
 /// Extension to have CKDiscoverAllContactsOperation conform to CKDiscoverAllContactsOperationType
 #if !os(tvOS)
+@available(iOS, introduced=8.0, deprecated=10.0, message="Use CKDiscoverAllUserIdentitiesOperation instead")
+@available(OSX, introduced=10.10, deprecated=10.12, message="Use CKDiscoverAllUserIdentitiesOperation instead")
+@available(watchOS, introduced=2.0, deprecated=3.0, message="Use CKDiscoverAllUserIdentitiesOperation instead")
 extension CKDiscoverAllContactsOperation: CKDiscoverAllContactsOperationType, AssociatedErrorType {
 
     // The associated error type
@@ -572,6 +575,10 @@ extension CKDiscoverAllUserIdentitiesOperation: CKDiscoverAllUserIdentitiesOpera
     public typealias Error = CloudKitError
 }
 
+@available(iOS, introduced=8.0, deprecated=10.0, message="Use CKDiscoverUserIdentitiesOperation instead")
+@available(OSX, introduced=10.10, deprecated=10.12, message="Use CKDiscoverUserIdentitiesOperation instead")
+@available(tvOS, introduced=8.0, deprecated=10.0, message="Use CKDiscoverUserIdentitiesOperation instead")
+@available(watchOS, introduced=2.0, deprecated=3.0, message="Use CKDiscoverUserIdentitiesOperation instead")
 extension CKDiscoverUserInfosOperation: CKDiscoverUserInfosOperationType, AssociatedErrorType {
 
     // The associated error type
@@ -615,6 +622,10 @@ extension CKFetchDatabaseChangesOperation: CKFetchDatabaseChangesOperationType, 
     public typealias Error = FetchDatabaseChangesError<ServerChangeToken>
 }
 
+@available(iOS, introduced=8.0, deprecated=10.0, message="Use CKFetchRecordZoneChangesOperation instead")
+@available(OSX, introduced=10.10, deprecated=10.12, message="Use CKFetchRecordZoneChangesOperation instead")
+@available(tvOS, introduced=8.0, deprecated=10.0, message="Use CKFetchRecordZoneChangesOperation instead")
+@available(watchOS, introduced=2.0, deprecated=3.0, message="Use CKFetchRecordZoneChangesOperation instead")
 extension CKFetchRecordChangesOperation: CKFetchRecordChangesOperationType, AssociatedErrorType {
 
     // The associated error type

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -9,6 +9,8 @@
 import Foundation
 import CloudKit
 
+// swiftlint:disable file_length
+
 /**
  A generic protocol which exposes the types and properties used by
  Apple's CloudKit Operation types.
@@ -736,3 +738,5 @@ extension CKQueryOperation: CKQueryOperationType, AssociatedErrorType {
     // The associated error type
     public typealias Error = QueryError<QueryCursor>
 }
+
+// swiftlint:enable file_length

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -571,12 +571,14 @@ extension CKDiscoverAllContactsOperation: CKDiscoverAllContactsOperationType, As
 }
 #endif
 
-@available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+#if !os(tvOS)
+@available(iOS 10.0, OSX 10.12, watchOS 3.0, *)
 extension CKDiscoverAllUserIdentitiesOperation: CKDiscoverAllUserIdentitiesOperationType, AssociatedErrorType {
 
     // The associated error type
     public typealias Error = CloudKitError
 }
+#endif
 
 @available(iOS, introduced=8.0, deprecated=10.0, message="Use CKDiscoverUserIdentitiesOperation instead")
 @available(OSX, introduced=10.10, deprecated=10.12, message="Use CKDiscoverUserIdentitiesOperation instead")

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -309,6 +309,34 @@ public protocol CKFetchRecordsOperationType: CKDatabaseOperationType, CKDesiredK
     var fetchRecordsCompletionBlock: (([RecordID: Record]?, NSError?) -> Void)? { get set }
 }
 
+/// A generic protocol which exposes the properties used by Apple's CKFetchRecordZoneChangesOperation.
+public protocol CKFetchRecordZoneChangesOperationType: CKDatabaseOperationType, CKFetchAllChanges {
+
+    /// The type of the CloudKit FetchRecordZoneChangesOptions
+    associatedtype FetchRecordZoneChangesOptions
+
+    /// - returns: the record zone IDs which will fetch changes
+    var recordZoneIDs: [RecordZoneID] { get set }
+
+    /// - returns: the per-record-zone options
+    var optionsByRecordZoneID: [RecordZoneID : FetchRecordZoneChangesOptions]? { get set }
+
+    /// - returns: a block for when a record is changed
+    var recordChangedBlock: ((Record) -> Void)? { get set }
+
+    /// - returns: a block for when a recordID is deleted (receives the recordID and the recordType)
+    var recordWithIDWasDeletedBlock: ((RecordID, String) -> Void)? { get set }
+
+    /// - returns: a block for when a recordZone changeToken update is sent
+    var recordZoneChangeTokensUpdatedBlock: ((RecordZoneID, ServerChangeToken?, NSData?) -> Void)? { get set }
+
+    /// - returns: a block for when a recordZone fetch is complete
+    var recordZoneFetchCompletionBlock: ((RecordZoneID, ServerChangeToken?, NSData?, Bool, NSError?) -> Void)? { get set }
+
+    /// - returns: the completion for fetching records (i.e. for the entire operation)
+    var fetchRecordZoneChangesCompletionBlock: ((NSError?) -> Void)? { get set }
+}
+
 /// A generic protocol which exposes the properties used by Apple's CKFetchSubscriptionsOperation.
 public protocol CKFetchSubscriptionsOperationType: CKDatabaseOperationType {
 
@@ -571,6 +599,16 @@ extension CKFetchRecordsOperation: CKFetchRecordsOperationType, AssociatedErrorT
 
     // The associated error type
     public typealias Error = FetchRecordsError<Record, RecordID>
+}
+
+@available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+extension CKFetchRecordZoneChangesOperation: CKFetchRecordZoneChangesOperationType, AssociatedErrorType {
+
+    // The associated error type
+    public typealias Error = FetchRecordZoneChangesError
+
+    /// The type of the CloudKit FetchRecordZoneChangesOptions
+    public typealias FetchRecordZoneChangesOptions = CKFetchRecordZoneChangesOptions
 }
 
 extension CKFetchSubscriptionsOperation: CKFetchSubscriptionsOperationType, AssociatedErrorType {

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -208,6 +208,19 @@ public protocol CKDiscoverUserInfosOperationType: CKOperationType {
     var discoverUserInfosCompletionBlock: (([String: DiscoveredUserInfo]?, [RecordID: DiscoveredUserInfo]?, NSError?) -> Void)? { get set }
 }
 
+/// A generic protocol which exposes the properties used by Apple's CKDiscoverUserIdentitiesOperation.
+public protocol CKDiscoverUserIdentitiesOperationType: CKOperationType {
+
+    /// - returns: the user identity lookup info used in discovery
+    var userIdentityLookupInfos: [UserIdentityLookupInfo] { get set }
+
+    /// - returns: the block used to return discovered user identities
+    var userIdentityDiscoveredBlock: ((UserIdentity, UserIdentityLookupInfo) -> Void)? { get set }
+
+    /// - returns: the completion block used for discovering user identities
+    var discoverUserIdentitiesCompletionBlock: ((NSError?) -> Void)? { get set }
+}
+
 /// A generic protocol which exposes the properties used by Apple's CKFetchNotificationChangesOperation.
 public protocol CKFetchNotificationChangesOperationType: CKFetchOperationType {
 
@@ -484,6 +497,13 @@ extension CKDiscoverAllUserIdentitiesOperation: CKDiscoverAllUserIdentitiesOpera
 }
 
 extension CKDiscoverUserInfosOperation: CKDiscoverUserInfosOperationType, AssociatedErrorType {
+
+    // The associated error type
+    public typealias Error = CloudKitError
+}
+
+@available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+extension CKDiscoverUserIdentitiesOperation: CKDiscoverUserIdentitiesOperationType, AssociatedErrorType {
 
     // The associated error type
     public typealias Error = CloudKitError

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -145,6 +145,13 @@ public protocol CKMoreComing: CKOperationType {
     var moreComing: Bool { get }
 }
 
+/// A generic protocol which exposes the properties used by Apple's CloudKit Operation's which have a flag to fetch all changes.
+public protocol CKFetchAllChanges: CKOperationType {
+
+    /// - returns: whether there are more results on the server
+    var fetchAllChanges: Bool { get set }
+}
+
 /// A generic protocol which exposes the properties used by Apple's CloudKit Operation's which have desired keys.
 public protocol CKDesiredKeys: CKOperationType {
 

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -384,8 +384,6 @@ public protocol CKFetchSubscriptionsOperationType: CKDatabaseOperationType {
 /// A generic protocol which exposes the properties used by Apple's CKModifyRecordZonesOperation.
 public protocol CKModifyRecordZonesOperationType: CKDatabaseOperationType {
 
-    associatedtype Error = ModifyRecordZonesError<RecordZone, RecordZoneID>
-
     /// - returns: the record zones to save
     var recordZonesToSave: [RecordZone]? { get set }
 
@@ -398,8 +396,6 @@ public protocol CKModifyRecordZonesOperationType: CKDatabaseOperationType {
 
 // A generic protocol which exposes the properties used by Apple's CKModifyRecordsOperation.
 public protocol CKModifyRecordsOperationType: CKDatabaseOperationType {
-
-    associatedtype Error = ModifyRecordsError<Record, RecordID>
 
     /// - returns: the records to save
     var recordsToSave: [Record]? { get set }

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -172,6 +172,19 @@ public protocol CKDiscoverAllContactsOperationType: CKOperationType {
     var discoverAllContactsCompletionBlock: (([DiscoveredUserInfo]?, NSError?) -> Void)? { get set }
 }
 
+/// A generic protocol which exposes the properties used by Apple's CKAcceptSharesOperation.
+public protocol CKAcceptSharesOperationType: CKOperationType {
+
+    /// - returns: the share metadatas
+    var shareMetadatas: [ShareMetadata] { get set }
+
+    /// - returns: the block used to return accepted shares
+    var perShareCompletionBlock: ((ShareMetadata, Share?, NSError?) -> Void)? { get set }
+
+    /// - returns: the completion block used for accepting shares
+    var acceptSharesCompletionBlock: ((NSError?) -> Void)? { get set }
+}
+
 /// A generic protocol which exposes the properties used by Apple's CKDiscoverUserInfosOperation.
 public protocol CKDiscoverUserInfosOperationType: CKOperationType {
 
@@ -435,6 +448,13 @@ extension CKDatabaseOperation: CKDatabaseOperationType {
 
     /// The Database is a CKDatabase
     public typealias Database = CKDatabase
+}
+
+@available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+extension CKAcceptSharesOperation: CKAcceptSharesOperationType, AssociatedErrorType {
+
+    // The associated error type
+    public typealias Error = CloudKitError
 }
 
 /// Extension to have CKDiscoverAllContactsOperation conform to CKDiscoverAllContactsOperationType

--- a/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitInterface.swift
@@ -356,6 +356,19 @@ public protocol CKFetchShareMetadataOperationType: CKOperationType {
     var fetchShareMetadataCompletionBlock: ((NSError?) -> Void)? { get set }
 }
 
+/// A generic protocol which exposes the properties used by Apple's CKFetchShareParticipantsOperation.
+public protocol CKFetchShareParticipantsOperationType: CKOperationType {
+
+    /// - returns: the user identity lookup infos
+    var userIdentityLookupInfos: [UserIdentityLookupInfo] { get set }
+
+    /// - returns: the share participant fetched block
+    var shareParticipantFetchedBlock: ((ShareParticipant) -> Void)? { get set }
+
+    /// - returns: the fetch share participants completion block
+    var fetchShareParticipantsCompletionBlock: ((NSError?) -> Void)? { get set }
+}
+
 /// A generic protocol which exposes the properties used by Apple's CKFetchSubscriptionsOperation.
 public protocol CKFetchSubscriptionsOperationType: CKDatabaseOperationType {
 
@@ -632,6 +645,13 @@ extension CKFetchRecordZoneChangesOperation: CKFetchRecordZoneChangesOperationTy
 
 @available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
 extension CKFetchShareMetadataOperation: CKFetchShareMetadataOperationType, AssociatedErrorType {
+
+    // The associated error type
+    public typealias Error = CloudKitError
+}
+
+@available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+extension CKFetchShareParticipantsOperation: CKFetchShareParticipantsOperationType, AssociatedErrorType {
 
     // The associated error type
     public typealias Error = CloudKitError

--- a/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
@@ -668,6 +668,70 @@ extension CloudKitOperation where T: CKDiscoverUserInfosOperationType {
     }
 }
 
+// MARK: - CKDiscoverUserIdentitiesOperation
+
+extension OPRCKOperation where T: CKDiscoverUserIdentitiesOperationType, T: AssociatedErrorType, T.Error: CloudKitErrorType {
+
+    public var userIdentityLookupInfos: [T.UserIdentityLookupInfo] {
+        get { return operation.userIdentityLookupInfos }
+        set { operation.userIdentityLookupInfos = newValue }
+    }
+
+    public var userIdentityDiscoveredBlock: CloudKitOperation<T>.DiscoverUserIdentitiesUserIdentityDiscoveredBlock? {
+        get { return operation.userIdentityDiscoveredBlock }
+        set { operation.userIdentityDiscoveredBlock = newValue }
+    }
+
+    func setDiscoverUserIdentitiesCompletionBlock(block: CloudKitOperation<T>.DiscoverUserIdentitiesCompletionBlock) {
+        operation.discoverUserIdentitiesCompletionBlock = { [unowned self] error in
+            if let error = error {
+                self.addFatalError(CloudKitError(error: error))
+            }
+            else {
+                block()
+            }
+        }
+    }
+}
+
+extension CloudKitOperation where T: CKDiscoverUserIdentitiesOperationType {
+
+    /// A typealias for the block type used by CloudKitOperation<CKDiscoverUserIdentitiesOperationType>
+    public typealias DiscoverUserIdentitiesUserIdentityDiscoveredBlock = (T.UserIdentity, T.UserIdentityLookupInfo) -> Void
+
+    /// A typealias for the block type used by CloudKitOperation<CKDiscoverUserIdentitiesOperationType>
+    public typealias DiscoverUserIdentitiesCompletionBlock = () -> Void
+
+    /// - returns: the user identity lookup info used in discovery
+    public var userIdentityLookupInfos: [T.UserIdentityLookupInfo] {
+        get { return operation.userIdentityLookupInfos }
+        set {
+            operation.userIdentityLookupInfos = newValue
+            addConfigureBlock { $0.userIdentityLookupInfos = newValue }
+        }
+    }
+
+    /// - returns: the block used to return discovered user identities
+    var userIdentityDiscoveredBlock: DiscoverUserIdentitiesUserIdentityDiscoveredBlock? {
+        get { return operation.userIdentityDiscoveredBlock }
+        set {
+            operation.userIdentityDiscoveredBlock = newValue
+            addConfigureBlock { $0.userIdentityDiscoveredBlock = newValue }
+        }
+    }
+
+    /**
+     Before adding the CloudKitOperation instance to a queue, set a completion block
+     to collect the results in the successful case. Setting this completion block also
+     ensures that error handling gets triggered.
+
+     - parameter block: a DiscoverUserIdentitiesCompletionBlock block
+     */
+    public func setDiscoverUserIdentitiesCompletionBlock(block: DiscoverUserIdentitiesCompletionBlock) {
+        addConfigureBlock { $0.setDiscoverUserIdentitiesCompletionBlock(block) }
+    }
+}
+
 // MARK: - CKFetchNotificationChangesOperation
 
 public struct FetchNotificationChangesError<ServerChangeToken>: CloudKitErrorType {

--- a/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
@@ -1303,6 +1303,136 @@ extension CloudKitOperation where T: CKFetchRecordsOperationType {
     }
 }
 
+// MARK: - CKFetchRecordZoneChangesOperation (iOS 10+, macOS 10.12+, tvOS 10.0+, watchOS 3.0+)
+
+public struct FetchRecordZoneChangesError: CloudKitErrorType {
+
+    public let underlyingError: NSError
+
+    init(error: NSError) {
+        self.underlyingError = error
+    }
+}
+
+extension OPRCKOperation where T: CKFetchRecordZoneChangesOperationType, T: AssociatedErrorType, T.Error: CloudKitErrorType {
+
+    /// - returns: the record zone IDs which will fetch changes
+    public var recordZoneIDs: [T.RecordZoneID] {
+        get { return operation.recordZoneIDs }
+        set { operation.recordZoneIDs = newValue }
+    }
+
+    /// - returns: the per-record-zone options
+    public var optionsByRecordZoneID: [T.RecordZoneID : T.FetchRecordZoneChangesOptions]? {
+        get { return operation.optionsByRecordZoneID }
+        set { operation.optionsByRecordZoneID = newValue }
+    }
+
+    /// - returns: a block for when a record is changed
+    public var recordChangedBlock: CloudKitOperation<T>.FetchRecordZoneChangesRecordChangedBlock? {
+        get { return operation.recordChangedBlock }
+        set { operation.recordChangedBlock = newValue }
+    }
+
+    /// - returns: a block for when a recordID is deleted (receives the recordID and the recordType)
+    public var recordWithIDWasDeletedBlock: CloudKitOperation<T>.FetchRecordZoneChangesRecordWithIDWasDeletedBlock? {
+        get { return operation.recordWithIDWasDeletedBlock }
+        set { operation.recordWithIDWasDeletedBlock = newValue }
+    }
+
+    /// - returns: a block for when a recordZone changeToken update is sent
+    public var recordZoneChangeTokensUpdatedBlock: CloudKitOperation<T>.FetchRecordZoneChangesRecordZoneChangeTokensUpdatedBlock? {
+        get { return operation.recordZoneChangeTokensUpdatedBlock }
+        set { operation.recordZoneChangeTokensUpdatedBlock = newValue }
+    }
+
+    /// - returns: the completion for fetching records (i.e. for the entire operation)
+    func setFetchRecordZoneChangesCompletionBlock(block: CloudKitOperation<T>.FetchRecordZoneChangesCompletionBlock) {
+        operation.fetchRecordZoneChangesCompletionBlock = { [unowned self] error in
+            if let error = error {
+                self.addFatalError(FetchRecordZoneChangesError(error: error))
+            }
+            else {
+                block()
+            }
+        }
+    }
+}
+
+extension CloudKitOperation where T: CKFetchRecordZoneChangesOperationType {
+
+    /// A typealias for the block types used by CloudKitOperation<CKFetchRecordZoneChangesOperationType>
+    public typealias FetchRecordZoneChangesRecordChangedBlock = T.Record -> Void
+
+    /// A typealias for the block types used by CloudKitOperation<CKFetchRecordZoneChangesOperationType>
+    public typealias FetchRecordZoneChangesRecordWithIDWasDeletedBlock = (T.RecordID, String) -> Void
+
+    /// A typealias for the block types used by CloudKitOperation<CKFetchRecordZoneChangesOperationType>
+    public typealias FetchRecordZoneChangesRecordZoneChangeTokensUpdatedBlock = (T.RecordZoneID, T.ServerChangeToken?, NSData?) -> Void
+
+    /// A typealias for the block types used by CloudKitOperation<CKFetchRecordZoneChangesOperationType>
+    public typealias FetchRecordChangesCompletionRecordZoneFetchCompletionBlock = (T.RecordZoneID, T.ServerChangeToken?, NSData?, Bool, NSError?) -> Void
+
+    /// A typealias for the block types used by CloudKitOperation<CKFetchRecordZoneChangesOperationType>
+    public typealias FetchRecordZoneChangesCompletionBlock = (Void) -> Void
+
+    /// - returns: the record zone IDs which will fetch changes
+    public var recordZoneIDs: [T.RecordZoneID] {
+        get { return operation.recordZoneIDs }
+        set {
+            operation.recordZoneIDs = newValue
+            addConfigureBlock { $0.recordZoneIDs = newValue }
+        }
+    }
+
+    /// - returns: the per-record-zone options
+    var optionsByRecordZoneID: [T.RecordZoneID : T.FetchRecordZoneChangesOptions]? {
+        get { return operation.optionsByRecordZoneID }
+        set {
+            operation.optionsByRecordZoneID = newValue
+            addConfigureBlock { $0.optionsByRecordZoneID = newValue }
+        }
+    }
+
+    /// - returns: a block for when a record is changed
+    var recordChangedBlock: FetchRecordZoneChangesRecordChangedBlock? {
+        get { return operation.recordChangedBlock }
+        set {
+            operation.recordChangedBlock = newValue
+            addConfigureBlock { $0.recordChangedBlock = newValue }
+        }
+    }
+
+    /// - returns: a block for when a recordID is deleted (receives the recordID and the recordType)
+    var recordWithIDWasDeletedBlock: FetchRecordZoneChangesRecordWithIDWasDeletedBlock? {
+        get { return operation.recordWithIDWasDeletedBlock }
+        set {
+            operation.recordWithIDWasDeletedBlock = newValue
+            addConfigureBlock { $0.recordWithIDWasDeletedBlock = newValue }
+        }
+    }
+
+    /// - returns: a block for when a recordZone changeToken update is sent
+    var recordZoneChangeTokensUpdatedBlock: FetchRecordZoneChangesRecordZoneChangeTokensUpdatedBlock? {
+        get { return operation.recordZoneChangeTokensUpdatedBlock }
+        set {
+            operation.recordZoneChangeTokensUpdatedBlock = newValue
+            addConfigureBlock { $0.recordZoneChangeTokensUpdatedBlock = newValue }
+        }
+    }
+
+    /**
+     Before adding the CloudKitOperation instance to a queue, set a completion block
+     to collect the results in the successful case. Setting this completion block also
+     ensures that error handling gets triggered.
+
+     - parameter block: a FetchRecordZoneChangesCompletionBlock block
+     */
+    public func setFetchRecordZoneChangesCompletionBlock(block: FetchRecordZoneChangesCompletionBlock) {
+        addConfigureBlock { $0.setFetchRecordZoneChangesCompletionBlock(block) }
+    }
+}
+
 // MARK: - CKFetchSubscriptionsOperation
 
 public struct FetchSubscriptionsError<Subscription>: CloudKitErrorType {

--- a/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
@@ -38,7 +38,7 @@ extension OPRCKOperation where T: CKOperationType {
 
     #if swift(>=3.0) // TEMPORARY FIX: Swift 2.3 compiler crash (see: CloudKitInterface.swift)
         @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
-        var longLivedOperationWasPersistedBlock: () -> Swift.Void {
+        var longLivedOperationWasPersistedBlock: () -> Void {
             get { return operation.longLivedOperationWasPersistedBlock }
             set { operation.longLivedOperationWasPersistedBlock = newValue }
         }
@@ -96,7 +96,7 @@ extension CloudKitOperation where T: CKOperationType {
     #if swift(>=3.0) // TEMPORARY FIX: Swift 2.3 compiler crash (see: CloudKitInterface.swift)
         /// - returns the block to execute when the server starts storing callbacks for this long-lived CKOperation
         @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
-        var longLivedOperationWasPersistedBlock: () -> Swift.Void {
+        public var longLivedOperationWasPersistedBlock: () -> Void {
             get { return operation.longLivedOperationWasPersistedBlock }
             set {
                 operation.longLivedOperationWasPersistedBlock = newValue
@@ -108,7 +108,7 @@ extension CloudKitOperation where T: CKOperationType {
     /// If non-zero, overrides the timeout interval for any network requests issued by this operation.
     /// See NSURLSessionConfiguration.timeoutIntervalForRequest
     @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
-    var timeoutIntervalForRequest: NSTimeInterval  {
+    public var timeoutIntervalForRequest: NSTimeInterval  {
         get { return operation.timeoutIntervalForRequest }
         set {
             operation.timeoutIntervalForRequest = newValue
@@ -119,7 +119,7 @@ extension CloudKitOperation where T: CKOperationType {
     /// If non-zero, overrides the timeout interval for any network resources retrieved by this operation.
     /// See NSURLSessionConfiguration.timeoutIntervalForResource
     @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
-    var timeoutIntervalForResource: NSTimeInterval {
+    public var timeoutIntervalForResource: NSTimeInterval {
         get { return operation.timeoutIntervalForResource }
         set {
             operation.timeoutIntervalForResource = newValue
@@ -167,7 +167,7 @@ extension BatchedCloudKitOperation where T: CKOperationType {
     #if swift(>=3.0) // TEMPORARY FIX: Swift 2.3 compiler crash (see: CloudKitInterface.swift)
         /// - returns the block to execute when the server starts storing callbacks for this long-lived CKOperation
         @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
-        var longLivedOperationWasPersistedBlock: () -> Swift.Void {
+        public var longLivedOperationWasPersistedBlock: () -> Void {
             get { return operation.longLivedOperationWasPersistedBlock }
             set {
                 operation.longLivedOperationWasPersistedBlock = newValue
@@ -179,7 +179,7 @@ extension BatchedCloudKitOperation where T: CKOperationType {
     /// If non-zero, overrides the timeout interval for any network requests issued by this operation.
     /// See NSURLSessionConfiguration.timeoutIntervalForRequest
     @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
-    var timeoutIntervalForRequest: NSTimeInterval  {
+    public var timeoutIntervalForRequest: NSTimeInterval  {
         get { return operation.timeoutIntervalForRequest }
         set {
             operation.timeoutIntervalForRequest = newValue
@@ -190,7 +190,7 @@ extension BatchedCloudKitOperation where T: CKOperationType {
     /// If non-zero, overrides the timeout interval for any network resources retrieved by this operation.
     /// See NSURLSessionConfiguration.timeoutIntervalForResource
     @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
-    var timeoutIntervalForResource: NSTimeInterval {
+    public var timeoutIntervalForResource: NSTimeInterval {
         get { return operation.timeoutIntervalForResource }
         set {
             operation.timeoutIntervalForResource = newValue
@@ -484,7 +484,7 @@ extension CloudKitOperation where T: CKAcceptSharesOperationType {
     public typealias AcceptSharesCompletionBlock = () -> Void
 
     /// - returns: the share metadatas
-    var shareMetadatas: [T.ShareMetadata] {
+    public var shareMetadatas: [T.ShareMetadata] {
         get { return operation.shareMetadatas }
         set {
             operation.shareMetadatas = newValue
@@ -493,7 +493,7 @@ extension CloudKitOperation where T: CKAcceptSharesOperationType {
     }
 
     /// - returns: the block used to return accepted shares
-    var perShareCompletionBlock: AcceptSharesPerShareCompletionBlock? {
+    public var perShareCompletionBlock: AcceptSharesPerShareCompletionBlock? {
         get { return operation.perShareCompletionBlock }
         set {
             operation.perShareCompletionBlock = newValue
@@ -587,7 +587,7 @@ extension CloudKitOperation where T: CKDiscoverAllUserIdentitiesOperationType {
     public typealias DiscoverAllUserIdentitiesCompletionBlock = () -> Void
 
     /// - returns: a block for when a recordZone changeToken update is sent
-    var userIdentityDiscoveredBlock: DiscoverAllUserIdentitiesUserIdentityDiscoveredBlock? {
+    public var userIdentityDiscoveredBlock: DiscoverAllUserIdentitiesUserIdentityDiscoveredBlock? {
         get { return operation.userIdentityDiscoveredBlock }
         set {
             operation.userIdentityDiscoveredBlock = newValue
@@ -712,7 +712,7 @@ extension CloudKitOperation where T: CKDiscoverUserIdentitiesOperationType {
     }
 
     /// - returns: the block used to return discovered user identities
-    var userIdentityDiscoveredBlock: DiscoverUserIdentitiesUserIdentityDiscoveredBlock? {
+    public var userIdentityDiscoveredBlock: DiscoverUserIdentitiesUserIdentityDiscoveredBlock? {
         get { return operation.userIdentityDiscoveredBlock }
         set {
             operation.userIdentityDiscoveredBlock = newValue
@@ -980,7 +980,7 @@ extension CloudKitOperation where T: CKFetchDatabaseChangesOperationType {
     public typealias FetchDatabaseChangesCompletionBlock = (serverChangeToken: T.ServerChangeToken?, moreComing: Bool) -> Void
 
     /// - returns: a block for when a record is changed
-    var recordZoneWithIDChangedBlock: FetchDatabaseChangesRecordZoneWithIDChangedBlock? {
+    public var recordZoneWithIDChangedBlock: FetchDatabaseChangesRecordZoneWithIDChangedBlock? {
         get { return operation.recordZoneWithIDChangedBlock }
         set {
             operation.recordZoneWithIDChangedBlock = newValue
@@ -989,7 +989,7 @@ extension CloudKitOperation where T: CKFetchDatabaseChangesOperationType {
     }
 
     /// - returns: a block for when a recordID is deleted (receives the recordID and the recordType)
-    var recordZoneWithIDWasDeletedBlock: FetchDatabaseChangesRecordZoneWithIDWasDeletedBlock? {
+    public var recordZoneWithIDWasDeletedBlock: FetchDatabaseChangesRecordZoneWithIDWasDeletedBlock? {
         get { return operation.recordZoneWithIDWasDeletedBlock }
         set {
             operation.recordZoneWithIDWasDeletedBlock = newValue
@@ -998,7 +998,7 @@ extension CloudKitOperation where T: CKFetchDatabaseChangesOperationType {
     }
 
     /// - returns: a block for when a recordZone changeToken update is sent
-    var changeTokenUpdatedBlock: FetchDatabaseChangesChangeTokenUpdatedBlock? {
+    public var changeTokenUpdatedBlock: FetchDatabaseChangesChangeTokenUpdatedBlock? {
         get { return operation.changeTokenUpdatedBlock }
         set {
             operation.changeTokenUpdatedBlock = newValue
@@ -1386,7 +1386,7 @@ extension CloudKitOperation where T: CKFetchRecordZoneChangesOperationType {
     }
 
     /// - returns: the per-record-zone options
-    var optionsByRecordZoneID: [T.RecordZoneID : T.FetchRecordZoneChangesOptions]? {
+    public var optionsByRecordZoneID: [T.RecordZoneID : T.FetchRecordZoneChangesOptions]? {
         get { return operation.optionsByRecordZoneID }
         set {
             operation.optionsByRecordZoneID = newValue
@@ -1395,7 +1395,7 @@ extension CloudKitOperation where T: CKFetchRecordZoneChangesOperationType {
     }
 
     /// - returns: a block for when a record is changed
-    var recordChangedBlock: FetchRecordZoneChangesRecordChangedBlock? {
+    public var recordChangedBlock: FetchRecordZoneChangesRecordChangedBlock? {
         get { return operation.recordChangedBlock }
         set {
             operation.recordChangedBlock = newValue
@@ -1404,7 +1404,7 @@ extension CloudKitOperation where T: CKFetchRecordZoneChangesOperationType {
     }
 
     /// - returns: a block for when a recordID is deleted (receives the recordID and the recordType)
-    var recordWithIDWasDeletedBlock: FetchRecordZoneChangesRecordWithIDWasDeletedBlock? {
+    public var recordWithIDWasDeletedBlock: FetchRecordZoneChangesRecordWithIDWasDeletedBlock? {
         get { return operation.recordWithIDWasDeletedBlock }
         set {
             operation.recordWithIDWasDeletedBlock = newValue
@@ -1413,7 +1413,7 @@ extension CloudKitOperation where T: CKFetchRecordZoneChangesOperationType {
     }
 
     /// - returns: a block for when a recordZone changeToken update is sent
-    var recordZoneChangeTokensUpdatedBlock: FetchRecordZoneChangesRecordZoneChangeTokensUpdatedBlock? {
+    public var recordZoneChangeTokensUpdatedBlock: FetchRecordZoneChangesRecordZoneChangeTokensUpdatedBlock? {
         get { return operation.recordZoneChangeTokensUpdatedBlock }
         set {
             operation.recordZoneChangeTokensUpdatedBlock = newValue
@@ -1487,7 +1487,7 @@ extension CloudKitOperation where T: CKFetchShareMetadataOperationType {
     }
 
     /// - returns: whether to fetch the share root record
-    var shouldFetchRootRecord: Bool {
+    public var shouldFetchRootRecord: Bool {
         get { return operation.shouldFetchRootRecord }
         set {
             operation.shouldFetchRootRecord = newValue
@@ -1496,7 +1496,7 @@ extension CloudKitOperation where T: CKFetchShareMetadataOperationType {
     }
 
     /// - returns: the share root record desired keys
-    var rootRecordDesiredKeys: [String]? {
+    public var rootRecordDesiredKeys: [String]? {
         get { return operation.rootRecordDesiredKeys }
         set {
             operation.rootRecordDesiredKeys = newValue
@@ -1505,7 +1505,7 @@ extension CloudKitOperation where T: CKFetchShareMetadataOperationType {
     }
 
     /// - returns: the per share metadata block
-    var perShareMetadataBlock: FetchShareMetadataPerShareMetadataBlock? {
+    public var perShareMetadataBlock: FetchShareMetadataPerShareMetadataBlock? {
         get { return operation.perShareMetadataBlock }
         set {
             operation.perShareMetadataBlock = newValue
@@ -1569,7 +1569,7 @@ extension CloudKitOperation where T: CKFetchShareParticipantsOperationType {
     }
 
     /// - returns: the share participant fetched block
-    var shareParticipantFetchedBlock: FetchShareParticipantsParticipantFetchedBlock? {
+    public var shareParticipantFetchedBlock: FetchShareParticipantsParticipantFetchedBlock? {
         get { return operation.shareParticipantFetchedBlock }
         set {
             operation.shareParticipantFetchedBlock = newValue

--- a/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
@@ -1433,6 +1433,98 @@ extension CloudKitOperation where T: CKFetchRecordZoneChangesOperationType {
     }
 }
 
+// MARK: - CKFetchShareMetadataOperation
+
+extension OPRCKOperation where T: CKFetchShareMetadataOperationType, T: AssociatedErrorType, T.Error: CloudKitErrorType {
+
+    public var shareURLs: [NSURL] {
+        get { return operation.shareURLs }
+        set { operation.shareURLs = newValue }
+    }
+
+    public var shouldFetchRootRecord: Bool {
+        get { return operation.shouldFetchRootRecord }
+        set { operation.shouldFetchRootRecord = newValue }
+    }
+
+    public var rootRecordDesiredKeys: [String]? {
+        get { return operation.rootRecordDesiredKeys }
+        set { operation.rootRecordDesiredKeys = newValue }
+    }
+
+    public var perShareMetadataBlock: CloudKitOperation<T>.FetchShareMetadataPerShareMetadataBlock? {
+        get { return operation.perShareMetadataBlock }
+        set { operation.perShareMetadataBlock = newValue }
+    }
+
+    func setFetchShareMetadataCompletionBlock(block: CloudKitOperation<T>.FetchShareMetadataCompletionBlock) {
+        operation.fetchShareMetadataCompletionBlock = { [unowned self] error in
+            if let error = error {
+                self.addFatalError(CloudKitError(error: error))
+            }
+            else {
+                block()
+            }
+        }
+    }
+}
+
+extension CloudKitOperation where T: CKFetchShareMetadataOperationType {
+
+    /// A typealias for the block types used by CloudKitOperation<CKFetchShareMetadataOperationType>
+    public typealias FetchShareMetadataPerShareMetadataBlock = (NSURL, T.ShareMetadata?, NSError?) -> Void
+
+    /// A typealias for the block types used by CloudKitOperation<CKFetchShareMetadataOperationType>
+    public typealias FetchShareMetadataCompletionBlock = (Void) -> Void
+
+    /// - returns: the share URLs
+    public var shareURLs: [NSURL] {
+        get { return operation.shareURLs }
+        set {
+            operation.shareURLs = newValue
+            addConfigureBlock { $0.shareURLs = newValue }
+        }
+    }
+
+    /// - returns: whether to fetch the share root record
+    var shouldFetchRootRecord: Bool {
+        get { return operation.shouldFetchRootRecord }
+        set {
+            operation.shouldFetchRootRecord = newValue
+            addConfigureBlock { $0.shouldFetchRootRecord = newValue }
+        }
+    }
+
+    /// - returns: the share root record desired keys
+    var rootRecordDesiredKeys: [String]? {
+        get { return operation.rootRecordDesiredKeys }
+        set {
+            operation.rootRecordDesiredKeys = newValue
+            addConfigureBlock { $0.rootRecordDesiredKeys = newValue }
+        }
+    }
+
+    /// - returns: the per share metadata block
+    var perShareMetadataBlock: FetchShareMetadataPerShareMetadataBlock? {
+        get { return operation.perShareMetadataBlock }
+        set {
+            operation.perShareMetadataBlock = newValue
+            addConfigureBlock { $0.perShareMetadataBlock = newValue }
+        }
+    }
+
+    /**
+     Before adding the CloudKitOperation instance to a queue, set a completion block
+     to collect the results in the successful case. Setting this completion block also
+     ensures that error handling gets triggered.
+
+     - parameter block: a FetchShareMetadataCompletionBlock block
+     */
+    public func setFetchShareMetadataCompletionBlock(block: FetchShareMetadataCompletionBlock) {
+        addConfigureBlock { $0.setFetchShareMetadataCompletionBlock(block) }
+    }
+}
+
 // MARK: - CKFetchSubscriptionsOperation
 
 public struct FetchSubscriptionsError<Subscription>: CloudKitErrorType {

--- a/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
@@ -19,6 +19,42 @@ extension OPRCKOperation where T: CKOperationType {
         get { return operation.container }
         set { operation.container = newValue }
     }
+
+    var allowsCellularAccess: Bool {
+        get { return operation.allowsCellularAccess }
+        set { operation.allowsCellularAccess = newValue }
+    }
+
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    var operationID: String {
+        get { return operation.operationID }
+    }
+
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    var longLived: Bool {
+        get { return operation.longLived }
+        set { operation.longLived = newValue }
+    }
+
+    #if swift(>=3.0) // TEMPORARY FIX: Swift 2.3 compiler crash (see: CloudKitInterface.swift)
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        var longLivedOperationWasPersistedBlock: () -> Swift.Void {
+            get { return operation.longLivedOperationWasPersistedBlock }
+            set { operation.longLivedOperationWasPersistedBlock = newValue }
+        }
+    #endif
+
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    var timeoutIntervalForRequest: NSTimeInterval  {
+        get { return operation.timeoutIntervalForRequest }
+        set { operation.timeoutIntervalForRequest = newValue }
+    }
+
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    var timeoutIntervalForResource: NSTimeInterval {
+        get { return operation.timeoutIntervalForResource }
+        set { operation.timeoutIntervalForResource = newValue }
+    }
 }
 
 extension CloudKitOperation where T: CKOperationType {
@@ -31,6 +67,65 @@ extension CloudKitOperation where T: CKOperationType {
             addConfigureBlock { $0.container = newValue }
         }
     }
+
+    /// - returns whether to use cellular data access, if WiFi is unavailable (CKOperation default is true)
+    public var allowsCellularAccess: Bool {
+        get { return operation.allowsCellularAccess }
+        set {
+            operation.allowsCellularAccess = newValue
+            addConfigureBlock { $0.allowsCellularAccess = newValue }
+        }
+    }
+
+    /// - returns a unique identifier for a long-lived CKOperation
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    public var operationID: String {
+        get { return operation.operationID }
+    }
+
+    /// - returns whether the operation is long-lived
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    public var longLived: Bool {
+        get { return operation.longLived }
+        set {
+            operation.longLived = newValue
+            addConfigureBlock { $0.longLived = newValue }
+        }
+    }
+
+    #if swift(>=3.0) // TEMPORARY FIX: Swift 2.3 compiler crash (see: CloudKitInterface.swift)
+        /// - returns the block to execute when the server starts storing callbacks for this long-lived CKOperation
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        var longLivedOperationWasPersistedBlock: () -> Swift.Void {
+            get { return operation.longLivedOperationWasPersistedBlock }
+            set {
+                operation.longLivedOperationWasPersistedBlock = newValue
+                addConfigureBlock { $0.longLivedOperationWasPersistedBlock = newValue }
+            }
+        }
+    #endif
+
+    /// If non-zero, overrides the timeout interval for any network requests issued by this operation.
+    /// See NSURLSessionConfiguration.timeoutIntervalForRequest
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    var timeoutIntervalForRequest: NSTimeInterval  {
+        get { return operation.timeoutIntervalForRequest }
+        set {
+            operation.timeoutIntervalForRequest = newValue
+            addConfigureBlock { $0.timeoutIntervalForRequest = newValue }
+        }
+    }
+
+    /// If non-zero, overrides the timeout interval for any network resources retrieved by this operation.
+    /// See NSURLSessionConfiguration.timeoutIntervalForResource
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    var timeoutIntervalForResource: NSTimeInterval {
+        get { return operation.timeoutIntervalForResource }
+        set {
+            operation.timeoutIntervalForResource = newValue
+            addConfigureBlock { $0.timeoutIntervalForResource = newValue }
+        }
+    }
 }
 
 extension BatchedCloudKitOperation where T: CKOperationType {
@@ -41,6 +136,65 @@ extension BatchedCloudKitOperation where T: CKOperationType {
         set {
             operation.container = newValue
             addConfigureBlock { $0.container = newValue }
+        }
+    }
+
+    /// - returns whether to use cellular data access, if WiFi is unavailable (CKOperation default is true)
+    public var allowsCellularAccess: Bool {
+        get { return operation.allowsCellularAccess }
+        set {
+            operation.allowsCellularAccess = newValue
+            addConfigureBlock { $0.allowsCellularAccess = newValue }
+        }
+    }
+
+    /// - returns a unique identifier for a long-lived CKOperation
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    public var operationID: String {
+        get { return operation.operationID }
+    }
+
+    /// - returns whether the operation is long-lived
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    public var longLived: Bool {
+        get { return operation.longLived }
+        set {
+            operation.longLived = newValue
+            addConfigureBlock { $0.longLived = newValue }
+        }
+    }
+
+    #if swift(>=3.0) // TEMPORARY FIX: Swift 2.3 compiler crash (see: CloudKitInterface.swift)
+        /// - returns the block to execute when the server starts storing callbacks for this long-lived CKOperation
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        var longLivedOperationWasPersistedBlock: () -> Swift.Void {
+            get { return operation.longLivedOperationWasPersistedBlock }
+            set {
+                operation.longLivedOperationWasPersistedBlock = newValue
+                addConfigureBlock { $0.longLivedOperationWasPersistedBlock = newValue }
+            }
+        }
+    #endif
+
+    /// If non-zero, overrides the timeout interval for any network requests issued by this operation.
+    /// See NSURLSessionConfiguration.timeoutIntervalForRequest
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    var timeoutIntervalForRequest: NSTimeInterval  {
+        get { return operation.timeoutIntervalForRequest }
+        set {
+            operation.timeoutIntervalForRequest = newValue
+            addConfigureBlock { $0.timeoutIntervalForRequest = newValue }
+        }
+    }
+
+    /// If non-zero, overrides the timeout interval for any network resources retrieved by this operation.
+    /// See NSURLSessionConfiguration.timeoutIntervalForResource
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    var timeoutIntervalForResource: NSTimeInterval {
+        get { return operation.timeoutIntervalForResource }
+        set {
+            operation.timeoutIntervalForResource = newValue
+            addConfigureBlock { $0.timeoutIntervalForResource = newValue }
         }
     }
 }

--- a/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
@@ -326,6 +326,40 @@ extension BatchedCloudKitOperation where T: CKMoreComing {
     }
 }
 
+// MARK: - CKFetchAllChanges
+
+extension OPRCKOperation where T: CKFetchAllChanges {
+
+    public var fetchAllChanges: Bool {
+        get { return operation.fetchAllChanges }
+        set { operation.fetchAllChanges = newValue }
+    }
+}
+
+extension CloudKitOperation where T: CKFetchAllChanges {
+
+    /// - returns: the previous server change token
+    public var fetchAllChanges: Bool {
+        get { return operation.fetchAllChanges }
+        set {
+            operation.fetchAllChanges = newValue
+            addConfigureBlock { $0.fetchAllChanges = newValue }
+        }
+    }
+}
+
+extension BatchedCloudKitOperation where T: CKFetchAllChanges {
+
+    /// - returns: the previous server change token
+    public var fetchAllChanges: Bool {
+        get { return operation.fetchAllChanges }
+        set {
+            operation.fetchAllChanges = newValue
+            addConfigureBlock { $0.fetchAllChanges = newValue }
+        }
+    }
+}
+
 // MARK: - CKDesiredKeys
 
 extension OPRCKOperation where T: CKDesiredKeys {

--- a/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
@@ -449,6 +449,70 @@ public extension CloudKitOperation where T: BatchModifyOperationType {
     }
 }
 
+// MARK: - CKAcceptSharesOperation
+
+extension OPRCKOperation where T: CKAcceptSharesOperationType, T: AssociatedErrorType, T.Error: CloudKitErrorType {
+
+    public var shareMetadatas: [T.ShareMetadata] {
+        get { return operation.shareMetadatas }
+        set { operation.shareMetadatas = newValue }
+    }
+
+    public var perShareCompletionBlock: CloudKitOperation<T>.AcceptSharesPerShareCompletionBlock? {
+        get { return operation.perShareCompletionBlock }
+        set { operation.perShareCompletionBlock = newValue }
+    }
+
+    func setAcceptSharesCompletionBlock(block: CloudKitOperation<T>.AcceptSharesCompletionBlock) {
+        operation.acceptSharesCompletionBlock = { [unowned self] error in
+            if let error = error {
+                self.addFatalError(CloudKitError(error: error))
+            }
+            else {
+                block()
+            }
+        }
+    }
+}
+
+extension CloudKitOperation where T: CKAcceptSharesOperationType {
+
+    /// A typealias for the block type used by CloudKitOperation<CKAcceptSharesOperationType>
+    public typealias AcceptSharesPerShareCompletionBlock = (T.ShareMetadata, T.Share?, NSError?) -> Void
+
+    /// A typealias for the block type used by CloudKitOperation<CKAcceptSharesOperationType>
+    public typealias AcceptSharesCompletionBlock = () -> Void
+
+    /// - returns: the share metadatas
+    var shareMetadatas: [T.ShareMetadata] {
+        get { return operation.shareMetadatas }
+        set {
+            operation.shareMetadatas = newValue
+            addConfigureBlock { $0.shareMetadatas = newValue }
+        }
+    }
+
+    /// - returns: the block used to return accepted shares
+    var perShareCompletionBlock: AcceptSharesPerShareCompletionBlock? {
+        get { return operation.perShareCompletionBlock }
+        set {
+            operation.perShareCompletionBlock = newValue
+            addConfigureBlock { $0.perShareCompletionBlock = newValue }
+        }
+    }
+
+    /**
+     Before adding the CloudKitOperation instance to a queue, set a completion block
+     to collect the results in the successful case. Setting this completion block also
+     ensures that error handling gets triggered.
+
+     - parameter block: an AcceptSharesCompletionBlock block
+     */
+    public func setAcceptSharesCompletionBlock(block: AcceptSharesCompletionBlock) {
+        addConfigureBlock { $0.setAcceptSharesCompletionBlock(block) }
+    }
+}
+
 // MARK: - CKDiscoverAllContactsOperation
 
 public struct DiscoverAllContactsError<DiscoveredUserInfo>: CloudKitErrorType {

--- a/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
@@ -1525,6 +1525,70 @@ extension CloudKitOperation where T: CKFetchShareMetadataOperationType {
     }
 }
 
+// MARK: - CKFetchShareParticipantsOperation
+
+extension OPRCKOperation where T: CKFetchShareParticipantsOperationType, T: AssociatedErrorType, T.Error: CloudKitErrorType {
+
+    public var userIdentityLookupInfos: [T.UserIdentityLookupInfo] {
+        get { return operation.userIdentityLookupInfos }
+        set { operation.userIdentityLookupInfos = newValue }
+    }
+
+    public var shareParticipantFetchedBlock: CloudKitOperation<T>.FetchShareParticipantsParticipantFetchedBlock? {
+        get { return operation.shareParticipantFetchedBlock }
+        set { operation.shareParticipantFetchedBlock = newValue }
+    }
+
+    func setFetchShareParticipantsCompletionBlock(block: CloudKitOperation<T>.FetchShareParticipantsCompletionBlock) {
+        operation.fetchShareParticipantsCompletionBlock = { [unowned self] error in
+            if let error = error {
+                self.addFatalError(CloudKitError(error: error))
+            }
+            else {
+                block()
+            }
+        }
+    }
+}
+
+extension CloudKitOperation where T: CKFetchShareParticipantsOperationType {
+
+    /// A typealias for the block types used by CloudKitOperation<CKFetchShareMetadataOperationType>
+    public typealias FetchShareParticipantsParticipantFetchedBlock = (T.ShareParticipant) -> Void
+
+    /// A typealias for the block types used by CloudKitOperation<CKFetchShareMetadataOperationType>
+    public typealias FetchShareParticipantsCompletionBlock = (Void) -> Void
+
+    /// - returns: the user identity lookup infos
+    public var userIdentityLookupInfos: [T.UserIdentityLookupInfo] {
+        get { return operation.userIdentityLookupInfos }
+        set {
+            operation.userIdentityLookupInfos = newValue
+            addConfigureBlock { $0.userIdentityLookupInfos = newValue }
+        }
+    }
+
+    /// - returns: the share participant fetched block
+    var shareParticipantFetchedBlock: FetchShareParticipantsParticipantFetchedBlock? {
+        get { return operation.shareParticipantFetchedBlock }
+        set {
+            operation.shareParticipantFetchedBlock = newValue
+            addConfigureBlock { $0.shareParticipantFetchedBlock = newValue }
+        }
+    }
+
+    /**
+     Before adding the CloudKitOperation instance to a queue, set a completion block
+     to collect the results in the successful case. Setting this completion block also
+     ensures that error handling gets triggered.
+
+     - parameter block: a FetchShareParticipantsCompletionBlock block
+     */
+    public func setFetchShareParticipantsCompletionBlock(block: FetchShareParticipantsCompletionBlock) {
+        addConfigureBlock { $0.setFetchShareParticipantsCompletionBlock(block) }
+    }
+}
+
 // MARK: - CKFetchSubscriptionsOperation
 
 public struct FetchSubscriptionsError<Subscription>: CloudKitErrorType {

--- a/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
+++ b/Sources/Features/Shared/CloudKit/CloudKitOperationExtensions.swift
@@ -557,6 +557,56 @@ extension CloudKitOperation where T: CKDiscoverAllContactsOperationType {
     }
 }
 
+// MARK: - CKDiscoverAllUserIdentitiesOperation
+
+extension OPRCKOperation where T: CKDiscoverAllUserIdentitiesOperationType, T: AssociatedErrorType, T.Error: CloudKitErrorType {
+
+    public var userIdentityDiscoveredBlock: CloudKitOperation<T>.DiscoverAllUserIdentitiesUserIdentityDiscoveredBlock? {
+        get { return operation.userIdentityDiscoveredBlock }
+        set { operation.userIdentityDiscoveredBlock = newValue }
+    }
+
+    func setDiscoverAllUserIdentitiesCompletionBlock(block: CloudKitOperation<T>.DiscoverAllUserIdentitiesCompletionBlock) {
+        operation.discoverAllUserIdentitiesCompletionBlock = { [unowned self] error in
+            if let error = error {
+                self.addFatalError(CloudKitError(error: error))
+            }
+            else {
+                block()
+            }
+        }
+    }
+}
+
+extension CloudKitOperation where T: CKDiscoverAllUserIdentitiesOperationType {
+
+    /// A typealias for the block type used by CloudKitOperation<CKDiscoverAllUserIdentitiesOperationType>
+    public typealias DiscoverAllUserIdentitiesUserIdentityDiscoveredBlock = (T.UserIdentity) -> Void
+
+    /// A typealias for the block type used by CloudKitOperation<CKDiscoverAllUserIdentitiesOperationType>
+    public typealias DiscoverAllUserIdentitiesCompletionBlock = () -> Void
+
+    /// - returns: a block for when a recordZone changeToken update is sent
+    var userIdentityDiscoveredBlock: DiscoverAllUserIdentitiesUserIdentityDiscoveredBlock? {
+        get { return operation.userIdentityDiscoveredBlock }
+        set {
+            operation.userIdentityDiscoveredBlock = newValue
+            addConfigureBlock { $0.userIdentityDiscoveredBlock = newValue }
+        }
+    }
+
+    /**
+     Before adding the CloudKitOperation instance to a queue, set a completion block
+     to collect the results in the successful case. Setting this completion block also
+     ensures that error handling gets triggered.
+
+     - parameter block: a DiscoverAllContactsCompletionBlock block
+     */
+    public func setDiscoverAllUserIdentitiesCompletionBlock(block: DiscoverAllUserIdentitiesCompletionBlock) {
+        addConfigureBlock { $0.setDiscoverAllUserIdentitiesCompletionBlock(block) }
+    }
+}
+
 // MARK: - CKDiscoverUserInfosOperation
 
 extension OPRCKOperation where T: CKDiscoverUserInfosOperationType, T: AssociatedErrorType, T.Error: CloudKitErrorType {

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -26,7 +26,25 @@ class TestCloudOperation: NSOperation, CKOperationType {
     typealias Query = String
     typealias QueryCursor = String
 
+    typealias UserIdentity = String
+    typealias UserIdentityLookupInfo = String
+    typealias Share = String
+    typealias ShareMetadata = String
+    typealias ShareParticipant = String
+
     var container: String? // just a test
+    var allowsCellularAccess: Bool = true
+    
+    //@available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    var operationID: String = ""
+    var longLived: Bool = false
+    
+    typealias CKOperationLongLivedOperationWasPersistedBlock = () -> Void
+    var longLivedOperationWasPersistedBlock: CKOperationLongLivedOperationWasPersistedBlock = { }
+    
+    //@available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    var timeoutIntervalForRequest: NSTimeInterval = 0
+    var timeoutIntervalForResource: NSTimeInterval = 0
 }
 
 class TestDatabaseOperation: TestCloudOperation, CKDatabaseOperationType, CKPreviousServerChangeToken, CKResultsLimit, CKMoreComing, CKDesiredKeys {
@@ -360,6 +378,7 @@ class OPRCKOperationTests: CKTests {
         operation = OPRCKOperation(operation: target)
     }
 
+    // .container
     func test__get_container() {
         let container = "I'm a test container!"
         target.container = container
@@ -378,6 +397,129 @@ class OPRCKOperationTests: CKTests {
         XCTAssertEqual(operation.container, container)
     }
 
+    // .allowsCellularAccess
+    func test__get_allowsCellularAccess() {
+        let allowsCellularAccess = true
+        target.allowsCellularAccess = allowsCellularAccess
+        XCTAssertEqual(operation.allowsCellularAccess, allowsCellularAccess)
+    }
+    
+    func test__set_allowsCellularAccess() {
+        let allowsCellularAccess = true
+        operation.allowsCellularAccess = allowsCellularAccess
+        XCTAssertEqual(target.allowsCellularAccess, allowsCellularAccess)
+    }
+    
+    func test__set_get_allowsCellularAccess() {
+        let allowsCellularAccess = true
+        operation.allowsCellularAccess = allowsCellularAccess
+        XCTAssertEqual(operation.allowsCellularAccess, allowsCellularAccess)
+    }
+    
+    // .operationID
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    func test__get_operationID() {
+        let operationID = "testOperationID"
+        target.operationID = operationID
+        XCTAssertEqual(operation.operationID, operationID)
+    }
+    
+    // .longLived
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    func test__get_longLived() {
+        let longLived = true
+        target.longLived = longLived
+        XCTAssertEqual(operation.longLived, longLived)
+    }
+    
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    func test__set_longLived() {
+        let longLived = true
+        operation.longLived = longLived
+        XCTAssertEqual(target.longLived, longLived)
+    }
+    
+    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+    func test__set_get_longLived() {
+        let longLived = true
+        operation.longLived = longLived
+        XCTAssertEqual(operation.longLived, longLived)
+    }
+    
+    #if swift(>=3.0) // TEMPORARY FIX: Swift 2.3 compiler crash (see: CloudKitInterface.swift)
+        // .longLivedOperationWasPersistedBlock
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        func test__get_longLivedOperationWasPersistedBlock() {
+            var setByBlock = false
+            let block: CKOperationLongLivedOperationWasPersistedBlock = { setByBlock = true }
+            target.longLived = block
+            operation.longLivedOperationWasPersistedBlock()
+            XCTAssertTrue(setByBlock)
+        }
+        
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        func test__set_longLivedOperationWasPersistedBlock() {
+            var setByBlock = false
+            let block: CKOperationLongLivedOperationWasPersistedBlock = { setByBlock = true }
+            operation.longLived = block
+            target.longLivedOperationWasPersistedBlock()
+            XCTAssertTrue(setByBlock)
+        }
+    
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        func test__set_get_longLivedOperationWasPersistedBlock() {
+            var setByBlock = false
+            let block: CKOperationLongLivedOperationWasPersistedBlock = { setByBlock = true }
+            operation.longLived = block
+            operation.longLivedOperationWasPersistedBlock()
+            XCTAssertTrue(setByBlock)
+        }
+    #endif
+    
+    // .timeoutIntervalForRequest
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    func test__get_timeoutIntervalForRequest() {
+        let timeoutIntervalForRequest: NSTimeInterval = 42
+        target.timeoutIntervalForRequest = timeoutIntervalForRequest
+        XCTAssertEqual(operation.timeoutIntervalForRequest, timeoutIntervalForRequest)
+    }
+    
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    func test__set_timeoutIntervalForRequest() {
+        let timeoutIntervalForRequest: NSTimeInterval = 42
+        operation.timeoutIntervalForRequest = timeoutIntervalForRequest
+        XCTAssertEqual(target.timeoutIntervalForRequest, timeoutIntervalForRequest)
+    }
+    
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    func test__set_get_timeoutIntervalForRequest() {
+        let timeoutIntervalForRequest: NSTimeInterval = 42
+        operation.timeoutIntervalForRequest = timeoutIntervalForRequest
+        XCTAssertEqual(operation.timeoutIntervalForRequest, timeoutIntervalForRequest)
+    }
+    
+    // .timeoutIntervalForResource
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    func test__get_timeoutIntervalForResource() {
+        let timeoutIntervalForResource: NSTimeInterval = 42
+        target.timeoutIntervalForResource = timeoutIntervalForResource
+        XCTAssertEqual(operation.timeoutIntervalForResource, timeoutIntervalForResource)
+    }
+    
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    func test__set_timeoutIntervalForResource() {
+        let timeoutIntervalForResource: NSTimeInterval = 42
+        operation.timeoutIntervalForResource = timeoutIntervalForResource
+        XCTAssertEqual(target.timeoutIntervalForResource, timeoutIntervalForResource)
+    }
+    
+    @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
+    func test__set_get_timeoutIntervalForResource() {
+        let timeoutIntervalForResource: NSTimeInterval = 42
+        operation.timeoutIntervalForResource = timeoutIntervalForResource
+        XCTAssertEqual(operation.timeoutIntervalForResource, timeoutIntervalForResource)
+    }
+    
     func test__timeout() {
         XCTAssertEqual(timeoutObserver?.timeout ?? 0, 300)
 

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -55,6 +55,10 @@ class TestDatabaseOperation: TestCloudOperation, CKDatabaseOperationType, CKPrev
     var desiredKeys: [String]? = .None
 }
 
+class TestFetchAllChangesOperation: TestCloudOperation, CKFetchAllChanges {
+    var fetchAllChanges: Bool = true
+}
+
 class TestDiscoverAllContactsOperation: TestCloudOperation, CKDiscoverAllContactsOperationType, AssociatedErrorType {
     typealias Error = DiscoverAllContactsError<DiscoveredUserInfo>
 
@@ -592,6 +596,45 @@ class OPRCKDatabaseOperationTests: CKTests {
         operation.desiredKeys = keys
         XCTAssertNotNil(target.desiredKeys)
         XCTAssertEqual(target.desiredKeys!, keys)
+    }
+}
+
+class OPRCKFetchAllChangesTests: CKTests {
+    
+    var target: TestFetchAllChangesOperation!
+    var operation: OPRCKOperation<TestFetchAllChangesOperation>!
+    
+    override func setUp() {
+        super.setUp()
+        target = TestFetchAllChangesOperation()
+        operation = OPRCKOperation(operation: target)
+    }
+    
+    func test__get_fetch_all_changes() {
+        var fetchAllChanges = false
+        target.fetchAllChanges = fetchAllChanges
+        XCTAssertEqual(operation.fetchAllChanges, fetchAllChanges)
+        fetchAllChanges = true
+        target.fetchAllChanges = fetchAllChanges
+        XCTAssertEqual(operation.fetchAllChanges, fetchAllChanges)
+    }
+    
+    func test__set_fetch_all_changes() {
+        var fetchAllChanges = false
+        operation.fetchAllChanges = fetchAllChanges
+        XCTAssertEqual(target.fetchAllChanges, fetchAllChanges)
+        fetchAllChanges = true
+        operation.fetchAllChanges = fetchAllChanges
+        XCTAssertEqual(target.fetchAllChanges, fetchAllChanges)
+    }
+    
+    func test__set_get_fetch_all_changes() {
+        var fetchAllChanges = false
+        operation.fetchAllChanges = fetchAllChanges
+        XCTAssertEqual(operation.fetchAllChanges, fetchAllChanges)
+        fetchAllChanges = true
+        operation.fetchAllChanges = fetchAllChanges
+        XCTAssertEqual(operation.fetchAllChanges, fetchAllChanges)
     }
 }
 

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -792,6 +792,86 @@ class OPRCKFetchAllChangesTests: CKTests {
     }
 }
 
+class OPRCKAcceptSharesOperationTests: CKTests {
+    
+    var target: TestAcceptSharesOperation!
+    var operation: OPRCKOperation<TestAcceptSharesOperation>!
+    
+    override func setUp() {
+        super.setUp()
+        target = TestAcceptSharesOperation()
+        operation = OPRCKOperation(operation: target)
+    }
+    
+    func test__get_share_metadatas() {
+        target.shareMetadatas = [ "hello@world.com" ]
+        XCTAssertNotNil(operation.shareMetadatas)
+        XCTAssertEqual(operation.shareMetadatas.count, 1)
+        XCTAssertEqual(operation.shareMetadatas, [ "hello@world.com" ])
+    }
+    
+    func test__set_share_metadatas() {
+        operation.shareMetadatas = [ "hello@world.com" ]
+        XCTAssertNotNil(target.shareMetadatas)
+        XCTAssertEqual(target.shareMetadatas.count, 1)
+        XCTAssertEqual(target.shareMetadatas, [ "hello@world.com" ])
+    }
+    
+    func test__get_per_share_completion_block() {
+        target.perShareCompletionBlock = { _ in }
+        XCTAssertNotNil(operation.perShareCompletionBlock)
+    }
+    
+    func test__set_per_share_completion_block() {
+        operation.perShareCompletionBlock = { _ in }
+        XCTAssertNotNil(target.perShareCompletionBlock)
+    }
+    
+    func test__execution_after_cancellation() {
+        operation.cancel()
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertTrue(operation.cancelled)
+    }
+    
+    func test__successful_execution_without_completion_block() {
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+    }
+    
+    func test__error_without_completion_block() {
+        target.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+    }
+    
+    func test__success_with_completion_block() {
+        var didExecuteBlock: Bool = false
+        operation.setAcceptSharesCompletionBlock {
+            didExecuteBlock = true
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+        XCTAssertTrue(didExecuteBlock)
+    }
+    
+    func test__error_with_completion_block() {
+        var didExecuteBlock: Bool = false
+        target.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+        operation.setAcceptSharesCompletionBlock {
+            didExecuteBlock = true
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 1)
+        XCTAssertFalse(didExecuteBlock)
+    }
+}
+
 class OPRCKDiscoverAllContactsOperationTests: CKTests {
 
     var target: TestDiscoverAllContactsOperation!
@@ -845,6 +925,72 @@ class OPRCKDiscoverAllContactsOperationTests: CKTests {
         waitForOperation(operation)
         XCTAssertTrue(operation.finished)
         XCTAssertEqual(operation.errors.count, 1)
+    }
+}
+
+class OPRCKDiscoverAllUserIdentitiesOperationTests: CKTests {
+    
+    var target: TestDiscoverAllUserIdentitiesOperation!
+    var operation: OPRCKOperation<TestDiscoverAllUserIdentitiesOperation>!
+    
+    override func setUp() {
+        super.setUp()
+        target = TestDiscoverAllUserIdentitiesOperation()
+        operation = OPRCKOperation(operation: target)
+    }
+    
+    func test__get_user_identity_discovered_block() {
+        target.userIdentityDiscoveredBlock = { _ in }
+        XCTAssertNotNil(operation.userIdentityDiscoveredBlock)
+    }
+    
+    func test__set_user_identity_discovered_block() {
+        operation.userIdentityDiscoveredBlock = { _ in }
+        XCTAssertNotNil(target.userIdentityDiscoveredBlock)
+    }
+    
+    func test__execution_after_cancellation() {
+        operation.cancel()
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertTrue(operation.cancelled)
+    }
+    
+    func test__successful_execution_without_completion_block() {
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+    }
+    
+    func test__error_without_completion_block() {
+        target.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+    }
+    
+    func test__success_with_completion_block() {
+        var didExecuteBlock: Bool = false
+        operation.setDiscoverAllUserIdentitiesCompletionBlock {
+            didExecuteBlock = true
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+        XCTAssertTrue(didExecuteBlock)
+    }
+    
+    func test__error_with_completion_block() {
+        var didExecuteBlock: Bool = false
+        target.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+        operation.setDiscoverAllUserIdentitiesCompletionBlock {
+            didExecuteBlock = true
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 1)
+        XCTAssertFalse(didExecuteBlock)
     }
 }
 
@@ -915,6 +1061,86 @@ class OPRCKDiscoverUserInfosOperationTests: CKTests {
 
         XCTAssertTrue(operation.finished)
         XCTAssertEqual(operation.errors.count, 1)
+    }
+}
+
+class OPRCKDiscoverUserIdentitiesOperationTests: CKTests {
+    
+    var target: TestDiscoverUserIdentitiesOperation!
+    var operation: OPRCKOperation<TestDiscoverUserIdentitiesOperation>!
+    
+    override func setUp() {
+        super.setUp()
+        target = TestDiscoverUserIdentitiesOperation()
+        operation = OPRCKOperation(operation: target)
+    }
+    
+    func test__get_user_identity_lookup_infos() {
+        target.userIdentityLookupInfos = [ "hello@world.com" ]
+        XCTAssertNotNil(operation.userIdentityLookupInfos)
+        XCTAssertEqual(operation.userIdentityLookupInfos.count, 1)
+        XCTAssertEqual(operation.userIdentityLookupInfos, [ "hello@world.com" ])
+    }
+    
+    func test__set_user_identity_lookup_infos() {
+        operation.userIdentityLookupInfos = [ "hello@world.com" ]
+        XCTAssertNotNil(target.userIdentityLookupInfos)
+        XCTAssertEqual(target.userIdentityLookupInfos.count, 1)
+        XCTAssertEqual(target.userIdentityLookupInfos, [ "hello@world.com" ])
+    }
+    
+    func test__get_user_identity_discovered_block() {
+        target.userIdentityDiscoveredBlock = { _, _ in }
+        XCTAssertNotNil(operation.userIdentityDiscoveredBlock)
+    }
+    
+    func test__set_user_identity_discovered_block() {
+        operation.userIdentityDiscoveredBlock = { _, _ in }
+        XCTAssertNotNil(target.userIdentityDiscoveredBlock)
+    }
+    
+    func test__execution_after_cancellation() {
+        operation.cancel()
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertTrue(operation.cancelled)
+    }
+    
+    func test__successful_execution_without_completion_block() {
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+    }
+    
+    func test__error_without_completion_block() {
+        target.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+    }
+    
+    func test__success_with_completion_block() {
+        var didExecuteBlock: Bool = false
+        operation.setDiscoverUserIdentitiesCompletionBlock {
+            didExecuteBlock = true
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+        XCTAssertTrue(didExecuteBlock)
+    }
+    
+    func test__error_with_completion_block() {
+        var didExecuteBlock: Bool = false
+        target.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+        operation.setDiscoverUserIdentitiesCompletionBlock {
+            didExecuteBlock = true
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 1)
+        XCTAssertFalse(didExecuteBlock)
     }
 }
 
@@ -1068,6 +1294,76 @@ class OPRCKModifyBadgeOperationTests: CKTests {
 
         XCTAssertTrue(operation.finished)
         XCTAssertEqual(operation.errors.count, 1)
+    }
+}
+
+class OPRCKFetchDatabaseChangesOperationTests: CKTests {
+    
+    var target: TestFetchDatabaseChangesOperation!
+    var operation: OPRCKOperation<TestFetchDatabaseChangesOperation>!
+    
+    override func setUp() {
+        super.setUp()
+        target = TestFetchDatabaseChangesOperation()
+        operation = OPRCKOperation(operation: target)
+    }
+
+    func test__get_record_zone_with_id_changed_block() {
+        target.recordZoneWithIDChangedBlock = { _ in }
+        XCTAssertNotNil(operation.recordZoneWithIDChangedBlock)
+    }
+    
+    func test__set_record_zone_with_id_changed_block() {
+        operation.recordZoneWithIDChangedBlock = { _ in }
+        XCTAssertNotNil(target.recordZoneWithIDChangedBlock)
+    }
+    
+    func test__get_record_zone_with_id_was_deleted_block() {
+        target.recordZoneWithIDWasDeletedBlock = { _ in }
+        XCTAssertNotNil(operation.recordZoneWithIDWasDeletedBlock)
+    }
+    
+    func test__set_record_zone_with_id_was_deleted_block() {
+        operation.recordZoneWithIDWasDeletedBlock = { _ in }
+        XCTAssertNotNil(target.recordZoneWithIDWasDeletedBlock)
+    }
+    
+    func test__get_change_token_updated_block() {
+        target.changeTokenUpdatedBlock = { _ in }
+        XCTAssertNotNil(operation.changeTokenUpdatedBlock)
+    }
+    
+    func test__set_change_token_updated_block() {
+        operation.changeTokenUpdatedBlock = { _ in }
+        XCTAssertNotNil(target.changeTokenUpdatedBlock)
+    }
+    
+    func test__success_with_completion_block() {
+        var blockDidRun = false
+        operation.setFetchDatabaseChangesCompletionBlock { _, _ in
+            blockDidRun = true
+        }
+        
+        waitForOperation(operation)
+        
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+        XCTAssertTrue(blockDidRun)
+    }
+    
+    func test__error_with_completion_block() {
+        var blockDidRun = false
+        target.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+        
+        operation.setFetchDatabaseChangesCompletionBlock { _, _ in
+            blockDidRun = true
+        }
+        
+        waitForOperation(operation)
+        
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 1)
+        XCTAssertFalse(blockDidRun)
     }
 }
 

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -59,6 +59,25 @@ class TestFetchAllChangesOperation: TestCloudOperation, CKFetchAllChanges {
     var fetchAllChanges: Bool = true
 }
 
+class TestAcceptSharesOperation: TestCloudOperation, CKAcceptSharesOperationType, AssociatedErrorType {
+    typealias Error = DiscoverAllContactsError<DiscoveredUserInfo>
+
+    var error: NSError?
+
+    var shareMetadatas: [ShareMetadata] = []
+    var perShareCompletionBlock: ((ShareMetadata, Share?, NSError?) -> Void)? = .None
+    var acceptSharesCompletionBlock: ((NSError?) -> Void)? = .None
+
+    init(error: NSError? = .None) {
+        self.error = error
+        super.init()
+    }
+
+    override func main() {
+        acceptSharesCompletionBlock?(error)
+    }
+}
+
 class TestDiscoverAllContactsOperation: TestCloudOperation, CKDiscoverAllContactsOperationType, AssociatedErrorType {
     typealias Error = DiscoverAllContactsError<DiscoveredUserInfo>
 
@@ -74,6 +93,24 @@ class TestDiscoverAllContactsOperation: TestCloudOperation, CKDiscoverAllContact
 
     override func main() {
         discoverAllContactsCompletionBlock?(result, error)
+    }
+}
+
+class TestDiscoverAllUserIdentitiesOperation: TestCloudOperation, CKDiscoverAllUserIdentitiesOperationType, AssociatedErrorType {
+    typealias Error = CloudKitError
+
+    var error: NSError?
+    
+    var userIdentityDiscoveredBlock: ((UserIdentity) -> Void)? = .None
+    var discoverAllUserIdentitiesCompletionBlock: ((NSError?) -> Void)? = .None
+    
+    init(error: NSError? = .None) {
+        self.error = error
+        super.init()
+    }
+    
+    override func main() {
+        discoverAllUserIdentitiesCompletionBlock?(error)
     }
 }
 
@@ -96,6 +133,25 @@ class TestDiscoverUserInfosOperation: TestCloudOperation, CKDiscoverUserInfosOpe
 
     override func main() {
         discoverUserInfosCompletionBlock?(userInfosByEmailAddress, userInfoByRecordID, error)
+    }
+}
+
+class TestDiscoverUserIdentitiesOperation: TestCloudOperation, CKDiscoverUserIdentitiesOperationType, AssociatedErrorType {
+    typealias Error = CloudKitError
+    
+    var error: NSError?
+    
+    var userIdentityLookupInfos: [UserIdentityLookupInfo] = []
+    var userIdentityDiscoveredBlock: ((UserIdentity, UserIdentityLookupInfo) -> Void)? = .None
+    var discoverUserIdentitiesCompletionBlock: ((NSError?) -> Void)? = .None
+    
+    init(error: NSError? = .None) {
+        self.error = error
+        super.init()
+    }
+    
+    override func main() {
+        discoverUserIdentitiesCompletionBlock?(error)
     }
 }
 
@@ -167,6 +223,31 @@ class TestModifyBadgeOperation: TestCloudOperation, CKModifyBadgeOperationType, 
     }
 }
 
+class TestFetchDatabaseChangesOperation: TestDatabaseOperation, CKFetchDatabaseChangesOperationType, AssociatedErrorType {
+    typealias Error = FetchDatabaseChangesError<ServerChangeToken>
+
+    var token: String?
+    // var moreComing: Bool
+    var error: NSError?
+
+    var fetchAllChanges: Bool = true
+    var recordZoneWithIDChangedBlock: ((RecordZoneID) -> Void)? = .None
+    var recordZoneWithIDWasDeletedBlock: ((RecordZoneID) -> Void)? = .None
+    var changeTokenUpdatedBlock: ((ServerChangeToken) -> Void)? = .None
+    var fetchDatabaseChangesCompletionBlock: ((ServerChangeToken?, Bool, NSError?) -> Void)? = .None
+    
+    init(token: String? = "new-token", moreComing: Bool = false, error: NSError? = .None) {
+        self.token = token
+        self.error = error
+        super.init()
+        self.moreComing = moreComing
+    }
+
+    override func main() {
+        fetchDatabaseChangesCompletionBlock?(token, moreComing, error)
+    }
+}
+
 class TestFetchRecordChangesOperation: TestDatabaseOperation, CKFetchRecordChangesOperationType, AssociatedErrorType {
     typealias Error = FetchRecordChangesError<ServerChangeToken>
 
@@ -230,6 +311,79 @@ class TestFetchRecordsOperation: TestDatabaseOperation, CKFetchRecordsOperationT
 
     override func main() {
         fetchRecordsCompletionBlock?(recordsByID, error)
+    }
+}
+
+class TestFetchRecordZoneChangesOperation: TestDatabaseOperation, CKFetchRecordZoneChangesOperationType, AssociatedErrorType {
+    typealias Error = FetchRecordZoneChangesError
+    typealias FetchRecordZoneChangesOptions = String
+    
+    typealias ResponseSimulationBlock = ((TestFetchRecordZoneChangesOperation) -> NSError?)
+    var responseSimulationBlock: ResponseSimulationBlock? = .None
+    func setSimulationOutputError(error: NSError) {
+        responseSimulationBlock = { operation in
+            return error
+        }
+    }
+    
+    var fetchAllChanges: Bool = true
+    var recordZoneIDs: [RecordZoneID] = ["zone-id"]
+    var optionsByRecordZoneID: [RecordZoneID : FetchRecordZoneChangesOptions]? = .None
+    
+    var recordChangedBlock: ((Record) -> Void)? = .None
+    var recordWithIDWasDeletedBlock: ((RecordID, String) -> Void)? = .None
+    var recordZoneChangeTokensUpdatedBlock: ((RecordZoneID, ServerChangeToken?, NSData?) -> Void)? = .None
+    var recordZoneFetchCompletionBlock: ((RecordZoneID, ServerChangeToken?, NSData?, Bool, NSError?) -> Void)? = .None
+    var fetchRecordZoneChangesCompletionBlock: ((NSError?) -> Void)? = .None
+    
+    init(responseSimulationBlock: ResponseSimulationBlock? = .None) {
+        self.responseSimulationBlock = responseSimulationBlock
+        super.init()
+    }
+    
+    override func main() {
+        let outputError = responseSimulationBlock?(self)
+        fetchRecordZoneChangesCompletionBlock?(outputError)
+    }
+}
+
+class TestFetchShareMetadataOperation: TestCloudOperation, CKFetchShareMetadataOperationType, AssociatedErrorType {
+    typealias Error = CloudKitError
+    
+    var error: NSError?
+    
+    var shareURLs: [NSURL] = []
+    var shouldFetchRootRecord: Bool = false
+    var rootRecordDesiredKeys: [String]? = .None
+    var perShareMetadataBlock: ((NSURL, ShareMetadata?, NSError?) -> Void)? = .None
+    var fetchShareMetadataCompletionBlock: ((NSError?) -> Void)? = .None
+    
+    init(error: NSError? = .None) {
+        self.error = error
+        super.init()
+    }
+    
+    override func main() {
+        fetchShareMetadataCompletionBlock?(error)
+    }
+}
+
+class TestFetchShareParticipantsOperation: TestCloudOperation, CKFetchShareParticipantsOperationType, AssociatedErrorType {
+    typealias Error = CloudKitError
+    
+    var error: NSError?
+    
+    var userIdentityLookupInfos: [UserIdentityLookupInfo] = []
+    var shareParticipantFetchedBlock: ((ShareParticipant) -> Void)? = .None
+    var fetchShareParticipantsCompletionBlock: ((NSError?) -> Void)? = .None
+    
+    init(error: NSError? = .None) {
+        self.error = error
+        super.init()
+    }
+    
+    override func main() {
+        fetchShareParticipantsCompletionBlock?(error)
     }
 }
 

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -1549,6 +1549,254 @@ class OPRCKFetchRecordsOperationTests: CKTests {
     }
 }
 
+class OPRCKFetchRecordZoneChangesOperationTests: CKTests {
+    
+    var target: TestFetchRecordZoneChangesOperation!
+    var operation: OPRCKOperation<TestFetchRecordZoneChangesOperation>!
+    
+    override func setUp() {
+        super.setUp()
+        target = TestFetchRecordZoneChangesOperation()
+        operation = OPRCKOperation(operation: target)
+    }
+    
+    func test__get_record_zone_ids() {
+        let zoneIDs = ["zone-id"]
+        target.recordZoneIDs = zoneIDs
+        XCTAssertEqual(operation.recordZoneIDs, zoneIDs)
+    }
+    
+    func test__set_record_zone_id() {
+        let zoneIDs = ["a-different-zone-id"]
+        operation.recordZoneIDs = zoneIDs
+        XCTAssertEqual(target.recordZoneIDs, zoneIDs)
+    }
+    
+    func test__get_optionsByRecordZoneID() {
+        let optionsByRecordZoneID = ["zone-id": "testoption"]
+        target.optionsByRecordZoneID = optionsByRecordZoneID
+        XCTAssertNotNil(operation.optionsByRecordZoneID)
+        XCTAssertEqual(operation.optionsByRecordZoneID ?? [:], optionsByRecordZoneID)
+    }
+    
+    func test__set_optionsByRecordZoneID() {
+        let optionsByRecordZoneID = ["zone-id": "a-different-test-option"]
+        operation.optionsByRecordZoneID = optionsByRecordZoneID
+        XCTAssertNotNil(target.optionsByRecordZoneID)
+        XCTAssertEqual(target.optionsByRecordZoneID ?? [:], optionsByRecordZoneID)
+    }
+    
+    func test__get_record_changed_block() {
+        target.recordChangedBlock = { _ in }
+        XCTAssertNotNil(operation.recordChangedBlock)
+    }
+    
+    func test__set_record_changed_block() {
+        operation.recordChangedBlock = { _ in }
+        XCTAssertNotNil(target.recordChangedBlock)
+    }
+    
+    func test__get_record_with_id_was_deleted_block() {
+        target.recordWithIDWasDeletedBlock = { _ in }
+        XCTAssertNotNil(operation.recordWithIDWasDeletedBlock)
+    }
+    
+    func test__set_record_with_id_was_deleted_block() {
+        operation.recordWithIDWasDeletedBlock = { _ in }
+        XCTAssertNotNil(target.recordWithIDWasDeletedBlock)
+    }
+
+    func test__get_record_zone_change_tokens_updated_block() {
+        target.recordZoneChangeTokensUpdatedBlock = { _ in }
+        XCTAssertNotNil(operation.recordZoneChangeTokensUpdatedBlock)
+    }
+    
+    func test__set_record_zone_change_tokens_updated_block() {
+        operation.recordZoneChangeTokensUpdatedBlock = { _ in }
+        XCTAssertNotNil(target.recordZoneChangeTokensUpdatedBlock)
+    }
+    
+    func test__success_with_completion_block() {
+        var blockDidRun = false
+        operation.setFetchRecordZoneChangesCompletionBlock { _ in
+            blockDidRun = true
+        }
+        
+        waitForOperation(operation)
+        
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+        XCTAssertTrue(blockDidRun)
+    }
+    
+    func test__error_with_completion_block() {
+        var blockDidRun = false
+        target.setSimulationOutputError(NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil))
+        
+        operation.setFetchRecordZoneChangesCompletionBlock {
+            blockDidRun = true
+        }
+        
+        waitForOperation(operation)
+        
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 1)
+        XCTAssertFalse(blockDidRun)
+    }
+}
+
+class OPRCKFetchShareMetadataOperationTests: CKTests {
+    
+    var target: TestFetchShareMetadataOperation!
+    var operation: OPRCKOperation<TestFetchShareMetadataOperation>!
+    
+    override func setUp() {
+        super.setUp()
+        target = TestFetchShareMetadataOperation()
+        operation = OPRCKOperation(operation: target)
+    }
+    
+    func test__get_share_urls() {
+        let shareURLs = [ NSURL(string: "http://example.com")! ]
+        target.shareURLs = shareURLs
+        XCTAssertEqual(operation.shareURLs, shareURLs)
+    }
+    
+    func test__set_share_urls() {
+        let shareURLs = [ NSURL(string: "http://example.com")! ]
+        operation.shareURLs = shareURLs
+        XCTAssertEqual(target.shareURLs, shareURLs)
+    }
+    
+    func test__get_should_fetch_root_record() {
+        let shouldFetchRootRecord = true
+        target.shouldFetchRootRecord = shouldFetchRootRecord
+        XCTAssertEqual(operation.shouldFetchRootRecord, shouldFetchRootRecord)
+    }
+    
+    func test__set_should_fetch_root_record() {
+        let shouldFetchRootRecord = true
+        operation.shouldFetchRootRecord = shouldFetchRootRecord
+        XCTAssertEqual(target.shouldFetchRootRecord, shouldFetchRootRecord)
+    }
+    
+    func test__get_root_record_desired_keys() {
+        let rootRecordDesiredKeys = ["recordKeyExample"]
+        target.rootRecordDesiredKeys = rootRecordDesiredKeys
+        XCTAssertNotNil(operation.rootRecordDesiredKeys)
+        XCTAssertEqual(operation.rootRecordDesiredKeys ?? [], rootRecordDesiredKeys)
+    }
+    
+    func test__set_root_record_desired_keys() {
+        let rootRecordDesiredKeys = ["recordKeyExample"]
+        operation.rootRecordDesiredKeys = rootRecordDesiredKeys
+        XCTAssertNotNil(target.rootRecordDesiredKeys)
+        XCTAssertEqual(target.rootRecordDesiredKeys ?? [], rootRecordDesiredKeys)
+    }
+    
+    func test__get_per_share_metadata_block() {
+        target.perShareMetadataBlock = { _, _, _ in }
+        XCTAssertNotNil(operation.perShareMetadataBlock)
+    }
+    
+    func test__set_per_share_metadata_block() {
+        operation.perShareMetadataBlock = { _, _, _ in }
+        XCTAssertNotNil(target.perShareMetadataBlock)
+    }
+    
+    func test__success_with_completion_block() {
+        var blockDidRun = false
+        operation.setFetchShareMetadataCompletionBlock {
+            blockDidRun = true
+        }
+        
+        waitForOperation(operation)
+        
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+        XCTAssertTrue(blockDidRun)
+    }
+    
+    func test__error_with_completion_block() {
+        var blockDidRun = false
+        target.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+        
+        operation.setFetchShareMetadataCompletionBlock {
+            blockDidRun = true
+        }
+        
+        waitForOperation(operation)
+        
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 1)
+        XCTAssertFalse(blockDidRun)
+    }
+}
+
+class OPRCKFetchShareParticipantsOperationTests: CKTests {
+    
+    var target: TestFetchShareParticipantsOperation!
+    var operation: OPRCKOperation<TestFetchShareParticipantsOperation>!
+    
+    override func setUp() {
+        super.setUp()
+        target = TestFetchShareParticipantsOperation()
+        operation = OPRCKOperation(operation: target)
+    }
+    
+    func test__get_user_identity_lookup_infos() {
+        target.userIdentityLookupInfos = [ "hello@world.com" ]
+        XCTAssertNotNil(operation.userIdentityLookupInfos)
+        XCTAssertEqual(operation.userIdentityLookupInfos.count, 1)
+        XCTAssertEqual(operation.userIdentityLookupInfos, [ "hello@world.com" ])
+    }
+    
+    func test__set_user_identity_lookup_infos() {
+        operation.userIdentityLookupInfos = [ "hello@world.com" ]
+        XCTAssertNotNil(target.userIdentityLookupInfos)
+        XCTAssertEqual(target.userIdentityLookupInfos.count, 1)
+        XCTAssertEqual(target.userIdentityLookupInfos, [ "hello@world.com" ])
+    }
+    
+    func test__get_share_participant_fetched_block() {
+        target.shareParticipantFetchedBlock = { _ in }
+        XCTAssertNotNil(operation.shareParticipantFetchedBlock)
+    }
+    
+    func test__set_share_participant_fetched_block() {
+        operation.shareParticipantFetchedBlock = { _ in }
+        XCTAssertNotNil(target.shareParticipantFetchedBlock)
+    }
+    
+    func test__success_with_completion_block() {
+        var blockDidRun = false
+        operation.setFetchShareParticipantsCompletionBlock {
+            blockDidRun = true
+        }
+        
+        waitForOperation(operation)
+        
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+        XCTAssertTrue(blockDidRun)
+    }
+    
+    func test__error_with_completion_block() {
+        var blockDidRun = false
+        target.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+        
+        operation.setFetchShareParticipantsCompletionBlock {
+            blockDidRun = true
+        }
+        
+        waitForOperation(operation)
+        
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 1)
+        XCTAssertFalse(blockDidRun)
+    }
+}
+
 class OPRCKFetchSubscriptionsOperationTests: CKTests {
 
     var target: TestFetchSubscriptionsOperation!

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -2151,6 +2151,95 @@ class OPRCKQueryOperationTests: CKTests {
 
 // MARK: - CloudKitOperation Test Cases
 
+class CloudKitOperationAcceptSharesOperationTests: CKTests {
+    
+    var container: TestAcceptSharesOperation.Container!
+    var shareMetadatas: [TestAcceptSharesOperation.ShareMetadata]!
+    var setByBlock_perShareCompletionBlock: Bool!
+    
+    var operation: CloudKitOperation<TestAcceptSharesOperation>!
+    
+    override func setUp() {
+        super.setUp()
+        container = "I'm a test container!"
+        shareMetadatas = [ "hello@world.com" ]
+        setByBlock_perShareCompletionBlock = false
+        
+        operation = CloudKitOperation(strategy: .Immediate) { TestAcceptSharesOperation() }
+        operation.container = container
+        operation.shareMetadatas = shareMetadatas
+        operation.perShareCompletionBlock = { [unowned self] _, _, _ in
+            self.setByBlock_perShareCompletionBlock = true
+        }
+    }
+    
+    func test__setting_common_properties() {
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        
+        XCTAssertEqual(operation.container, container)
+        XCTAssertEqual(operation.shareMetadatas, shareMetadatas)
+        
+        XCTAssertNotNil(operation.perShareCompletionBlock)
+        operation.perShareCompletionBlock?("shareMetadata", "acceptedShare", nil)
+        XCTAssertTrue(setByBlock_perShareCompletionBlock)
+    }
+    
+    func test__execution_after_cancellation() {
+        operation.cancel()
+        waitForOperation(operation)
+        
+        XCTAssertTrue(operation.finished)
+        XCTAssertTrue(operation.cancelled)
+    }
+    
+    func test__success_without_completion_block() {
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+    }
+    
+    func test__success_with_completion_block() {
+        var didExecuteBlock = false
+        operation.setAcceptSharesCompletionBlock {
+            didExecuteBlock = true
+        }
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+        XCTAssertTrue(didExecuteBlock)
+    }
+    
+    func test__error_without_completion_block() {
+        operation = CloudKitOperation(strategy: .Immediate) {
+            let op = TestAcceptSharesOperation()
+            op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+            return op
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+    }
+    
+    func test__error_with_completion_block() {
+        operation = CloudKitOperation(strategy: .Immediate) {
+            let op = TestAcceptSharesOperation()
+            op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+            return op
+        }
+        var didExecuteBlock = false
+        operation.setAcceptSharesCompletionBlock {
+            didExecuteBlock = true
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 1)
+        XCTAssertFalse(didExecuteBlock)
+    }
+}
+
 // Note: This also tests the error-handling/retry code.
 class CloudKitOperationDiscoverAllContractsTests: CKTests {
 
@@ -2362,6 +2451,91 @@ class CloudKitOperationDiscoverAllContractsTests: CKTests {
     }
 }
 
+class CloudKitOperationDiscoverAllUserIdentitiesOperationTests: CKTests {
+    
+    var container: TestDiscoverAllUserIdentitiesOperation.Container!
+    var setByBlock_userIdentityDiscoveredBlock: Bool!
+    
+    var operation: CloudKitOperation<TestDiscoverAllUserIdentitiesOperation>!
+    
+    override func setUp() {
+        super.setUp()
+        container = "I'm a test container!"
+        setByBlock_userIdentityDiscoveredBlock = false
+        
+        operation = CloudKitOperation(strategy: .Immediate) { TestDiscoverAllUserIdentitiesOperation() }
+        operation.container = container
+        operation.userIdentityDiscoveredBlock = { [unowned self] _ in
+            self.setByBlock_userIdentityDiscoveredBlock = true
+        }
+    }
+    
+    func test__setting_common_properties() {
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        
+        XCTAssertEqual(operation.container, container)
+        
+        XCTAssertNotNil(operation.userIdentityDiscoveredBlock)
+        operation.userIdentityDiscoveredBlock?("userIdentity")
+        XCTAssertTrue(setByBlock_userIdentityDiscoveredBlock)
+    }
+    
+    func test__execution_after_cancellation() {
+        operation.cancel()
+        waitForOperation(operation)
+        
+        XCTAssertTrue(operation.finished)
+        XCTAssertTrue(operation.cancelled)
+    }
+    
+    func test__success_without_completion_block() {
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+    }
+    
+    func test__success_with_completion_block() {
+        var didExecuteBlock = false
+        operation.setDiscoverAllUserIdentitiesCompletionBlock {
+            didExecuteBlock = true
+        }
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+        XCTAssertTrue(didExecuteBlock)
+    }
+    
+    func test__error_without_completion_block() {
+        operation = CloudKitOperation(strategy: .Immediate) {
+            let op = TestDiscoverAllUserIdentitiesOperation()
+            op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+            return op
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+    }
+    
+    func test__error_with_completion_block() {
+        operation = CloudKitOperation(strategy: .Immediate) {
+            let op = TestDiscoverAllUserIdentitiesOperation()
+            op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+            return op
+        }
+        var didExecuteBlock = false
+        operation.setDiscoverAllUserIdentitiesCompletionBlock {
+            didExecuteBlock = true
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 1)
+        XCTAssertFalse(didExecuteBlock)
+    }
+}
+
 class CloudKitOperationDiscoverUserInfosOperationTests: CKTests {
 
     var operation: CloudKitOperation<TestDiscoverUserInfosOperation>!
@@ -2435,6 +2609,95 @@ class CloudKitOperationDiscoverUserInfosOperationTests: CKTests {
         waitForOperation(operation)
         XCTAssertTrue(operation.finished)
         XCTAssertEqual(operation.errors.count, 1)
+    }
+}
+
+class CloudKitOperationDiscoverUserIdentitiesOperationTests: CKTests {
+    
+    var container: TestDiscoverUserIdentitiesOperation.Container!
+    var userIdentityLookupInfos: [TestDiscoverUserIdentitiesOperation.UserIdentityLookupInfo]!
+    var setByBlock_userIdentityDiscoveredBlock: Bool!
+    
+    var operation: CloudKitOperation<TestDiscoverUserIdentitiesOperation>!
+    
+    override func setUp() {
+        super.setUp()
+        container = "I'm a test container!"
+        userIdentityLookupInfos = [ "hello@world.com" ]
+        setByBlock_userIdentityDiscoveredBlock = false
+        
+        operation = CloudKitOperation(strategy: .Immediate) { TestDiscoverUserIdentitiesOperation() }
+        operation.container = container
+        operation.userIdentityLookupInfos = userIdentityLookupInfos
+        operation.userIdentityDiscoveredBlock = { [unowned self] _, _ in
+            self.setByBlock_userIdentityDiscoveredBlock = true
+        }
+    }
+    
+    func test__setting_common_properties() {
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        
+        XCTAssertEqual(operation.container, container)
+        XCTAssertEqual(operation.userIdentityLookupInfos, userIdentityLookupInfos)
+        
+        XCTAssertNotNil(operation.userIdentityDiscoveredBlock)
+        operation.userIdentityDiscoveredBlock?("userIdentity", "lookupInfo")
+        XCTAssertTrue(setByBlock_userIdentityDiscoveredBlock)
+    }
+    
+    func test__execution_after_cancellation() {
+        operation.cancel()
+        waitForOperation(operation)
+        
+        XCTAssertTrue(operation.finished)
+        XCTAssertTrue(operation.cancelled)
+    }
+    
+    func test__success_without_completion_block() {
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+    }
+    
+    func test__success_with_completion_block() {
+        var didExecuteBlock = false
+        operation.setDiscoverUserIdentitiesCompletionBlock {
+            didExecuteBlock = true
+        }
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+        XCTAssertTrue(didExecuteBlock)
+    }
+    
+    func test__error_without_completion_block() {
+        operation = CloudKitOperation(strategy: .Immediate) {
+            let op = TestDiscoverUserIdentitiesOperation()
+            op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+            return op
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 0)
+    }
+    
+    func test__error_with_completion_block() {
+        operation = CloudKitOperation(strategy: .Immediate) {
+            let op = TestDiscoverUserIdentitiesOperation()
+            op.error = NSError(domain: CKErrorDomain, code: CKErrorCode.InternalError.rawValue, userInfo: nil)
+            return op
+        }
+        var didExecuteBlock = false
+        operation.setDiscoverUserIdentitiesCompletionBlock {
+            didExecuteBlock = true
+        }
+        
+        waitForOperation(operation)
+        XCTAssertTrue(operation.finished)
+        XCTAssertEqual(operation.errors.count, 1)
+        XCTAssertFalse(didExecuteBlock)
     }
 }
 


### PR DESCRIPTION
This PR:
- Adds support for the new CloudKit operations in iOS 10 / macOS 10.12
- Adds tests for those new operations
- Adds support for the remaining/new parameters in CKOperation
- Adds appropriate availability markers for the now-deprecated older CloudKit operations
- Adds watchOS support for CloudKitOperation (via some fixes in `CloudKitInterface.swift`)