### PR TITLE
Tests may randomly fail due to a bug in expectation fulfillment

### DIFF
--- a/Tests/Core/BasicTests.swift
+++ b/Tests/Core/BasicTests.swift
@@ -47,7 +47,7 @@ class BasicTests: OperationTests {
     }
 
     func test__add_multiple_completion_blocks() {
-        let expectation = expectationWithDescription("Test: \(#function)")
+        weak var expectation = expectationWithDescription("Test: \(#function)")
 
         var completionBlockOneDidRun = 0
         operation.addCompletionBlock {
@@ -62,7 +62,10 @@ class BasicTests: OperationTests {
         var finalCompletionBlockDidRun = 0
         operation.addCompletionBlock {
             finalCompletionBlockDidRun += 1
-            expectation.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = expectation else { print("Test: \(#function): Finished expectation after timeout"); return }
+                expectation.fulfill()
+            })
         }
 
         addCompletionBlockToTestOperation(operation)
@@ -174,7 +177,7 @@ class UserIntentOperationTests: OperationTests {
 class CompletionBlockOperationTests: OperationTests {
 
     func test__block_operation_with_default_block_runs_completion_block_once() {
-        let expectation = expectationWithDescription("Test: \(#function)")
+        weak var expectation = expectationWithDescription("Test: \(#function)")
         var numberOfTimesCompletionBlockIsRun = 0
 
         let operation = BlockOperation()
@@ -186,8 +189,11 @@ class CompletionBlockOperationTests: OperationTests {
 
         let delay = DelayOperation(interval: 0.1)
         delay.addObserver(BlockObserver { op, errors in
-            expectation.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = expectation else { print("Test: \(#function): Finished expectation after timeout"); return }
+                expectation.fulfill()
             })
+        })
         delay.addDependency(operation)
 
         runOperations(delay, operation)
@@ -198,10 +204,15 @@ class CompletionBlockOperationTests: OperationTests {
 
     func test__nsblockoperation_runs_completion_block_once() {
         let _queue = NSOperationQueue()
-        let expectation = expectationWithDescription("Test: \(#function)")
+        weak var expectation = expectationWithDescription("Test: \(#function)")
 
         let operation = NSBlockOperation()
-        operation.completionBlock = { expectation.fulfill() }
+        operation.completionBlock = {
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = expectation else { print("Test: \(#function): Finished expectation after timeout"); return }
+                expectation.fulfill()
+            })
+        }
 
         _queue.addOperation(operation)
         waitForExpectationsWithTimeout(3, handler: nil)
@@ -220,26 +231,35 @@ class OperationDependencyTests: OperationTests {
         for i in 0..<count {
 
             let op1name = "Operation 1, iteration: \(i)"
-            let op1Expectation = expectationWithDescription(op1name)
+            weak var op1Expectation = expectationWithDescription(op1name)
             let op1 = BlockOperation { (continuation: BlockOperation.ContinuationBlockType) in
                 counter1 += 1
-                op1Expectation.fulfill()
+                dispatch_async(Queue.Main.queue, {
+                    guard let op1Expectation = op1Expectation else { print("Test: \(#function): Finished expectation \"op1Expectation\" after timeout"); return }
+                    op1Expectation.fulfill()
+                })
                 continuation(error: nil)
             }
 
             let op2name = "Operation 2, iteration: \(i)"
-            let op2Expectation = expectationWithDescription(op2name)
+            weak var op2Expectation = expectationWithDescription(op2name)
             let op2 = BlockOperation { (continuation: BlockOperation.ContinuationBlockType) in
                 counter2 += 1
-                op2Expectation.fulfill()
+                dispatch_async(Queue.Main.queue, {
+                    guard let op2Expectation = op2Expectation else { print("Test: \(#function): Finished expectation \"op2Expectation\" after timeout"); return }
+                    op2Expectation.fulfill()
+                })
                 continuation(error: nil)
             }
 
             let op3name = "Operation 3, iteration: \(i)"
-            let op3Expectation = expectationWithDescription(op3name)
+            weak var op3Expectation = expectationWithDescription(op3name)
             let op3 = BlockOperation { (continuation: BlockOperation.ContinuationBlockType) in
                 counter3 += 1
-                op3Expectation.fulfill()
+                dispatch_async(Queue.Main.queue, {
+                    guard let op3Expectation = op3Expectation else { print("Test: \(#function): Finished expectation \"op3Expectation\" after timeout"); return }
+                    op3Expectation.fulfill()
+                })
                 continuation(error: nil)
             }
 
@@ -295,12 +315,15 @@ class DelayOperationTests: OperationTests {
     func test__delay_operation_completes_after_interval() {
         var started: NSDate!
         var ended: NSDate!
-        let expectation = expectationWithDescription("Test: \(#function)")
+        weak var expectation = expectationWithDescription("Test: \(#function)")
         let interval: NSTimeInterval = 0.5
         let operation = DelayOperation(interval: interval)
         operation.addCompletionBlock {
             ended = NSDate()
-            expectation.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = expectation else { print("Test: \(#function): Finished expectation after timeout"); return }
+                expectation.fulfill()
+            })
         }
         started = NSDate()
         runOperation(operation)

--- a/Tests/Core/BlockConditionTests.swift
+++ b/Tests/Core/BlockConditionTests.swift
@@ -25,14 +25,17 @@ class BlockConditionTests: OperationTests {
 
     func test__operation_with_unsuccessful_block_condition_errors() {
 
-        let expectation = expectationWithDescription("Test: \(#function)")
+        weak var expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
         operation.addCondition(BlockCondition { false })
 
         var receivedErrors = [ErrorType]()
         operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
-            expectation.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = expectation else { print("Test: \(#function): Finished expectation after timeout"); return }
+                expectation.fulfill()
+            })
         })
 
         runOperation(operation)
@@ -47,7 +50,7 @@ class BlockConditionTests: OperationTests {
     }
 
     func test__operation_with_block_which_throws_condition_errors() {
-        let expectation = expectationWithDescription("Test: \(#function)")
+        weak var expectation = expectationWithDescription("Test: \(#function)")
 
         let operation = TestOperation()
         operation.addCondition(BlockCondition { throw TestOperation.Error.SimulatedError })
@@ -55,7 +58,10 @@ class BlockConditionTests: OperationTests {
         var receivedErrors = [ErrorType]()
         operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
-            expectation.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = expectation else { print("Test: \(#function): Finished expectation after timeout"); return }
+                expectation.fulfill()
+            })
         })
 
         runOperation(operation)

--- a/Tests/Core/GroupOperationTests.swift
+++ b/Tests/Core/GroupOperationTests.swift
@@ -49,10 +49,13 @@ class GroupOperationTests: OperationTests {
 
     func test__group_operations_are_performed_in_order() {
         let group = createGroupOperations()
-        let expectation = expectationWithDescription("Test: \(#function)")
+        weak var expectation = expectationWithDescription("Test: \(#function)")
         let operation = GroupOperation(operations: group)
         operation.addCompletionBlock {
-            expectation.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = expectation else { print("Test: \(#function): Finished expectation after timeout"); return }
+                expectation.fulfill()
+            })
         }
 
         runOperation(operation)
@@ -64,10 +67,13 @@ class GroupOperationTests: OperationTests {
     }
 
     func test__adding_operation_to_running_group() {
-        let expectation = expectationWithDescription("Test: \(#function)")
+        weak var expectation = expectationWithDescription("Test: \(#function)")
         let operation = GroupOperation(operations: TestOperation(), TestOperation())
         operation.addCompletionBlock {
-            expectation.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = expectation else { print("Test: \(#function): Finished expectation after timeout"); return }
+                expectation.fulfill()
+            })
         }
         let extra = TestOperation()
         runOperation(operation)

