### PR TITLE
Procedure finishing fixes

### DIFF
--- a/Sources/Testing/ProcedureKitTestCase.swift
+++ b/Sources/Testing/ProcedureKitTestCase.swift
@@ -72,7 +72,7 @@ open class ProcedureKitTestCase: XCTestCase {
     public func add(expectation: XCTestExpectation, to procedure: Procedure) {
         weak var weakExpectation = expectation
         procedure.addDidFinishBlockObserver { _, _ in
-            DispatchQueue.default.async {
+            DispatchQueue.main.async {
                 weakExpectation?.fulfill()
             }
         }


### PR DESCRIPTION
Fixes: Procedure would not finish if `_finish()` was called from `main()`. (ex. If cancelled before executing.)

Also adds a StressTest to cover concurrent calls to `finish()`.