### PR TITLE
Error types

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -361,8 +361,6 @@
 		653C9FD81D6097D00070B7A2 /* ProcedureKit */ = {
 			isa = PBXGroup;
 			children = (
-				65A2D8031D6A1ED500FB067C /* AnyObserver.swift */,
-				65A2D7FA1D6852A500FB067C /* BlockObservers.swift */,
 				6584AF441D74770C0030DBB3 /* Errors.swift */,
 				65245D221D723A6B00340A2D /* Logging.swift */,
 				655E86461D67BA9C000FBA6C /* Support.swift */,
@@ -484,12 +482,14 @@
 		658A7B491D74D5B900F897C8 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				65A2D8031D6A1ED500FB067C /* AnyObserver.swift */,
+				65A2D7FA1D6852A500FB067C /* BlockObservers.swift */,
+				6518D5E21D7B3A2800A12EF4 /* Condition.swift */,
 				65245D261D7258E400340A2D /* Group.swift */,
 				65B97DB41D65138F00AC3B5D /* Procedure.swift */,
 				655E86441D67B9F9000FBA6C /* ProcedureObserver.swift */,
 				65A2D8011D6A05D800FB067C /* ProcedureProcotol.swift */,
 				655E86421D67B55B000FBA6C /* ProcedureQueue.swift */,
-				6518D5E21D7B3A2800A12EF4 /* Condition.swift */,
 			);
 			name = Core;
 			sourceTree = "<group>";

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		65403AB81D7C453200D6036B /* ConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65403AB71D7C453200D6036B /* ConditionTests.swift */; };
 		65403ABA1D7C49C500D6036B /* XCTAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65403AB91D7C49C500D6036B /* XCTAsserts.swift */; };
 		65403ABC1D7C6CBC00D6036B /* TestCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65403ABB1D7C6CBC00D6036B /* TestCondition.swift */; };
+		65403ABE1D7C9E7600D6036B /* ResultInjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65403ABD1D7C9E7600D6036B /* ResultInjectionTests.swift */; };
 		655E86431D67B55B000FBA6C /* ProcedureQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655E86421D67B55B000FBA6C /* ProcedureQueue.swift */; };
 		655E86451D67B9F9000FBA6C /* ProcedureObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655E86441D67B9F9000FBA6C /* ProcedureObserver.swift */; };
 		655E86471D67BA9C000FBA6C /* Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655E86461D67BA9C000FBA6C /* Support.swift */; };
@@ -225,6 +226,7 @@
 		65403AB71D7C453200D6036B /* ConditionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ConditionTests.swift; path = Tests/ConditionTests.swift; sourceTree = "<group>"; };
 		65403AB91D7C49C500D6036B /* XCTAsserts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = XCTAsserts.swift; path = Sources/Testing/XCTAsserts.swift; sourceTree = "<group>"; };
 		65403ABB1D7C6CBC00D6036B /* TestCondition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestCondition.swift; path = Sources/Testing/TestCondition.swift; sourceTree = "<group>"; };
+		65403ABD1D7C9E7600D6036B /* ResultInjectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResultInjectionTests.swift; path = Tests/ResultInjectionTests.swift; sourceTree = "<group>"; };
 		655E86421D67B55B000FBA6C /* ProcedureQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProcedureQueue.swift; path = Sources/ProcedureQueue.swift; sourceTree = "<group>"; };
 		655E86441D67B9F9000FBA6C /* ProcedureObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProcedureObserver.swift; path = Sources/ProcedureObserver.swift; sourceTree = "<group>"; };
 		655E86461D67BA9C000FBA6C /* Support.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Support.swift; path = Sources/Support.swift; sourceTree = "<group>"; };
@@ -380,6 +382,7 @@
 				65245D241D724FC200340A2D /* LoggerTests.swift */,
 				653C9FE81D6099F10070B7A2 /* ProcedureKitTests.swift */,
 				65245D1C1D721A7100340A2D /* ProcedureTests.swift */,
+				65403ABD1D7C9E7600D6036B /* ResultInjectionTests.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -1141,6 +1144,7 @@
 			files = (
 				65245D251D724FC200340A2D /* LoggerTests.swift in Sources */,
 				6591B3001D74954E00C2B57F /* GroupTests.swift in Sources */,
+				65403ABE1D7C9E7600D6036B /* ResultInjectionTests.swift in Sources */,
 				65245D1F1D7231DC00340A2D /* CancellationTests.swift in Sources */,
 				65245D211D72345000340A2D /* FinishingTests.swift in Sources */,
 				65403AB81D7C453200D6036B /* ConditionTests.swift in Sources */,

