### PR TITLE
URLSessionTaskOperation rework proposal

### DIFF
--- a/Sources/Features/Shared/URLSessionTaskOperation.swift
+++ b/Sources/Features/Shared/URLSessionTaskOperation.swift
@@ -18,15 +18,24 @@ setup, so that conditions or observers can be attached.
 
 */
 public class URLSessionTaskOperation: Operation {
-
-    enum KeyPath: String {
-        case State = "state"
-    }
-
     public private(set) var task: NSURLSessionTask!
 
+    private override init() {
+        super.init()
+    }
+
+    // Deprecated init
+    @available(*, unavailable, message="URLSessionTaskOperation has been refactored to utilize factory methods that create the task and the operation.")
+    public init(task: NSURLSessionTask) {
+        super.init()
+    }
+
+    // MARK: - Factory Methods
+
+    // MARK: -- Data Tasks
+
     public static func dataTask(fromSession session: NSURLSession, withURL url: NSURL, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> URLSessionTaskOperation {
-        let op = URLSessionTaskOperation()
+        let op = URLSessionTaskOperationWithCompletionHandler()
         let task = session.dataTaskWithURL(url) { (data, response, error) in
             completionHandler(data, response, error)
             op.finish(error)
@@ -40,7 +49,7 @@ public class URLSessionTaskOperation: Operation {
     }
 
     public static func dataTask(fromSession session: NSURLSession, withRequest request: NSURLRequest, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> URLSessionTaskOperation {
-        let op = URLSessionTaskOperation()
+        let op = URLSessionTaskOperationWithCompletionHandler()
         let task = session.dataTaskWithRequest(request) { (data, response, error) in
             completionHandler(data, response, error)
             op.finish(error)
@@ -52,9 +61,35 @@ public class URLSessionTaskOperation: Operation {
         })
         return op
     }
+    
+    // without completion handler
+
+    public static func dataTask(fromSession session: NSURLSession, withURL url: NSURL) -> URLSessionTaskOperation {
+        let op = URLSessionTaskOperationWithoutCompletionHandler(session: session)
+        let task = session.dataTaskWithURL(url)
+        assert(task.state == .Suspended, "NSURLSessionTask must be suspended, not \(task.state)")
+        op.task = task
+        op.addObserver(DidCancelObserver { _ in
+            task.cancel()
+        })
+        return op
+    }
+
+    public static func dataTask(fromSession session: NSURLSession, withRequest request: NSURLRequest) -> URLSessionTaskOperation {
+        let op = URLSessionTaskOperationWithoutCompletionHandler(session: session)
+        let task = session.dataTaskWithRequest(request)
+        assert(task.state == .Suspended, "NSURLSessionTask must be suspended, not \(task.state)")
+        op.task = task
+        op.addObserver(DidCancelObserver { _ in
+            task.cancel()
+        })
+        return op
+    }
+
+    // MARK: -- Download Tasks
 
     public static func downloadTask(fromSession session: NSURLSession, withURL url: NSURL, completionHandler: (NSURL?, NSURLResponse?, NSError?) -> Void) -> URLSessionTaskOperation {
-        let op = URLSessionTaskOperation()
+        let op = URLSessionTaskOperationWithCompletionHandler()
         let task = session.downloadTaskWithURL(url) { (location, response, error) in
             completionHandler(location, response, error)
             op.finish(error)
@@ -68,7 +103,7 @@ public class URLSessionTaskOperation: Operation {
     }
 
     public static func downloadTask(fromSession session: NSURLSession, withRequest request: NSURLRequest, completionHandler: (NSURL?, NSURLResponse?, NSError?) -> Void) -> URLSessionTaskOperation {
-        let op = URLSessionTaskOperation()
+        let op = URLSessionTaskOperationWithCompletionHandler()
         let task = session.downloadTaskWithRequest(request) { (location, response, error) in
             completionHandler(location, response, error)
             op.finish(error)
@@ -81,23 +116,88 @@ public class URLSessionTaskOperation: Operation {
         return op
     }
 
-    private override init () {
-        super.init()
-    }
+    // without completion handler
 
-    @available(*, unavailable, message="URLSessionTaskOperation has been refactored to utilize factory methods that create the task and the operation.")
-    public init(task: NSURLSessionTask) {
+    public static func downloadTask(fromSession session: NSURLSession, withURL url: NSURL) -> URLSessionTaskOperation {
+        let op = URLSessionTaskOperationWithoutCompletionHandler(session: session)
+        let task = session.downloadTaskWithURL(url)
         assert(task.state == .Suspended, "NSURLSessionTask must be suspended, not \(task.state)")
-        self.task = task
-        super.init()
-        addObserver(DidCancelObserver { _ in
+        op.task = task
+        op.addObserver(DidCancelObserver { _ in
             task.cancel()
         })
+        return op
     }
 
-    public override func execute() {
+    public static func downloadTask(fromSession session: NSURLSession, withRequest request: NSURLRequest) -> URLSessionTaskOperation {
+        let op = URLSessionTaskOperationWithoutCompletionHandler(session: session)
+        let task = session.downloadTaskWithRequest(request)
+        assert(task.state == .Suspended, "NSURLSessionTask must be suspended, not \(task.state)")
+        op.task = task
+        op.addObserver(DidCancelObserver { _ in
+            task.cancel()
+        })
+        return op
+    }
+}
+
+// For URLSessionTasks with a completion handler, we can properly handle finishing the operation 
+// by utilizing the completion handler. So this is pretty simple:
+internal class URLSessionTaskOperationWithCompletionHandler: URLSessionTaskOperation {
+    override func execute() {
         assert(task.state == .Suspended, "NSURLSessionTask resumed outside of \(self)")
         task.resume()
     }
 }
 
+// For URLSessionTasks *without* a completion handler, we must: 
+// 1.) Use KVO to determine when the task is finished
+// 2.) Dispatch the call to `finish()` to the NSURLSession's delegateQueue
+internal class URLSessionTaskOperationWithoutCompletionHandler: URLSessionTaskOperation {
+
+    enum KeyPath: String {
+        case State = "state"
+    }
+
+    private var removedObserved = false
+    private let lock = NSLock()
+    private var sessionDelegateQueue: NSOperationQueue
+    
+    init(session: NSURLSession) {
+        self.sessionDelegateQueue = session.delegateQueue
+        super.init()
+    }
+
+    internal override func execute() {
+        assert(task.state == .Suspended, "NSURLSessionTask resumed outside of \(self)")
+        task.addObserver(self, forKeyPath: KeyPath.State.rawValue, options: [], context: &URLSessionTaskOperationKVOContext)
+        task.resume()
+    }
+
+    internal override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+        guard context == &URLSessionTaskOperationKVOContext else { return }
+
+        lock.withCriticalScope {
+            if object === task && keyPath == KeyPath.State.rawValue && !removedObserved {
+
+                if case .Completed = task.state {
+                    sessionDelegateQueue.addOperation(NSBlockOperation { [unowned self] in
+                        self.finish(self.task.error)
+                    })
+                }
+
+                switch task.state {
+                case .Completed, .Canceling:
+                    task.removeObserver(self, forKeyPath: KeyPath.State.rawValue)
+                    removedObserved = true
+                default:
+                    break
+                }
+            }
+        }
+    }
+}
+
+// swiftlint:disable variable_name
+private var URLSessionTaskOperationKVOContext = 0
+// swiftlint:enable variable_name

--- a/Tests/Features/URLSessionTaskOperationTests.swift
+++ b/Tests/Features/URLSessionTaskOperationTests.swift
@@ -14,4 +14,85 @@ class URLSessionTaskOperationTests: OperationTests {
     // TODO: The question is, how to test URLSessionTask
     // stuff without introducing a dependency like DVR?
 
+    typealias FinalSessionTaskDelegateCallback = (NSURLSession, NSURLSessionTask, NSError?) -> Void
+
+    class TestSessionDelegate: NSObject, NSURLSessionTaskDelegate {
+        private var finalTaskDelegateMethodObservers = [FinalTaskDelegateMethodObserver]()
+        
+        func URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError error: NSError?) {
+            // should be the last delegate method called for a sessionTask
+            for observer in finalTaskDelegateMethodObservers {
+                observer.finalDelegateCallbackHandler(session, task, error)
+            }
+        }
+
+        func addFinalTaskDelegateMethodObserver(observer: FinalTaskDelegateMethodObserver) {
+            finalTaskDelegateMethodObservers.append(observer)
+        }
+    }
+
+    struct FinalTaskDelegateMethodObserver {
+        private let finalDelegateCallbackHandler: FinalSessionTaskDelegateCallback
+
+        init(finalDelegateCallbackHandler: FinalSessionTaskDelegateCallback) {
+            self.finalDelegateCallbackHandler = finalDelegateCallbackHandler
+        }
+    }
+
+    var session: NSURLSession!
+    var sessionDelegate: TestSessionDelegate!
+
+    override func setUp() {
+        super.setUp()
+        sessionDelegate = TestSessionDelegate()
+        session = NSURLSession(configuration: NSURLSessionConfiguration.ephemeralSessionConfiguration(), delegate: sessionDelegate, delegateQueue: nil)
+    }
+    
+    override func tearDown() {
+        session = nil
+        super.tearDown()
+    }
+    
+    func test__simple_data_task_with_url_completion_handler() {
+        var r_data: NSData?
+        var r_response: NSURLResponse?
+        var r_error: NSError?
+        
+        let url = NSURL(string: "https://www.google.com/robots.txt")!
+        let expectation = expectationWithDescription("Test: \(#function), completed task")
+        
+        let operation = URLSessionTaskOperation.dataTask(fromSession: session, withURL: url) { (data, response, error) in
+            r_data = data
+            r_response = response
+            r_error = error
+            expectation.fulfill()
+        }
+        waitForOperation(operation)
+        XCTAssertNotNil(r_data)
+        XCTAssertNotNil(r_response)
+        XCTAssertNil(r_error)
+    }
+    
+    func test__simple_data_task_with_url_delegate() {
+        let url = NSURL(string: "https://www.google.com/robots.txt")!
+        let actions = Protector<Array<String>>([])
+        
+        let expectation = expectationWithDescription("Test: \(#function), called final delegate method")
+        sessionDelegate.addFinalTaskDelegateMethodObserver( FinalTaskDelegateMethodObserver { (session, task, error) in
+            // called final NSURLSessionTaskDelegate method
+            actions.append("NSURLSessionTaskDelegate - final task delegate method")
+            expectation.fulfill()
+        })
+        let operation = URLSessionTaskOperation.dataTask(fromSession: session, withURL: url)
+        operation.addObserver(DidFinishObserver { (operation, errors) in
+            actions.append("URLSessionTaskOperation.DidFinishObserver")
+        })
+        waitForOperation(operation, withTimeout: 50)
+        
+        let resultingActions = actions.read { $0 }
+        XCTAssertEqual(resultingActions.count, 2)
+        XCTAssertEqual(resultingActions[0], "NSURLSessionTaskDelegate - final task delegate method")
+        XCTAssertEqual(resultingActions[1], "URLSessionTaskOperation.DidFinishObserver")
+    }
+
 }


### PR DESCRIPTION
**Note: This PR is unfinished, and is a work-in-progress.**

There are several issues surrounding the current structure of URLSessionTaskOperation.

- #418 URLSessionOperation completion handler executes before Task is finished.
- #320 NSURLSessionTask state property KVO may be inadvisable
- #340 Operation which depends on the network operation
etc.

Most of these issues are caused by the lack of consistent ordering and timing surrounding the completion of the URLSessionOperation and the completion of its NSURLSessionTask.

The culprit? KVO to determine when the NSURLSessionTask has completed.

This proposal restructures URLSessionTaskOperation to be constructed with static factory methods that create the task and set a completionHandler with predictable ordering and behavior. (i.e. You now construct the URLSessionTaskOperation and the NSURLSessionTask at the same time.)

This means that code like:

```swift
let task = session.dataTaskWithURL(url) { (data, response, error) in
    // do something with the data
}
let operation = URLSessionTaskOperation(task: task)
```

becomes:

```swift
let operation = URLSessionTaskOperation.dataTask(fromSession: session, withURL: url) { (data, response, error) in
    // do something with the data
}
// to access the task directly, use operation.task
```

More importantly, it means that we can ensure that the URLSessionTaskOperation itself finishes **after** the user's completionHandler has returned.

-----

Needs factory methods for the following methods of NSURLSession:

Adding Data Tasks to a Session
- [ ] dataTaskWithURL(_:)
- [x] dataTaskWithURL(_:completionHandler:)
- [ ] dataTaskWithRequest(_:)
- [x] dataTaskWithRequest(_:completionHandler:)

Adding Download Tasks to a Session
- [ ] downloadTaskWithURL(_:)
- [x] downloadTaskWithURL(_:completionHandler:)
- [ ] downloadTaskWithRequest(_:)
- [x] downloadTaskWithRequest(_:completionHandler:)
- [ ] downloadTaskWithResumeData(_:)
- [ ] downloadTaskWithResumeData(_:completionHandler:)

Adding Upload Tasks to a Session
- [ ] uploadTaskWithRequest(_:fromData:)
- [ ] uploadTaskWithRequest(_:fromData:completionHandler:)
- [ ] uploadTaskWithRequest(_:fromFile:)
- [ ] uploadTaskWithRequest(_:fromFile:completionHandler:)
- [ ] uploadTaskWithStreamedRequest(_:)

-----

This is complicated by the methods without completion handlers.

It may be possible to safely use KVO for tasks created without completion handlers since there is no user completion handler to worry about (timing-wise), and the documentation for NSURLSessionTask state says:

> Completed
> The task has completed (without being canceled), and the **task's delegate receives no further callbacks**.

Thus, KVO may be safe in this case. (For these tasks, the consumer relies on receiving all data as delegate callbacks.)