### PR TITLE
Procedure name and identity

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		655E86431D67B55B000FBA6C /* ProcedureQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655E86421D67B55B000FBA6C /* ProcedureQueue.swift */; };
 		655E86451D67B9F9000FBA6C /* ProcedureObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655E86441D67B9F9000FBA6C /* ProcedureObserver.swift */; };
 		655E86471D67BA9C000FBA6C /* Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655E86461D67BA9C000FBA6C /* Support.swift */; };
+		657431281D8D9765002E8FC9 /* Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657431271D8D9765002E8FC9 /* Identity.swift */; };
 		6583F95F1D8C4C7F00000A8D /* NoFailedDependenciesConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6583F95E1D8C4C7F00000A8D /* NoFailedDependenciesConditionTests.swift */; };
 		6584AF451D74770C0030DBB3 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6584AF441D74770C0030DBB3 /* Errors.swift */; };
 		65881B791D880ACB00C212C8 /* MutualExclusivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65881B781D880ACB00C212C8 /* MutualExclusivityTests.swift */; };
@@ -259,6 +260,7 @@
 		655E86421D67B55B000FBA6C /* ProcedureQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProcedureQueue.swift; path = Sources/ProcedureQueue.swift; sourceTree = "<group>"; };
 		655E86441D67B9F9000FBA6C /* ProcedureObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProcedureObserver.swift; path = Sources/ProcedureObserver.swift; sourceTree = "<group>"; };
 		655E86461D67BA9C000FBA6C /* Support.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Support.swift; path = Sources/Support.swift; sourceTree = "<group>"; };
+		657431271D8D9765002E8FC9 /* Identity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Identity.swift; path = Sources/Identity.swift; sourceTree = "<group>"; };
 		6583F95E1D8C4C7F00000A8D /* NoFailedDependenciesConditionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NoFailedDependenciesConditionTests.swift; path = Tests/NoFailedDependenciesConditionTests.swift; sourceTree = "<group>"; };
 		6584AF441D74770C0030DBB3 /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Errors.swift; sourceTree = "<group>"; };
 		65881B781D880ACB00C212C8 /* MutualExclusivityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MutualExclusivityTests.swift; path = Tests/MutualExclusivityTests.swift; sourceTree = "<group>"; };
@@ -546,6 +548,7 @@
 			children = (
 				65A2D8031D6A1ED500FB067C /* AnyObserver.swift */,
 				6518D5E21D7B3A2800A12EF4 /* Condition.swift */,
+				657431271D8D9765002E8FC9 /* Identity.swift */,
 				65DA49301D8142BE00D4E1AA /* MutualExclusion.swift */,
 				65B97DB41D65138F00AC3B5D /* Procedure.swift */,
 				655E86441D67B9F9000FBA6C /* ProcedureObserver.swift */,
@@ -1219,6 +1222,7 @@
 				65B97DB51D65138F00AC3B5D /* Procedure.swift in Sources */,
 				6518D5E31D7B3A2800A12EF4 /* Condition.swift in Sources */,
 				655E86471D67BA9C000FBA6C /* Support.swift in Sources */,
+				657431281D8D9765002E8FC9 /* Identity.swift in Sources */,
 				655E86451D67B9F9000FBA6C /* ProcedureObserver.swift in Sources */,
 				653EBBBA1D88AFA800F4DB9F /* Delay.swift in Sources */,
 				655E86431D67B55B000FBA6C /* ProcedureQueue.swift in Sources */,

