### PR TITLE
ConditionOperation "executed before operation set" assertion fix

### DIFF
--- a/Sources/Core/Shared/Condition.swift
+++ b/Sources/Core/Shared/Condition.swift
@@ -103,7 +103,7 @@ public class Condition: Operation, ConditionType, ResultOperationType {
 
     public final override func execute() {
         guard let operation = operation else {
-            assertionFailure("ConditionOperation executed before operation set.")
+            log.verbose("ConditionOperation finishing before evaluation because operation == .None.")
             finish()
             return
         }


### PR DESCRIPTION
Previously, if a ConditionOperation’s weak `operation` var was nil when it executed, the following assertionFailure occurred:
`assertionFailure("ConditionOperation executed before operation set.”)`

(Issue: #415)

However, this was not always correct, if the weak `operation` var was set, but the operation cancelled/finished/went away before the ConditionOperation was executed.

Since this can happen, the `assertionFailure` has been replaced with a more appropriate log statement.

A StressTest was also added to cover this case and #417.