--- a/Tests/Core/NegatedConditionTests.swift
+++ b/Tests/Core/NegatedConditionTests.swift
@@ -12,14 +12,17 @@ import XCTest
 class NegatedConditionTests: OperationTests {
 
     func test__operation_with_successful_block_condition_fails() {
-        let expectation = expectationWithDescription("Test: \(#function)")
+        weak var expectation = expectationWithDescription("Test: \(#function)")
         let operation = TestOperation()
         operation.addCondition(NegatedCondition(TrueCondition()))
 
         var receivedErrors = [ErrorType]()
         operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
-            expectation.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = expectation else { print("Test: \(#function): Finished expectation after timeout"); return }
+                expectation.fulfill()
+            })
         })
 
         runOperation(operation)

--- a/Tests/Core/OperationTests.swift
+++ b/Tests/Core/OperationTests.swift
@@ -179,20 +179,20 @@ class OperationTests: XCTestCase {
         queue.addOperations(operations, waitUntilFinished: false)
     }
 
-    func waitForOperation(operation: Operation, withExpectationDescription text: String = #function) {
+    func waitForOperation(operation: Operation, withTimeout timeout: NSTimeInterval = 3, withExpectationDescription text: String = #function) {
         addCompletionBlockToTestOperation(operation, withExpectationDescription: text)
         queue.delegate = delegate
         queue.addOperation(operation)
-        waitForExpectationsWithTimeout(3, handler: nil)
+        waitForExpectationsWithTimeout(timeout, handler: nil)
     }
 
-    func waitForOperations(operations: Operation..., withExpectationDescription text: String = #function) {
+    func waitForOperations(operations: Operation..., withTimeout timeout: NSTimeInterval = 3, withExpectationDescription text: String = #function) {
         for (i, op) in operations.enumerate() {
             addCompletionBlockToTestOperation(op, withExpectationDescription: "\(i), \(text)")
         }
         queue.delegate = delegate
         queue.addOperations(operations, waitUntilFinished: false)
-        waitForExpectationsWithTimeout(3, handler: nil)
+        waitForExpectationsWithTimeout(timeout, handler: nil)
     }
 
     func addCompletionBlockToTestOperation(operation: Operation, withExpectation expectation: XCTestExpectation) {

--- a/Tests/Core/OperationTests.swift
+++ b/Tests/Core/OperationTests.swift
@@ -198,14 +198,21 @@ class OperationTests: XCTestCase {
     func addCompletionBlockToTestOperation(operation: Operation, withExpectation expectation: XCTestExpectation) {
         weak var weakExpectation = expectation
         operation.addObserver(DidFinishObserver { _, _ in
-            weakExpectation?.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = weakExpectation else { return }
+                expectation.fulfill()
+            })
         })
     }
 
     func addCompletionBlockToTestOperation(operation: Operation, withExpectationDescription text: String = #function) -> XCTestExpectation {
         let expectation = expectationWithDescription("Test: \(text), \(NSUUID().UUIDString)")
+        weak var weakExpectation = expectation
         operation.addObserver(DidFinishObserver { _, _ in
-            expectation.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = weakExpectation else { return }
+                expectation.fulfill()
+            })
         })
         return expectation
     }

