### PR TITLE
Add support for mutual exclusive conditions

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		655E86451D67B9F9000FBA6C /* ProcedureObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655E86441D67B9F9000FBA6C /* ProcedureObserver.swift */; };
 		655E86471D67BA9C000FBA6C /* Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655E86461D67BA9C000FBA6C /* Support.swift */; };
 		6584AF451D74770C0030DBB3 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6584AF441D74770C0030DBB3 /* Errors.swift */; };
+		65881B791D880ACB00C212C8 /* MutualExclusivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65881B781D880ACB00C212C8 /* MutualExclusivityTests.swift */; };
 		658A7B4B1D74DCCD00F897C8 /* ProcedureStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658A7B4A1D74DCCD00F897C8 /* ProcedureStressTests.swift */; };
 		658A7B4F1D74E54800F897C8 /* GroupStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658A7B4E1D74E54800F897C8 /* GroupStressTests.swift */; };
 		6591B3001D74954E00C2B57F /* GroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B2FE1D74953A00C2B57F /* GroupTests.swift */; };
@@ -238,6 +239,7 @@
 		655E86441D67B9F9000FBA6C /* ProcedureObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProcedureObserver.swift; path = Sources/ProcedureObserver.swift; sourceTree = "<group>"; };
 		655E86461D67BA9C000FBA6C /* Support.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Support.swift; path = Sources/Support.swift; sourceTree = "<group>"; };
 		6584AF441D74770C0030DBB3 /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Errors.swift; sourceTree = "<group>"; };
+		65881B781D880ACB00C212C8 /* MutualExclusivityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MutualExclusivityTests.swift; path = Tests/MutualExclusivityTests.swift; sourceTree = "<group>"; };
 		658A7B4A1D74DCCD00F897C8 /* ProcedureStressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProcedureStressTests.swift; path = "Tests/Stress Tests/ProcedureStressTests.swift"; sourceTree = "<group>"; };
 		658A7B4E1D74E54800F897C8 /* GroupStressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupStressTests.swift; path = "Tests/Stress Tests/GroupStressTests.swift"; sourceTree = "<group>"; };
 		6591B2FE1D74953A00C2B57F /* GroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTests.swift; path = Tests/GroupTests.swift; sourceTree = "<group>"; };
@@ -391,6 +393,7 @@
 				65245D201D72345000340A2D /* FinishingTests.swift */,
 				6591B2FE1D74953A00C2B57F /* GroupTests.swift */,
 				65245D241D724FC200340A2D /* LoggerTests.swift */,
+				65881B781D880ACB00C212C8 /* MutualExclusivityTests.swift */,
 				653C9FE81D6099F10070B7A2 /* ProcedureKitTests.swift */,
 				65245D1C1D721A7100340A2D /* ProcedureTests.swift */,
 				65403ABD1D7C9E7600D6036B /* ResultInjectionTests.swift */,
@@ -1163,6 +1166,7 @@
 			files = (
 				65245D251D724FC200340A2D /* LoggerTests.swift in Sources */,
 				6591B3001D74954E00C2B57F /* GroupTests.swift in Sources */,
+				65881B791D880ACB00C212C8 /* MutualExclusivityTests.swift in Sources */,
 				65403ABE1D7C9E7600D6036B /* ResultInjectionTests.swift in Sources */,
 				65245D1F1D7231DC00340A2D /* CancellationTests.swift in Sources */,
 				65245D211D72345000340A2D /* FinishingTests.swift in Sources */,

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		65CFC61F1D60904700CAD875 /* TestingProcedureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 65CFC61E1D60904700CAD875 /* TestingProcedureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		65CFC6231D60911C00CAD875 /* TestingProcedureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65CFC6161D60900000CAD875 /* TestingProcedureKit.framework */; };
 		65CFC6261D60912900CAD875 /* ProcedureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */; };
