### PR TITLE
Make the conditions property publicly readable

### DIFF
--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -93,7 +93,7 @@ public class Operation: NSOperation {
     private let disableAutomaticFinishing: Bool
 
     internal private(set) var directDependencies = Set<NSOperation>()
-    internal private(set) var conditions = Set<Condition>()
+    public private(set) var conditions = Set<Condition>()
 
     internal var indirectDependencies: Set<NSOperation> {
         return Set(conditions


### PR DESCRIPTION
There isn't really any reason why the `conditions` property is internal. It can be useful to querying the attached conditions.