### PR TITLE
Fix compilation with swift legacy version.

### DIFF
--- a/Operations.xcodeproj/project.pbxproj
+++ b/Operations.xcodeproj/project.pbxproj
@@ -1769,6 +1769,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1816,6 +1817,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1868,6 +1870,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -1908,6 +1911,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.danthorpe.iOS-OperationsTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 2.3;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1960,6 +1964,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -2007,6 +2012,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 4;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2062,6 +2068,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2108,6 +2115,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -2159,6 +2167,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
@@ -2198,6 +2207,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.danthorpe.tvOS-OperationsTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 2.3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -2254,6 +2264,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2302,6 +2313,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2353,6 +2365,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -2394,6 +2407,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.danthorpe.OS-X-OperationsTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -2442,6 +2456,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -2484,6 +2499,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.danthorpe.Stress-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/Sources/Core/Shared/ExclusivityManager.swift
+++ b/Sources/Core/Shared/ExclusivityManager.swift
@@ -21,7 +21,7 @@ internal class ExclusivityManager {
     }
 
     func addOperation(operation: Operation, category: String) -> NSOperation? {
-        return dispatch_sync(queue) { self._addOperation(operation, category: category) }
+        return ThreadSafety.dispatch_sync(queue) { self._addOperation(operation, category: category) }
     }
 
     func removeOperation(operation: Operation, category: String) {
@@ -68,7 +68,7 @@ extension ExclusivityManager {
     /// This should only be used as part of the unit testing
     /// and in v2+ will not be publically accessible
     internal func __tearDownForUnitTesting() {
-        dispatch_sync(queue) {
+        ThreadSafety.dispatch_sync(queue) {
             for (category, operations) in self.operations {
                 for operation in operations {
                     operation.cancel()

--- a/Sources/Core/Shared/Operation.swift
+++ b/Sources/Core/Shared/Operation.swift
@@ -98,8 +98,7 @@ public class Operation: NSOperation {
     internal var indirectDependencies: Set<NSOperation> {
         return Set(conditions
             .flatMap { $0.directDependencies }
-            .filter { !directDependencies.contains($0) }
-        )
+            .filter { !directDependencies.contains($0) })
     }
 
     // Internal operation properties which are used to manage the scheduling of dependencies

--- a/Sources/Core/Shared/Profiler.swift
+++ b/Sources/Core/Shared/Profiler.swift
@@ -169,7 +169,7 @@ public final class OperationProfiler: Identifiable, Equatable {
     }
 
     func addMetricNow(now: NSTimeInterval = CFAbsoluteTimeGetCurrent() as NSTimeInterval, forEvent event: OperationEvent) {
-        dispatch_sync(queue) { [unowned self] in
+        ThreadSafety.dispatch_sync(queue) { [unowned self] in
             switch event {
             case .Attached:
                 self.result = self.result.attach(now)
@@ -192,7 +192,7 @@ public final class OperationProfiler: Identifiable, Equatable {
         if let operation = operation as? Operation {
             let profiler = OperationProfiler(parent: self)
             operation.addObserver(profiler)
-            dispatch_sync(queue) { [unowned self] in
+            ThreadSafety.dispatch_sync(queue) { [unowned self] in
                 self.children.append(operation.identity)
             }
         }
@@ -219,7 +219,7 @@ extension OperationProfiler.Reporter: OperationProfilerReporter {
 extension OperationProfiler: OperationProfilerReporter {
 
     public func finishedProfilingWithResult(result: ProfileResult) {
-        dispatch_sync(queue) { [unowned self] in
+        ThreadSafety.dispatch_sync(queue) { [unowned self] in
             if let index = self.children.indexOf(result.identity) {
                 self.result = self.result.addChild(result)
                 self.children.removeAtIndex(index)
@@ -232,7 +232,7 @@ extension OperationProfiler: OperationProfilerReporter {
 extension OperationProfiler: OperationObserverType {
 
     public func didAttachToOperation(operation: Operation) {
-        dispatch_sync(queue) { [unowned self] in
+        ThreadSafety.dispatch_sync(queue) { [unowned self] in
             self.result = self.result.setIdentity(operation.identity)
         }
         addMetricNow(forEvent: .Attached)

--- a/Sources/Extras/CloudKit/Shared/CloudKitInterface.swift
+++ b/Sources/Extras/CloudKit/Shared/CloudKitInterface.swift
@@ -244,7 +244,7 @@ public protocol CKModifyRecordsOperationType: CKDatabaseOperationType {
     var clientChangeTokenData: NSData? { get set }
 
     /// - returns: a flag for atomic changes
-    var atomic: Bool { get set }
+    var atomicRecord: Bool { get set }
 
     /// - returns: a per record progress block
     var perRecordProgressBlock: ((Record, Double) -> Void)? { get set }
@@ -446,6 +446,12 @@ extension CKModifyRecordsOperation: CKModifyRecordsOperationType, AssociatedErro
         get { return recordIDsToDelete }
         set { recordIDsToDelete = newValue }
     }
+
+    public var atomicRecord: Bool {
+        get { return self.isAtomic }
+        set { self.isAtomic = newValue }
+    }
+
 }
 
 extension CKModifySubscriptionsOperation: CKModifySubscriptionsOperationType, AssociatedErrorType, BatchModifyOperationType {

--- a/Sources/Extras/CloudKit/Shared/CloudKitOperationExtensions.swift
+++ b/Sources/Extras/CloudKit/Shared/CloudKitOperationExtensions.swift
@@ -1012,8 +1012,8 @@ extension OPRCKOperation where T: CKModifyRecordsOperationType, T: AssociatedErr
     }
 
     public var atomic: Bool {
-        get { return operation.atomic }
-        set { operation.atomic = newValue }
+        get { return operation.atomicRecord }
+        set { operation.atomicRecord = newValue }
     }
 
     public var perRecordProgressBlock: CloudKitOperation<T>.ModifyRecordsPerRecordProgressBlock? {
@@ -1087,9 +1087,9 @@ extension CloudKitOperation where T: CKModifyRecordsOperationType {
 
     /// - returns: a flag to indicate atomicity
     public var atomic: Bool {
-        get { return operation.atomic }
+        get { return operation.atomicRecord }
         set {
-            operation.atomic = newValue
+            operation.atomicRecord = newValue
             addConfigureBlock { $0.atomic = newValue }
         }
     }

--- a/Tests/Features/CloudKitOperationTests.swift
+++ b/Tests/Features/CloudKitOperationTests.swift
@@ -266,7 +266,7 @@ class TestModifyRecordsOperation: TestDatabaseOperation, CKModifyRecordsOperatio
     var recordIDsToDelete: [RecordID]?
     var savePolicy: RecordSavePolicy = 0
     var clientChangeTokenData: NSData?
-    var atomic: Bool = true
+    var atomicRecord: Bool = true
 
     var perRecordProgressBlock: ((Record, Double) -> Void)?
     var perRecordCompletionBlock: ((Record?, NSError?) -> Void)?
@@ -1076,13 +1076,13 @@ class OPRCKModifyRecordsOperationTests: CKTests {
     }
 
     func test__get_atomic() {
-        target.atomic = true
+        target.atomicRecord = true
         XCTAssertTrue(operation.atomic)
     }
 
     func test__set_atomic() {
         operation.atomic = true
-        XCTAssertTrue(target.atomic)
+        XCTAssertTrue(target.atomicRecord)
     }
 
     func test__get_per_record_progress_block() {


### PR DESCRIPTION
It was impossible to compile the project after settings the build
settings `SWIFT_VERSION=2.3`.

There was one ambiguity on the `dispatch_sync` function calls. I simply
added an intermediate struct to be able to call it explicitely.

There was one conflict with the Objective-C selector `atomic` when we
wanted to make `CKModifyRecordsOperation` adopting the
`CKModifyRecordsOperationType` protocol.
I renamed it as `atomicRecord`.