+		65DA49311D8142BE00D4E1AA /* MutualExclusion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65DA49301D8142BE00D4E1AA /* MutualExclusion.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -261,6 +262,7 @@
 		65CFC6161D60900000CAD875 /* TestingProcedureKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TestingProcedureKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65CFC61E1D60904700CAD875 /* TestingProcedureKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestingProcedureKit.h; path = "Supporting Files/TestingProcedureKit.h"; sourceTree = "<group>"; };
 		65CFC6201D60905000CAD875 /* TestingProcedureKit.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = TestingProcedureKit.xcconfig; path = "Supporting Files/TestingProcedureKit.xcconfig"; sourceTree = "<group>"; };
+		65DA49301D8142BE00D4E1AA /* MutualExclusion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MutualExclusion.swift; path = Sources/MutualExclusion.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -500,6 +502,7 @@
 				654FAFFC1D7CD5EA002FA74D /* BlockProcedure.swift */,
 				6518D5E21D7B3A2800A12EF4 /* Condition.swift */,
 				65245D261D7258E400340A2D /* Group.swift */,
+				65DA49301D8142BE00D4E1AA /* MutualExclusion.swift */,
 				65B97DB41D65138F00AC3B5D /* Procedure.swift */,
 				655E86441D67B9F9000FBA6C /* ProcedureObserver.swift */,
 				65A2D8011D6A05D800FB067C /* ProcedureProcotol.swift */,
