### PR TITLE
Reduce Release build leaking (due to Swift 2.x bug) (#433)

### DIFF
--- a/Sources/Core/Shared/Condition.swift
+++ b/Sources/Core/Shared/Condition.swift
@@ -47,7 +47,7 @@ public protocol ConditionType {
 internal extension ConditionType {
 
     internal var category: String {
-        return "\(self.dynamicType)"
+        return String(self.dynamicType)
     }
 }
 
@@ -240,7 +240,7 @@ internal class WrappedOperationCondition: Condition {
     let condition: OperationCondition
 
     var category: String {
-        return "\(condition.dynamicType)"
+        return String(condition.dynamicType)
     }
 
     init(_ condition: OperationCondition) {

--- a/Sources/Core/Shared/OperationQueue.swift
+++ b/Sources/Core/Shared/OperationQueue.swift
@@ -142,8 +142,7 @@ public class OperationQueue: NSOperationQueue {
                 let mutuallyExclusiveConditions = operation.conditions.filter { $0.mutuallyExclusive }
                 var previousMutuallyExclusiveOperations = Set<NSOperation>()
                 for condition in mutuallyExclusiveConditions {
-                    let category = "\(condition.category)"
-                    if let previous = manager.addOperation(operation, category: category) {
+                    if let previous = manager.addOperation(operation, category: condition.category) {
                         previousMutuallyExclusiveOperations.insert(previous)
                     }
                 }


### PR DESCRIPTION
Replace some instances of String interpolation, to reduce leaking in Release build on Swift 2.2.

See: #433 

As well as [this comment from an XCGLogger issue](https://github.com/DaveWoodCom/XCGLogger/issues/137#issuecomment-241268975):

> So I spent a tonne of time digging into the memory leaks. The leaks are actually in the Swift core library and our code just happened to trigger them. As you probably noticed, judging by the PR, the leak is triggered in some cases using string interpolation, so changing affected code from: "[\(owner.identifier)] " to "[" + owner.identifier + "] " avoids the leak.

> Worth noting the leaks appear to be fixed in Swift 3.