### PR TITLE
Makes the dynamicType the default name for Operations.

### DIFF
--- a/Sources/Core/Shared/GroupOperation.swift
+++ b/Sources/Core/Shared/GroupOperation.swift
@@ -154,7 +154,6 @@ public class GroupOperation: Operation, OperationQueueDelegate {
         // and its finishingOperation has finished.
         super.init(disableAutomaticFinishing: true) // Override default Operation finishing behavior
         canFinishOperation = GroupOperation.CanFinishOperation(parentGroupOperation: self)
-        name = "Group Operation"
         queue.suspended = true
         queue.delegate = self
         queue.underlyingQueue = underlyingQueue

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -197,6 +197,7 @@ public class Operation: NSOperation {
     public override init() {
         self.disableAutomaticFinishing = false
         super.init()
+        self.name = String(self.dynamicType)
     }
 
     // MARK: - Disable Automatic Finishing
@@ -240,6 +241,7 @@ public class Operation: NSOperation {
     public init(disableAutomaticFinishing: Bool) {
         self.disableAutomaticFinishing = disableAutomaticFinishing
         super.init()
+        self.name = String(self.dynamicType)
     }
 
     // MARK: - Add Condition

--- a/Tests/Core/BasicTests.swift
+++ b/Tests/Core/BasicTests.swift
@@ -521,3 +521,26 @@ class FinishingOperationTests: OperationTests {
         // This will crash the test execution if it happens.
     }
 }
+
+class SubclassedGroupOperation: GroupOperation { }
+
+class NamedOperationsTests: OperationTests {
+    
+    func test__operation_name() {
+        let operation = Operation()
+        
+        XCTAssertEqual(operation.name, "Operation")
+        
+        operation.name = "Changed Name"
+        XCTAssertEqual(operation.name, "Changed Name")
+        
+        operation.name = nil
+        XCTAssertNil(operation.name)
+    }
+    
+    func test__subclassed_group_operation_name() {
+        let operation = SubclassedGroupOperation()
+        XCTAssertEqual(operation.name, "SubclassedGroupOperation")
+    }
+    
+}


### PR DESCRIPTION
Having default names on operations is something that have been of great value for me when reading logs.

This only changes so the name property at init(), and will not interfere will later setting of the property.

Example in for log in old for a cancelled dependency:

```
Unnamed Operation Evaluate Conditions: Will finish with 1 errors.
Unnamed Operation: Did cancel with errors: [Operations.NoFailedDependenciesCondition.Error.CancelledDependencies].
Unnamed Operation: Did cancel with errors: [Operations.OperationError.ParentOperationCancelledWithErrors([Operations.NoFailedDependenciesCondition.Error.CancelledDependencies])].
```

```
MySubclassedGroupOperationWithAUsefulName Evaluate Conditions: Will finish with 1 errors.
MySubclassedGroupOperationWithAUsefulName: Did cancel with errors: [Operations.NoFailedDependenciesCondition.Error.CancelledDependencies].
MyInternalOperationWithAUsefulName: Did cancel with errors: [Operations.OperationError.ParentOperationCancelledWithErrors([Operations.NoFailedDependenciesCondition.Error.CancelledDependencies])].
```

"Unnamed Operation" comes from Logging.swift line 367 and will still be used of the operation name have been set to nil.