--- a/Sources/Condition.swift
+++ b/Sources/Condition.swift
@@ -50,7 +50,7 @@ internal extension ConditionProtocol {
 
 // MARK: Condition Errors
 
-public extension Errors {
+public extension ProcedureKitError {
 
     public struct FalseCondition: Error {
         internal init() { }
@@ -81,7 +81,7 @@ open class Condition: Procedure, ConditionProtocol {
     }
 
     open func evaluate(procedure: Procedure, completion: (ConditionResult) -> Void) {
-        completion(.failed(Errors.ProgrammingError(reason: "Condition must be subclassed, and \(#function) overridden.")))
+        completion(.failed(ProcedureKitError.programmingError(reason: "Condition must be subclassed, and \(#function) overridden.")))
     }
 
     internal func finish(withConditionResult conditionResult: ConditionResult) {
@@ -112,7 +112,7 @@ public class FalseCondition: Condition {
     }
 
     public override func evaluate(procedure: Procedure, completion: (ConditionResult) -> Void) {
-        completion(.failed(Errors.FalseCondition()))
+        completion(.failed(ProcedureKitError.FalseCondition()))
     }
 }
 

--- a/Sources/Errors.swift
+++ b/Sources/Errors.swift
@@ -6,15 +6,32 @@
 
 import Foundation
 
-public struct Errors {
+public struct ProcedureKitError: Error {
 
-    public struct ProgrammingError: Error {
-        public let reason: String
+    public enum Context {
+        case unknown
+        case programmingError(String)
+        case dependencyFinishedWithErrors
+        case parentCancelledWithErrors
+        case requirementNotSatisfied
     }
 
-    public struct Cancelled: Error {
-        let errors: [Error]
+    public static func programmingError(reason: String) -> ProcedureKitError {
+        return ProcedureKitError(context: .programmingError(reason), errors: [])
     }
 
+    public static func dependency(finishedWithErrors errors: [Error]) -> ProcedureKitError {
+        return ProcedureKitError(context: .dependencyFinishedWithErrors, errors: errors)
+    }
 
+    public static func parent(cancelledWithErrors errors: [Error]) -> ProcedureKitError {
+        return ProcedureKitError(context: .parentCancelledWithErrors, errors: errors)
+    }
+
+    public static func requirementNotSatisfied() -> ProcedureKitError {
+        return ProcedureKitError(context: .requirementNotSatisfied, errors: [])
+    }
+
+    let context: Context
+    let errors: [Error]
 }

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -81,7 +81,7 @@ open class Group: Procedure, ProcedureQueueDelegate {
             else {
                 let (operations, procedures) = group.children.operationsAndProcedures
                 operations.forEach { $0.cancel() }
-                procedures.forEach { $0.cancel(withError: Errors.Cancelled(errors: errors)) }
+                procedures.forEach { $0.cancel(withError: ProcedureKitError.parent(cancelledWithErrors: errors)) }
             }
         }
     }

--- a/Sources/Testing/TestProcedure.swift
+++ b/Sources/Testing/TestProcedure.swift
@@ -7,7 +7,11 @@
 import Foundation
 import ProcedureKit
 
-public struct TestError: Error {
+public struct TestError: Error, Equatable {
+    public static func == (lhs: TestError, rhs: TestError) -> Bool {
+        return lhs.uuid == rhs.uuid
+    }
+    let uuid = UUID()
     public init() { }
 }
 
@@ -16,8 +20,8 @@ open class TestProcedure: Procedure {
     public let delay: TimeInterval
     public let error: Error?
     public let producedOperation: Operation?
+    public var result: String? = "Hello World"
     public private(set) var didExecute = false
-
     public private(set) var procedureWillFinishCalled = false
     public private(set) var procedureDidFinishCalled = false
     public private(set) var procedureWillCancelCalled = false

--- a/Tests/ConditionTests.swift
+++ b/Tests/ConditionTests.swift
@@ -27,12 +27,8 @@ class ConditionTests: ProcedureKitTestCase {
             guard case let .failed(error) = result else {
                 XCTFail("FalseCondition did not evaluate as failed."); return
             }
-            XCTAssertTrue(error is Errors.FalseCondition)
+            XCTAssertTrue(error is ProcedureKitError.FalseCondition)
         }
-    }
-
-    func test__ignored_condition_is_cancelled() {
-        // TODO: Need to add IgnoredCondition
     }
 
     func test__condition_which_is_executed_without_a_procedure() {

--- a/Tests/ResultInjectionTests.swift
+++ b/Tests/ResultInjectionTests.swift
@@ -1,0 +1,55 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+import TestingProcedureKit
+@testable import ProcedureKit
+
+class DataProcessing: Procedure {
+    var requirement: String? = nil
+
+    override func execute() {
+        guard let output = requirement else {
+            finish(withError: ProcedureKitError.requirementNotSatisfied())
+            return
+        }
+        log.info(message: output)
+        finish()
+    }
+}
+
+class ResultInjectionTestCase: ProcedureKitTestCase {
+    var processing: DataProcessing!
+
+    override func setUp() {
+        super.setUp()
+        processing = DataProcessing()
+    }
+}
+
+class ManualResultInjectionTests: ResultInjectionTestCase {
+
+    func test__block_is_executed() {
+        var injectionBlockDidExecute = false
+        let _ = processing.inject(dependency: procedure) { processing, dependency, errors in
+            injectionBlockDidExecute = true
+        }
+        wait(for: procedure, processing)
+        XCTAssertTrue(injectionBlockDidExecute)
+    }
+
+    func test__block_passes_through_errors() {
+        let error = TestError()
+        var receivedErrors: [Error] = []
+        procedure = TestProcedure(error: error)
+        let _ = processing.inject(dependency: procedure) { processing, dependency, errors in
+            receivedErrors = errors
+        }
+        wait(for: procedure, processing)
+        XCTAssertEqual(error, (receivedErrors.first as? TestError) ?? TestError())
+    }
+}
+


### PR DESCRIPTION
For _ProcedureKit_, I'd like to revise how  `GroupOperation` (in _Operations_) managed errors from children. Previously, in v3, the group collects all of the child errors, and adds them to its own `errors` array property. This means that if a group contains another group, then the other group contains all the errors of the inner group.

Instead, for `Group`, I'd like to change it so that errors from child operations get stored inside an error aggregator, which itself is added to group's `error` property. So, if a group has 5 children of which 3 error, `GroupOperation` would report 3 errors, whereas I intend `Group` to report 1 error which in turn has 3 child errors.

This means, that `Group` can easily have child `Group` instances and the `errors` property can be easily and correctly consumed.   
- [x] child error aggregation  

