### PR TITLE
Fix for NetworkObserver Timer.cancel() (#344)

### DIFF
--- a/Sources/Core/iOS/NetworkObserver.swift
+++ b/Sources/Core/iOS/NetworkObserver.swift
@@ -94,7 +94,7 @@ private class NetworkIndicatorController {
     }
 }
 
-private struct Timer {
+internal class Timer {     // internal for testing
 
     private var isCancelled = false
 
@@ -107,7 +107,7 @@ private struct Timer {
         }
     }
 
-    mutating func cancel() {
+    func cancel() {
         isCancelled = true
     }
 }

--- a/Tests/Core/NetworkObserverTests.swift
+++ b/Tests/Core/NetworkObserverTests.swift
@@ -139,4 +139,21 @@ class NetworkObserverTests: OperationTests {
             XCTAssertEqual(self.visibilityChanges.count, 2)
         }
     }
+    
+    func test__network_indicator_timer_cancellation_prevents_handler_from_running() {
+        // Test for: https://github.com/ProcedureKit/ProcedureKit/issues/344
+        let interval = 0.4
+        var ranHandler = false
+        var timer = Timer(interval: interval) {
+            ranHandler = true
+        }
+        timer.cancel()
+        let expectation = expectationWithDescription("Test: \(#function)")
+        let after = dispatch_time(DISPATCH_TIME_NOW, Int64((interval + 0.1) * Double(NSEC_PER_SEC)))
+        dispatch_after(after, Queue.Main.queue) {
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(3, handler: nil)
+        XCTAssertFalse(ranHandler)
+    }
 }


### PR DESCRIPTION
The value of `isCancelled` was being captured by the `dispatch_after` block at `init`, and thus the check always passed and the handler was always invoked (even if `Timer.cancel()` was called).

See: https://github.com/ProcedureKit/ProcedureKit/issues/344