--- a/Tests/Core/StressTests.swift
+++ b/Tests/Core/StressTests.swift
@@ -27,7 +27,7 @@ class StressTest: OperationTests {
             }
             self.queue.addOperation(operation)
         }
-        waitForExpectationsWithTimeout(5, handler: nil)
+        waitForExpectationsWithTimeout(12, handler: nil)
     }
 
     func test__conditions() {

--- a/Tests/Core/StressTests.swift
+++ b/Tests/Core/StressTests.swift
@@ -22,7 +22,7 @@ class StressTest: OperationTests {
         (0..<batchSize).forEach { i in
             dispatch_group_enter(operationDispatchGroup)
 
-            let operation = BlockOperation { }
+            let operation = BlockOperation(block: { continuation in continuation(error: nil) })
             operation.addCompletionBlock {
                 dispatch_group_leave(operationDispatchGroup)
             }

--- a/Tests/Core/StressTests.swift
+++ b/Tests/Core/StressTests.swift
@@ -41,8 +41,7 @@ class StressTest: OperationTests {
         (0..<batchSize).forEach { i in
             operation.addCondition(TrueCondition())
         }
-        addCompletionBlockToTestOperation(operation)
-        waitForOperation(operation)
+        waitForOperation(operation, withTimeout: 10)
         XCTAssertTrue(operation.didExecute)
     }
 
@@ -53,8 +52,7 @@ class StressTest: OperationTests {
             condition.name = "Condition \(i)"
             operation.addCondition(condition)
         }
-        addCompletionBlockToTestOperation(operation)
-        waitForOperation(operation)
+        waitForOperation(operation, withTimeout: 10)
         XCTAssertTrue(operation.didExecute)
     }
     

--- a/Tests/Features/CloudCapabilityTests.swift
+++ b/Tests/Features/CloudCapabilityTests.swift
@@ -188,7 +188,7 @@ class CloudCapabilitiesTests: XCTestCase {
     // Requesting authorization
 
     func test__request_permissions() {
-        let expectation = expectationWithDescription("Test: \(#function)")
+        weak var expectation = expectationWithDescription("Test: \(#function)")
         requirement = [ .UserDiscoverability ]
         makeDefaultCapability()
         container.accountStatus = .Available
@@ -196,7 +196,10 @@ class CloudCapabilitiesTests: XCTestCase {
             XCTAssertTrue(self.container.didGetAccountStatus)
             XCTAssertTrue(self.container.didVerifyApplicationStatus)
             XCTAssertTrue(self.container.didRequestApplicationStatus)
-            expectation.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = expectation else { print("Test: \(#function): Finished expectation after timeout"); return }
+                expectation.fulfill()
+            })
         }
 
         waitForExpectationsWithTimeout(3, handler: nil)

--- a/Tests/Features/RemoteNotificationConditionTests.swift
+++ b/Tests/Features/RemoteNotificationConditionTests.swift
@@ -63,11 +63,14 @@ class RemoteNotificationConditionTests: OperationTests {
         let operation = TestOperation()
         operation.addCondition(condition)
 
-        let expectation = expectationWithDescription("Test: \(#function)")
+        weak var expectation = expectationWithDescription("Test: \(#function)")
         var receivedErrors = [ErrorType]()
         operation.addObserver(DidFinishObserver { _, errors in
             receivedErrors = errors
-            expectation.fulfill()
+            dispatch_async(Queue.Main.queue, {
+                guard let expectation = expectation else { print("Test: \(#function): Finished expectation after timeout"); return }
+                expectation.fulfill()
+            })
         })
 
         runOperation(operation)


### PR DESCRIPTION
If `XCTestExpectation`s are not fulfilled on the main thread, `waitForExpectationsWithTimeout` may occasionally fail with the timeout.

Fix: Ensure that `XCTestExpectation.fulfill()` is always called on the main thread.

Some places this needs to be fixed:

- [x] `OperationTests.addCompletionBlockToTestOperation()`

In BasicTests.swift:
- [x] `test__add_multiple_completion_blocks`
- [x] `test__block_operation_with_default_block_runs_completion_block_once`
- [x] `test__nsblockoperation_runs_completion_block_once`
- [x] `test__dependent_operations_always_run`
- [x] `test__delay_operation_completes_after_interval`

In BlockConditionTests.swift:

- [x] `test__operation_with_unsuccessful_block_condition_errors`
- [x] `test__operation_with_block_which_throws_condition_errors`

In CloudCapabilitiesTests.swift:
- [x] `test__request_permissions`

In GroupOperationTests.swift:
- [x] `test__group_operations_are_performed_in_order`
- [x] `test__adding_operation_to_running_group`

In NegatedConditionTests.swift:
- [x] `test__operation_with_successful_block_condition_fails`

In RemoteNotificationConditionTests.swift:
- [x] `test__condition_fails__when_registration_fails`

In StressTests.swift:
- [x] `test__completion_blocks`
- [x] `test__SR_192_OperationQueue_delegate_weak_var_thread_safety`