@@ -1136,6 +1139,7 @@
 			files = (
 				65A2D7FB1D6852A500FB067C /* BlockObservers.swift in Sources */,
 				65245D231D723A6B00340A2D /* Logging.swift in Sources */,
+				65DA49311D8142BE00D4E1AA /* MutualExclusion.swift in Sources */,
 				65A2D7FD1D69E52000FB067C /* DispatchQueue+ProcedureKit.swift in Sources */,
 				654FAFFD1D7CD5EA002FA74D /* BlockProcedure.swift in Sources */,
 				654FAFFB1D7CABA0002FA74D /* ResultInjection.swift in Sources */,

--- a/Sources/MutualExclusion.swift
+++ b/Sources/MutualExclusion.swift
@@ -1,0 +1,76 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import Foundation
+
+internal class ExclusivityManager {
+
+    static let sharedInstance = ExclusivityManager()
+
+    fileprivate let queue = DispatchQueue.initiated
+    fileprivate var procedures: [String: [Procedure]] = [:]
+
+    private init() {
+        // A private initalizer prevents any other part of the app
+        // from creating an instance.
+    }
+
+    func add(procedure: Procedure, category: String) -> Operation? {
+        return queue.sync { self._add(procedure: procedure, category: category) }
+    }
+
+    func remove(procedure: Procedure, category: String) {
+        queue.async { self._remove(procedure: procedure, category: category) }
+    }
+
+    fileprivate func _add(procedure: Procedure, category: String) -> Operation? {
+        procedure.log.verbose(message: ">>> \(category)")
+
+        procedure.addDidFinishBlockObserver { [unowned self] (procedure, errors) in
+            self.remove(procedure: procedure, category: category)
+        }
+
+        var proceduresWithThisCategory = procedures[category] ?? []
+
+        let previous = proceduresWithThisCategory.last
+
+        if let previous = previous {
+            procedure.add(dependencyOnPreviousMutuallyExclusiveProcedure: previous)
+        }
+
+        proceduresWithThisCategory.append(procedure)
+
+        procedures[category] = proceduresWithThisCategory
+
+        return previous
+    }
+
+    fileprivate func _remove(procedure: Procedure, category: String) {
+        procedure.log.verbose(message: "<<< \(category)")
+
+        if let proceduresWithThisCategory = procedures[category], let index = proceduresWithThisCategory.index(of: procedure) {
+            var mutableProceduresWithThisCategory = proceduresWithThisCategory
+            mutableProceduresWithThisCategory.remove(at: index)
+            procedures[category] = mutableProceduresWithThisCategory
+        }
+    }
+}
+
+internal extension ExclusivityManager {
+
+    /// This should only be used as part of the unit testing
+    /// and in v2+ will not be publically accessible
+    func __tearDownForUnitTesting() {
+        queue.sync {
+            for (category, procedures) in self.procedures {
+                for procedure in procedures {
+                    procedure.cancel()
+                    self._remove(procedure: procedure, category: category)
+                }
+            }
+        }
+    }
+}

--- a/Sources/MutualExclusion.swift
+++ b/Sources/MutualExclusion.swift
@@ -6,6 +6,25 @@
 
 import Foundation
 
+/**
+ A generic condition for describing operations that
+ cannot be allowed to execute concurrently.
+ */
+public final class MutuallyExclusive<T>: Condition {
+
+    /// Public constructor
+    public override init() {
+        super.init()
+        name = "MutuallyExclusive<\(T.self)>"
+        mutuallyExclusive = true
+    }
+
+    /// Required public override, but there is no evaluation, so it just completes with `.Satisfied`.
+    public override func evaluate(procedure: Procedure, completion: (ConditionResult) -> Void) {
+        completion(.satisfied)
+    }
+}
+
 internal class ExclusivityManager {
 
     static let sharedInstance = ExclusivityManager()

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -666,9 +666,9 @@ public extension Procedure {
         return evaluator
     }
 
-    internal func add(dependencyOnPreviousMutuallyExclusiveOperation operation: Procedure) {
+    internal func add(dependencyOnPreviousMutuallyExclusiveProcedure procedure: Procedure) {
         precondition(state <= .executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
-        super.addDependency(operation)
+        super.addDependency(procedure)
     }
 
     internal func add(directDependency: Operation) {

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -721,7 +721,7 @@ public extension Procedure {
 
      - parameter condition: a `Condition` which must be satisfied for the procedure to be executed.
      */
-    func add(condition: Condition) {
+    func attach(condition: Condition) {
         assert(state < .executing, "Cannot modify conditions after operation has begun executing, current state: \(state).")
         conditions.insert(condition)
     }

--- a/Sources/ProcedureQueue.swift
+++ b/Sources/ProcedureQueue.swift
@@ -167,20 +167,19 @@ open class ProcedureQueue: OperationQueue {
         /// Process any conditions
         if procedure.conditions.count > 0 {
 
-/* TODO: Mutual Exclusivity
             /// Check for mutual exclusion conditions
             let manager = ExclusivityManager.sharedInstance
-*/
+
             let mutuallyExclusiveConditions = procedure.conditions.filter { $0.mutuallyExclusive }
             var previousMutuallyExclusiveOperations = Set<Operation>()
-/*
+
             for condition in mutuallyExclusiveConditions {
                 let category = "\(condition.category)"
-                if let previous = manager.addOperation(operation, category: category) {
+                if let previous = manager.add(procedure: procedure, category: category) {
                     previousMutuallyExclusiveOperations.insert(previous)
                 }
             }
-*/
+
             // Create the condition evaluator
             let evaluator = procedure.evaluateConditions()
 

--- a/Sources/ProcedureQueue.swift
+++ b/Sources/ProcedureQueue.swift
@@ -163,7 +163,6 @@ open class ProcedureQueue: OperationQueue {
             }
         }
 
-
         /// Process any conditions
         if procedure.conditions.count > 0 {
 
@@ -219,7 +218,6 @@ open class ProcedureQueue: OperationQueue {
             // Add the evaluator
             addOperation(evaluator)
         }
-
 
         // Indicate to the operation that it is to be enqueued
         procedure.willEnqueue()

--- a/Sources/Testing/ProcedureKitTestCase.swift
+++ b/Sources/Testing/ProcedureKitTestCase.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 import XCTest
-import ProcedureKit
+@testable import ProcedureKit
 
 open class ProcedureKitTestCase: XCTestCase {
 
@@ -28,6 +28,7 @@ open class ProcedureKitTestCase: XCTestCase {
         delegate = nil
         queue = nil
         procedure = nil
+        ExclusivityManager.sharedInstance.__tearDownForUnitTesting()
         super.tearDown()
     }
 

--- a/Tests/ConditionTests.swift
+++ b/Tests/ConditionTests.swift
@@ -40,13 +40,13 @@ class ConditionTests: ProcedureKitTestCase {
     // MARK: - Single Attachment
 
     func test__single_condition_which_is_satisfied() {
-        procedure.add(condition: TrueCondition())
+        procedure.attach(condition: TrueCondition())
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors()
     }
 
     func test__single_condition_which_is_failed() {
-        procedure.add(condition: FalseCondition())
+        procedure.attach(condition: FalseCondition())
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors()
     }
@@ -54,33 +54,33 @@ class ConditionTests: ProcedureKitTestCase {
     // MARK: - Multiple Attachment
 
     func test__multiple_conditions_where_all_are_satisfied() {
-        procedure.add(condition: TrueCondition())
-        procedure.add(condition: TrueCondition())
-        procedure.add(condition: TrueCondition())
+        procedure.attach(condition: TrueCondition())
+        procedure.attach(condition: TrueCondition())
+        procedure.attach(condition: TrueCondition())
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors()
     }
 
     func test__multiple_conditions_where_all_fail() {
-        procedure.add(condition: FalseCondition())
-        procedure.add(condition: FalseCondition())
-        procedure.add(condition: FalseCondition())
+        procedure.attach(condition: FalseCondition())
+        procedure.attach(condition: FalseCondition())
+        procedure.attach(condition: FalseCondition())
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors(count: 3)
     }
 
     func test__multiple_conditions_where_one_succeeds() {
-        procedure.add(condition: TrueCondition())
-        procedure.add(condition: FalseCondition())
-        procedure.add(condition: FalseCondition())
+        procedure.attach(condition: TrueCondition())
+        procedure.attach(condition: FalseCondition())
+        procedure.attach(condition: FalseCondition())
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors(count: 2)
     }
 
     func test__multiple_conditions_where_one_fails() {
-        procedure.add(condition: TrueCondition())
-        procedure.add(condition: TrueCondition())
-        procedure.add(condition: FalseCondition())
+        procedure.attach(condition: TrueCondition())
+        procedure.attach(condition: TrueCondition())
+        procedure.attach(condition: FalseCondition())
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }
@@ -89,16 +89,16 @@ class ConditionTests: ProcedureKitTestCase {
 
     func test__single_condition_with_single_condition_which_both_succeed__executes() {
         let condition = TrueCondition()
-        condition.add(condition: TrueCondition())
-        procedure.add(condition: condition)
+        condition.attach(condition: TrueCondition())
+        procedure.attach(condition: condition)
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors()
     }
 
     func test__single_condition_which_succeeds_with_single_condition_which_fails__cancelled() {
         let condition = TrueCondition(name: "Condition 1")
-        condition.add(condition: FalseCondition(name: "Nested Condition 1"))
-        procedure.add(condition: condition)
+        condition.attach(condition: FalseCondition(name: "Nested Condition 1"))
+        procedure.attach(condition: condition)
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors(count: 2)
     }
@@ -130,8 +130,8 @@ class ConditionTests: ProcedureKitTestCase {
         let condition2 = TrueCondition(name: "Condition 2")
         condition2.add(dependency: conditionDependency2)
 
-        procedure.add(condition: condition1)
-        procedure.add(condition: condition2)
+        procedure.attach(condition: condition1)
+        procedure.attach(condition: condition2)
 
         run(operations: dependency1, dependency2)
         wait(for: procedure)
@@ -152,8 +152,8 @@ class ConditionTests: ProcedureKitTestCase {
 
         procedure.add(dependency: dependency1)
         procedure.add(dependency: dependency2)
-        procedure.add(condition: condition1)
-        procedure.add(condition: condition2)
+        procedure.attach(condition: condition1)
+        procedure.attach(condition: condition2)
 
         run(operations: dependency1, dependency2)
         wait(for: procedure)
@@ -166,7 +166,7 @@ class ConditionTests: ProcedureKitTestCase {
         let condition = TrueCondition(name: "Condition")
         condition.add(dependency: dependency)
 
-        procedure.add(condition: condition)
+        procedure.attach(condition: condition)
         procedure.add(dependency: dependency)
 
         wait(for: dependency, procedure)
@@ -183,14 +183,14 @@ class ConditionTests: ProcedureKitTestCase {
         condition1.add(dependency: dependency)
 
         let procedure1 = TestProcedure(name: "Procedure 1")
-        procedure1.add(condition: condition1)
+        procedure1.attach(condition: condition1)
         procedure1.add(dependency: dependency)
 
         let condition2 = TrueCondition(name: "Condition 2")
         condition2.add(dependency: dependency)
 
         let procedure2 = TestProcedure(name: "Procedure 2")
-        procedure2.add(condition: condition2)
+        procedure2.attach(condition: condition2)
         procedure2.add(dependency: procedure1)
 
         wait(for: procedure1, dependency, procedure2)
@@ -204,10 +204,10 @@ class ConditionTests: ProcedureKitTestCase {
 
     func test__ignored_failing_condition_does_not_result_in_failure() {
         let procedure1 = TestProcedure(name: "Procedure 1")
-        procedure1.add(condition: IgnoredCondition(FalseCondition()))
+        procedure1.attach(condition: IgnoredCondition(FalseCondition()))
 
         let procedure2 = TestProcedure(name: "Procedure 2")
-        procedure2.add(condition: FalseCondition())
+        procedure2.attach(condition: FalseCondition())
 
         wait(for: procedure1, procedure2)
 
@@ -217,10 +217,10 @@ class ConditionTests: ProcedureKitTestCase {
 
     func test__ignored_satisfied_condition_does_not_result_in_failure() {
         let procedure1 = TestProcedure(name: "Procedure 1")
-        procedure1.add(condition: IgnoredCondition(TrueCondition()))
+        procedure1.attach(condition: IgnoredCondition(TrueCondition()))
 
         let procedure2 = TestProcedure(name: "Procedure 2")
-        procedure2.add(condition: TrueCondition())
+        procedure2.attach(condition: TrueCondition())
 
         wait(for: procedure1, procedure2)
 
@@ -230,7 +230,7 @@ class ConditionTests: ProcedureKitTestCase {
     }
 
     func test__ignored_ignored_condition_does_not_result_in_failure() {
-        procedure.add(condition: IgnoredCondition(IgnoredCondition(FalseCondition())))
+        procedure.attach(condition: IgnoredCondition(IgnoredCondition(FalseCondition())))
         wait(for: procedure)
         XCTAssertProcedureCancelledWithoutErrors()
     }

--- a/Tests/MutualExclusivityTests.swift
+++ b/Tests/MutualExclusivityTests.swift
@@ -1,0 +1,129 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+import TestingProcedureKit
+@testable import ProcedureKit
+
+class MutualExclusiveTests: ProcedureKitTestCase {
+
+    func test__mutual_eclusive_name() {
+        let condition = MutuallyExclusive<Procedure>()
+        XCTAssertEqual(condition.name, "MutuallyExclusive<Procedure>")
+    }
+
+    func test__alert_presentation_is_mutually_exclusive() {
+        let condition = MutuallyExclusive<Procedure>()
+        XCTAssertTrue(condition.mutuallyExclusive)
+    }
+
+    func test__alert_presentation_evaluation_satisfied() {
+        let condition = MutuallyExclusive<Procedure>()
+        condition.evaluate(procedure: TestProcedure()) { result in
+            switch result {
+            case .satisfied:
+                return XCTAssertTrue(true)
+            default:
+                return XCTFail("Condition should evaluate true.")
+            }
+        }
+    }
+
+/*
+    func test__mutually_exclusive_operation_are_run_exclusively() {
+        var text = "Star Wars"
+
+        let operation1 = BlockOperation {
+            XCTAssertEqual(text, "Star Wars")
+            text = "\(text)\nA long time ago"
+        }
+        operation1.name = "Operation 1"
+        let condition1A = MutuallyExclusive<BlockOperation>()
+        let condition1B = MutuallyExclusive<TestOperation>()
+        operation1.addCondition(condition1A)
+        operation1.addCondition(condition1B)
+
+        let operation2 = BlockOperation {
+            XCTAssertEqual(text, "Star Wars\nA long time ago")
+            text = "\(text), in a galaxy far, far away."
+        }
+        operation2.name = "Operation 2"
+        let condition2A = MutuallyExclusive<BlockOperation>()
+        let condition2B = MutuallyExclusive<TestOperation>()
+        operation2.addCondition(condition2A)
+        operation2.addCondition(condition2B)
+
+        addCompletionBlockToTestOperation(operation1)
+        addCompletionBlockToTestOperation(operation2)
+        runOperations(operation1, operation2)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertEqual(text, "Star Wars\nA long time ago, in a galaxy far, far away.")
+    }
+
+    func test__condition_has_dependency_executed_first() {
+        var text = "Star Wars"
+
+        let conditionDependency1 = BlockOperation {
+            XCTAssertEqual(text, "Star Wars")
+            text = "\(text)\nA long time ago"
+        }
+        conditionDependency1.name = "Condition 1 Dependency"
+
+        let condition1 = TrueCondition(name: "Condition 1", mutuallyExclusive: true)
+        condition1.addDependency(conditionDependency1)
+
+        let operation1 = TestOperation()
+        operation1.name = "Operation 1"
+        operation1.addCondition(condition1)
+
+        let operation1Dependency = TestOperation()
+        operation1Dependency.name = "Dependency 1"
+        operation1.addDependency(operation1Dependency)
+
+        let conditionDependency2 = BlockOperation {
+            XCTAssertEqual(text, "Star Wars\nA long time ago")
+            text = "\(text), in a galaxy far, far away."
+        }
+        conditionDependency2.name = "Condition 2 Dependency"
+
+        let condition2 = TrueCondition(name: "Condition 2", mutuallyExclusive: true)
+        condition2.addDependency(conditionDependency2)
+
+        let operation2 = TestOperation()
+        operation2.addCondition(condition2)
+
+        let operation2Dependency = TestOperation()
+        operation2Dependency.name = "Dependency 2"
+        operation2.addDependency(operation2Dependency)
+
+        addCompletionBlockToTestOperation(operation1)
+        addCompletionBlockToTestOperation(operation2)
+        addCompletionBlockToTestOperation(operation1Dependency)
+        addCompletionBlockToTestOperation(operation2Dependency)
+        runOperations(operation1, operation2Dependency, operation2, operation1Dependency)
+        waitForExpectationsWithTimeout(3, handler: nil)
+
+        XCTAssertEqual(text, "Star Wars\nA long time ago, in a galaxy far, far away.")
+    }
+*/
+
+    func test__mutually_exclusive_operations_can_be_executed() {
+        let procedure1 = TestProcedure()
+        procedure1.name = "Procedure 1"
+        procedure1.add(condition: MutuallyExclusive<TestProcedure>())
+
+        let procedure2 = TestProcedure()
+        procedure2.name = "Procedure 2"
+        procedure2.add(condition: MutuallyExclusive<TestProcedure>())
+
+        wait(for: procedure1, procedure2)
+    }
+}
+
+
+
+

--- a/Tests/MutualExclusivityTests.swift
+++ b/Tests/MutualExclusivityTests.swift
@@ -32,34 +32,30 @@ class MutualExclusiveTests: ProcedureKitTestCase {
         }
     }
 
-/*
     func test__mutually_exclusive_operation_are_run_exclusively() {
         var text = "Star Wars"
 
-        let operation1 = BlockOperation {
+        let procedure1 = BlockProcedure {
             XCTAssertEqual(text, "Star Wars")
             text = "\(text)\nA long time ago"
         }
-        operation1.name = "Operation 1"
-        let condition1A = MutuallyExclusive<BlockOperation>()
-        let condition1B = MutuallyExclusive<TestOperation>()
-        operation1.addCondition(condition1A)
-        operation1.addCondition(condition1B)
+        procedure1.name = "Procedure 1"
+        let condition1A = MutuallyExclusive<BlockProcedure>()
+        let condition1B = MutuallyExclusive<TestProcedure>()
+        procedure1.add(condition: condition1A)
+        procedure1.add(condition: condition1B)
 
-        let operation2 = BlockOperation {
+        let procedure2 = BlockProcedure {
             XCTAssertEqual(text, "Star Wars\nA long time ago")
             text = "\(text), in a galaxy far, far away."
         }
-        operation2.name = "Operation 2"
-        let condition2A = MutuallyExclusive<BlockOperation>()
-        let condition2B = MutuallyExclusive<TestOperation>()
-        operation2.addCondition(condition2A)
-        operation2.addCondition(condition2B)
+        procedure2.name = "Procedure 2"
+        let condition2A = MutuallyExclusive<BlockProcedure>()
+        let condition2B = MutuallyExclusive<TestProcedure>()
+        procedure2.add(condition: condition2A)
+        procedure2.add(condition: condition2B)
 
-        addCompletionBlockToTestOperation(operation1)
-        addCompletionBlockToTestOperation(operation2)
-        runOperations(operation1, operation2)
-        waitForExpectationsWithTimeout(3, handler: nil)
+        wait(for: procedure1, procedure2)
 
         XCTAssertEqual(text, "Star Wars\nA long time ago, in a galaxy far, far away.")
     }
@@ -67,49 +63,40 @@ class MutualExclusiveTests: ProcedureKitTestCase {
     func test__condition_has_dependency_executed_first() {
         var text = "Star Wars"
 
-        let conditionDependency1 = BlockOperation {
+        let conditionDependency1 = BlockProcedure {
             XCTAssertEqual(text, "Star Wars")
             text = "\(text)\nA long time ago"
         }
         conditionDependency1.name = "Condition 1 Dependency"
 
         let condition1 = TrueCondition(name: "Condition 1", mutuallyExclusive: true)
-        condition1.addDependency(conditionDependency1)
+        condition1.add(dependency: conditionDependency1)
 
-        let operation1 = TestOperation()
-        operation1.name = "Operation 1"
-        operation1.addCondition(condition1)
+        let procedure1 = TestProcedure(name: "Procedure 1")
+        procedure1.add(condition: condition1)
 
-        let operation1Dependency = TestOperation()
-        operation1Dependency.name = "Dependency 1"
-        operation1.addDependency(operation1Dependency)
+        let procedure1Dependency = TestProcedure(name: "Dependency 1")
+        procedure1.add(dependency: procedure1Dependency)
 
-        let conditionDependency2 = BlockOperation {
+        let conditionDependency2 = BlockProcedure {
             XCTAssertEqual(text, "Star Wars\nA long time ago")
             text = "\(text), in a galaxy far, far away."
         }
         conditionDependency2.name = "Condition 2 Dependency"
 
         let condition2 = TrueCondition(name: "Condition 2", mutuallyExclusive: true)
-        condition2.addDependency(conditionDependency2)
+        condition2.add(dependency: conditionDependency2)
 
-        let operation2 = TestOperation()
-        operation2.addCondition(condition2)
+        let procedure2 = TestProcedure()
+        procedure2.add(condition: condition2)
 
-        let operation2Dependency = TestOperation()
-        operation2Dependency.name = "Dependency 2"
-        operation2.addDependency(operation2Dependency)
+        let procedure2Dependency = TestProcedure(name: "Dependency 2")
+        procedure2.add(dependency: procedure2Dependency)
 
-        addCompletionBlockToTestOperation(operation1)
-        addCompletionBlockToTestOperation(operation2)
-        addCompletionBlockToTestOperation(operation1Dependency)
-        addCompletionBlockToTestOperation(operation2Dependency)
-        runOperations(operation1, operation2Dependency, operation2, operation1Dependency)
-        waitForExpectationsWithTimeout(3, handler: nil)
+        wait(for: procedure1, procedure2, procedure1Dependency, procedure2Dependency)
 
         XCTAssertEqual(text, "Star Wars\nA long time ago, in a galaxy far, far away.")
     }
-*/
 
     func test__mutually_exclusive_operations_can_be_executed() {
         let procedure1 = TestProcedure()

--- a/Tests/MutualExclusivityTests.swift
+++ b/Tests/MutualExclusivityTests.swift
@@ -42,8 +42,8 @@ class MutualExclusiveTests: ProcedureKitTestCase {
         procedure1.name = "Procedure 1"
         let condition1A = MutuallyExclusive<BlockProcedure>()
         let condition1B = MutuallyExclusive<TestProcedure>()
-        procedure1.add(condition: condition1A)
-        procedure1.add(condition: condition1B)
+        procedure1.attach(condition: condition1A)
+        procedure1.attach(condition: condition1B)
 
         let procedure2 = BlockProcedure {
             XCTAssertEqual(text, "Star Wars\nA long time ago")
@@ -52,8 +52,8 @@ class MutualExclusiveTests: ProcedureKitTestCase {
         procedure2.name = "Procedure 2"
         let condition2A = MutuallyExclusive<BlockProcedure>()
         let condition2B = MutuallyExclusive<TestProcedure>()
-        procedure2.add(condition: condition2A)
-        procedure2.add(condition: condition2B)
+        procedure2.attach(condition: condition2A)
+        procedure2.attach(condition: condition2B)
 
         wait(for: procedure1, procedure2)
 
@@ -73,7 +73,7 @@ class MutualExclusiveTests: ProcedureKitTestCase {
         condition1.add(dependency: conditionDependency1)
 
         let procedure1 = TestProcedure(name: "Procedure 1")
-        procedure1.add(condition: condition1)
+        procedure1.attach(condition: condition1)
 
         let procedure1Dependency = TestProcedure(name: "Dependency 1")
         procedure1.add(dependency: procedure1Dependency)
@@ -88,7 +88,7 @@ class MutualExclusiveTests: ProcedureKitTestCase {
         condition2.add(dependency: conditionDependency2)
 
         let procedure2 = TestProcedure()
-        procedure2.add(condition: condition2)
+        procedure2.attach(condition: condition2)
 
         let procedure2Dependency = TestProcedure(name: "Dependency 2")
         procedure2.add(dependency: procedure2Dependency)
@@ -101,11 +101,11 @@ class MutualExclusiveTests: ProcedureKitTestCase {
     func test__mutually_exclusive_operations_can_be_executed() {
         let procedure1 = TestProcedure()
         procedure1.name = "Procedure 1"
-        procedure1.add(condition: MutuallyExclusive<TestProcedure>())
+        procedure1.attach(condition: MutuallyExclusive<TestProcedure>())
 
         let procedure2 = TestProcedure()
         procedure2.name = "Procedure 2"
-        procedure2.add(condition: MutuallyExclusive<TestProcedure>())
+        procedure2.attach(condition: MutuallyExclusive<TestProcedure>())
 
         wait(for: procedure1, procedure2)
     }

--- a/Tests/Stress Tests/ProcedureStressTests.swift
+++ b/Tests/Stress Tests/ProcedureStressTests.swift
@@ -42,7 +42,7 @@ class ProcedureConditionStressTest: StressTestCase {
     func test__adding_many_conditions() {
 
         StressLevel.custom(1, 10_000).forEach { _, _ in
-            procedure.add(condition: TrueCondition())
+            procedure.attach(condition: TrueCondition())
         }
         wait(for: procedure, withTimeout: 10)
         XCTAssertProcedureFinishedWithoutErrors()
@@ -51,7 +51,7 @@ class ProcedureConditionStressTest: StressTestCase {
     func test__adding_many_conditions_each_with_single_dependency() {
 
         StressLevel.custom(1, 10_000).forEach { _, _ in
-            procedure.add(condition: TestCondition(dependencies: [TestProcedure()]) { .satisfied })
+            procedure.attach(condition: TestCondition(dependencies: [TestProcedure()]) { .satisfied })
         }
         wait(for: procedure, withTimeout: 10)
         XCTAssertProcedureFinishedWithoutErrors()
@@ -87,7 +87,7 @@ class ProcedureConditionsWillFinishObserverCancelThreadSafety: StressTestCase {
         stress { batch, iteration in
             batch.dispatchGroup.enter()
             let procedure = TestProcedure()
-            procedure.add(condition: FalseCondition())
+            procedure.attach(condition: FalseCondition())
             procedure.addDidFinishBlockObserver { _, _ in
                 batch.dispatchGroup.leave()
             }


### PR DESCRIPTION
In addition to `MutuallyExclusive<T>` this ticket also refines the condition API to use

```swift
procedure.attach(condition: condition)
```