### PR TITLE
FIX: CloudKitOperation EXC_BAD_ACCESS on iOS9 (Swift 2.3) (#461)

### DIFF
--- a/Sources/Extras/CloudKit/Shared/CloudKitInterface.swift
+++ b/Sources/Extras/CloudKit/Shared/CloudKitInterface.swift
@@ -528,28 +528,26 @@ extension CKOperation: CKOperationType {
     /// The QueryCursor is a CKQueryCursor
     public typealias QueryCursor = CKQueryCursor
 
+    /// The CKOperationLongLivedOperationWasPersistedBlock is () -> Void
+    public typealias CKOperationLongLivedOperationWasPersistedBlock = () -> Void
+}
+
+@available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
+extension CKOperation: CKOperation2Type {
     /// The UserIdentity is a CKUserIdentity
-    @available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
     public typealias UserIdentity = CKUserIdentity
 
     /// The UserIdentityLookupInfo is a CKUserIdentityLookupInfo
-    @available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
     public typealias UserIdentityLookupInfo = CKUserIdentityLookupInfo
 
     /// The Share is a CKShare
-    @available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
     public typealias Share = CKShare
 
     /// The ShareMetadata is a CKShareMetadata
-    @available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
     public typealias ShareMetadata = CKShareMetadata
 
     /// The ShareParticipant is a CKShareParticipant
-    @available(iOS 10.0, OSX 10.12, tvOS 10.0, watchOS 3.0, *)
     public typealias ShareParticipant = CKShareParticipant
-
-    /// The CKOperationLongLivedOperationWasPersistedBlock is () -> Void
-    public typealias CKOperationLongLivedOperationWasPersistedBlock = () -> Void
 }
 
 extension CKDatabaseOperation: CKDatabaseOperationType {

--- a/Sources/Extras/CloudKit/Shared/CloudKitInterface.swift
+++ b/Sources/Extras/CloudKit/Shared/CloudKitInterface.swift
@@ -56,21 +56,6 @@ public protocol CKOperationType: class {
     /// The type of the CloudKit RecordID
     associatedtype RecordID: Hashable
 
-    /// The type of the CloudKit UserIdentity
-    associatedtype UserIdentity
-
-    /// The type of the CloudKit UserIdentityLookupInfo
-    associatedtype UserIdentityLookupInfo
-
-    /// The type of the CloudKit Share
-    associatedtype Share
-
-    /// The type of the CloudKit ShareMetadata
-    associatedtype ShareMetadata
-
-    /// The type of the CloudKit ShareParticipant
-    associatedtype ShareParticipant
-
     /// - returns the CloudKit Container
     var container: Container? { get set }
 
@@ -107,6 +92,27 @@ public protocol CKOperationType: class {
     /// See NSURLSessionConfiguration.timeoutIntervalForResource
     @available(iOS 10.0, tvOS 10.0, OSX 10.12, watchOS 3.0, *)
     var timeoutIntervalForResource: NSTimeInterval { get set }
+}
+
+/**
+ A generic protocol which exposes the additional types used by
+ Apple's new CloudKit Operation types in iOS 10 / macOS 10.12.
+ */
+public protocol CKOperation2Type: CKOperationType {
+    /// The type of the CloudKit UserIdentity
+    associatedtype UserIdentity
+
+    /// The type of the CloudKit UserIdentityLookupInfo
+    associatedtype UserIdentityLookupInfo
+
+    /// The type of the CloudKit Share
+    associatedtype Share
+
+    /// The type of the CloudKit ShareMetadata
+    associatedtype ShareMetadata
+
+    /// The type of the CloudKit ShareParticipant
+    associatedtype ShareParticipant
 }
 
 /**
@@ -175,7 +181,7 @@ public protocol CKDiscoverAllContactsOperationType: CKOperationType {
 }
 
 /// A generic protocol which exposes the properties used by Apple's CKAcceptSharesOperation.
-public protocol CKAcceptSharesOperationType: CKOperationType {
+public protocol CKAcceptSharesOperationType: CKOperation2Type {
 
     /// - returns: the share metadatas
     var shareMetadatas: [ShareMetadata] { get set }
@@ -188,7 +194,7 @@ public protocol CKAcceptSharesOperationType: CKOperationType {
 }
 
 /// A generic protocol which exposes the properties used by Apple's CKDiscoverAllUserIdentitiesOperation.
-public protocol CKDiscoverAllUserIdentitiesOperationType: CKOperationType {
+public protocol CKDiscoverAllUserIdentitiesOperationType: CKOperation2Type {
 
     /// - returns: a block for when a user identity is discovered
     var userIdentityDiscoveredBlock: ((UserIdentity) -> Void)? { get set }
@@ -211,7 +217,7 @@ public protocol CKDiscoverUserInfosOperationType: CKOperationType {
 }
 
 /// A generic protocol which exposes the properties used by Apple's CKDiscoverUserIdentitiesOperation.
-public protocol CKDiscoverUserIdentitiesOperationType: CKOperationType {
+public protocol CKDiscoverUserIdentitiesOperationType: CKOperation2Type {
 
     /// - returns: the user identity lookup info used in discovery
     var userIdentityLookupInfos: [UserIdentityLookupInfo] { get set }
@@ -340,7 +346,7 @@ public protocol CKFetchRecordZoneChangesOperationType: CKDatabaseOperationType, 
 }
 
 /// A generic protocol which exposes the properties used by Apple's CKFetchShareMetadataOperation.
-public protocol CKFetchShareMetadataOperationType: CKOperationType {
+public protocol CKFetchShareMetadataOperationType: CKOperation2Type {
 
     /// - returns: the share URLs
     var shareURLs: [NSURL] { get set }
@@ -359,7 +365,7 @@ public protocol CKFetchShareMetadataOperationType: CKOperationType {
 }
 
 /// A generic protocol which exposes the properties used by Apple's CKFetchShareParticipantsOperation.
-public protocol CKFetchShareParticipantsOperationType: CKOperationType {
+public protocol CKFetchShareParticipantsOperationType: CKOperation2Type {
 
     /// - returns: the user identity lookup infos
     var userIdentityLookupInfos: [UserIdentityLookupInfo] { get set }


### PR DESCRIPTION
Attempting to construct a CloudKitOperation would fail on iOS9. (See issue #461)

Example:
```swift
let _ = CloudKitOperation { CKFetchRecordChangesOperation() }
```

Would crash with `EXC_BAD_ACCESS` with the following stack trace:

```
* thread #1: [...] libswiftCore.dylib`swift_getObjCClassMetadata + 24, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x20)
    frame #0: [...] libswiftCore.dylib`swift_getObjCClassMetadata + 24
    frame #1: [...] TestOperations`type metadata accessor for CKShareMetadata + 45 at AppDelegate.swift:0
    frame #2: [...] TestOperations`type metadata accessor for CloudKitOperation<CKFetchRecordChangesOperation> + 246 at AppDelegate.swift:0
```

This PR fixes the issue by restructuring the CKOperationType protocol into two protocols:
- CKOperationType (for all the associated types for the original CKOperations)
- CKOperation2Type (for the associated types for the *new* CKOperations in iOS 10 / macOS 10.12).

CKOperation then only conforms to CKOperation2Type within an availability marker (i.e. on iOS 10 / macOS 10.12).