--- a/Sources/Condition.swift
+++ b/Sources/Condition.swift
@@ -92,7 +92,7 @@ open class Condition: Procedure, ConditionProtocol {
 
 public class TrueCondition: Condition {
 
-    public init(name: String = "True Condition", mutuallyExclusive: Bool = false) {
+    public init(name: String = "TrueCondition", mutuallyExclusive: Bool = false) {
         super.init()
         self.name = name
         self.mutuallyExclusive = mutuallyExclusive
@@ -105,7 +105,7 @@ public class TrueCondition: Condition {
 
 public class FalseCondition: Condition {
 
-    public init(name: String = "False Condition", mutuallyExclusive: Bool = false) {
+    public init(name: String = "FalseCondition", mutuallyExclusive: Bool = false) {
         super.init()
         self.name = name
         self.mutuallyExclusive = mutuallyExclusive

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -69,8 +69,6 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
         queue.isSuspended = true
         queue.underlyingQueue = underlyingQueue
         queue.delegate = self
-
-        name = "GroupProcedure"
         userIntent = operations.userIntent
         groupCanFinish = CanFinishGroup(group: self)
 

--- a/Sources/Identity.swift
+++ b/Sources/Identity.swift
@@ -1,0 +1,32 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import Foundation
+
+public protocol Identifiable {
+    var identifier: UUID { get }
+}
+
+public extension Procedure {
+
+    struct Identity: Identifiable, Equatable {
+
+        public static func == (lhs: Identity, rhs: Identity) -> Bool {
+            return lhs.identifier == rhs.identifier
+        }
+
+        public let identifier: UUID
+        public let name: String?
+
+        public var description: String {
+            return name.map { "\($0) #\(identifier)" } ?? "Unnamed Procedure #\(identifier)"
+        }
+    }
+
+    var identity: Identity {
+        return Identity(identifier: identifier, name: name)
+    }
+}

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -94,6 +94,8 @@ open class Procedure: Operation, ProcedureProcotol {
         }
     }
 
+    internal let identifier = UUID()
+
     // MARK: State
 
     private var _state = State.initialized
@@ -105,8 +107,7 @@ open class Procedure: Operation, ProcedureProcotol {
         }
         set(newState) {
             _stateLock.withCriticalScope {
-                assert(_state.canTransition(to: newState, whenCancelled: isCancelled), "Attempting to perform illegal cyclic state transition, \(_state) -> \(newState).")
-//                assert(_state.canTransition(to: newState, whenCancelled: isCancelled), "Attempting to perform illegal cyclic state transition, \(_state) -> \(newState) for operation: \(identity).")
+                assert(_state.canTransition(to: newState, whenCancelled: isCancelled), "Attempting to perform illegal cyclic state transition, \(_state) -> \(newState) for operation: \(identity).")
                 log.verbose(message: "\(_state) -> \(newState)")
                 _state = newState
             }
@@ -223,8 +224,9 @@ open class Procedure: Operation, ProcedureProcotol {
     // MARK: - Initialization
 
     public override init() {
-        self.isAutomaticFinishingDisabled = false
+        isAutomaticFinishingDisabled = false
         super.init()
+        name = String(describing: type(of: self))
     }
 
     // MARK: - Disable Automatic Finishing
@@ -266,8 +268,9 @@ open class Procedure: Operation, ProcedureProcotol {
 
      */
     public init(disableAutomaticFinishing: Bool) {
-        self.isAutomaticFinishingDisabled = disableAutomaticFinishing
+        isAutomaticFinishingDisabled = disableAutomaticFinishing
         super.init()
+        name = String(describing: type(of: self))
     }
 
 

--- a/Sources/Testing/TestProcedure.swift
+++ b/Sources/Testing/TestProcedure.swift
@@ -33,7 +33,7 @@ open class TestProcedure: Procedure, ResultInjectionProtocol {
     public private(set) var procedureWillCancelCalled = false
     public private(set) var procedureDidCancelCalled = false
 
-    public init(name: String = "Test Procedure", delay: TimeInterval = 0.000_001, error: Error? = .none, produced: Operation? = .none) {
+    public init(name: String = "TestProcedure", delay: TimeInterval = 0.000_001, error: Error? = .none, produced: Operation? = .none) {
         self.delay = delay
         self.error = error
         self.producedOperation = produced

--- a/Tests/GroupTests.swift
+++ b/Tests/GroupTests.swift
@@ -12,10 +12,6 @@ class GroupTests: GroupTestCase {
 
     // MARK: - Basic Group Tests
 
-    func test__group_sets_name() {
-       XCTAssertEqual(group.name, "GroupProcedure")
-    }
-
     func test__group_has_user_intent_set_from_input_operations() {
         let child = TestProcedure()
         child.userIntent = .initiated

--- a/Tests/NegatedConditionTests.swift
+++ b/Tests/NegatedConditionTests.swift
@@ -30,6 +30,6 @@ class NegatedConditionTests: ProcedureKitTestCase {
 
     func test__negated_condition_name() {
         let negated = NegatedCondition(FalseCondition())
-        XCTAssertEqual(negated.name, "Not<False Condition>")
+        XCTAssertEqual(negated.name, "Not<FalseCondition>")
     }
 }

--- a/Tests/ProcedureTests.swift
+++ b/Tests/ProcedureTests.swift
@@ -81,3 +81,27 @@ class UserIntentTests: ProcedureKitTestCase {
         XCTAssertNotEqual(Procedure.UserIntent.initiated, Procedure.UserIntent.sideEffect)
     }
 }
+
+class ProcedureTests: ProcedureKitTestCase {
+
+    func test__procedure_name() {
+        let block = BlockProcedure { }
+        XCTAssertEqual(block.name, "BlockProcedure")
+
+        let group = GroupProcedure(operations: [])
+        XCTAssertEqual(group.name, "GroupProcedure")
+    }
+
+    func test__identity_is_equatable() {
+        let identity1 = procedure.identity
+        let identity2 = procedure.identity
+        XCTAssertEqual(identity1, identity2)
+    }
+
+    func test__identity_description() {
+        XCTAssertTrue(procedure.identity.description.hasPrefix("TestProcedure #"))
+        procedure.name = nil
+        XCTAssertTrue(procedure.identity.description.hasPrefix("Unnamed Procedure #"))
+    }
+}
+

--- a/Tests/SilentConditionTests.swift
+++ b/Tests/SilentConditionTests.swift
@@ -12,7 +12,7 @@ class SilentConditionTests: ProcedureKitTestCase {
 
     func test__silent_condition_composes_name_correctly() {
         let silent = SilentCondition(FalseCondition())
-        XCTAssertEqual(silent.name, "Silent<False Condition>")        
+        XCTAssertEqual(silent.name, "Silent<FalseCondition>")        
     }
 
     func test__silent_condition_removes_dependencies_from_composed_condition() {


### PR DESCRIPTION
`Procedure` should automatically set its name to the dynamic type. Additionally we need to restore the nested `Identity` struct.