### PR TITLE
Fixes warning r.e. OpenInSafariOperationTests

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -818,7 +818,6 @@
 				65B9E0801CB85C53009161AD /* URLSessionTaskOperationTests.swift */,
 				6526172F1C11F5EB00654091 /* UserNotificationConditionTests.swift */,
 				652617301C11F5EB00654091 /* WebpageOperationTests.swift */,
-				2E7627411CE7BB7B0050AB05 /* OpenInSafariOperationTests.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";


### PR DESCRIPTION
There was an extra reference in the pfxproj which Xcode UI was ignoring, but command line tools were showing a warning.

This fixes #432 