### PR TITLE
Add AnyProcedure

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		6591B3021D74980900C2B57F /* GroupTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B3011D74980900C2B57F /* GroupTestCase.swift */; };
 		6593008C1DA8E31900750212 /* TransformProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6593008B1DA8E31900750212 /* TransformProcedureTests.swift */; };
 		6593008E1DA8E32D00750212 /* FilterProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6593008D1DA8E32D00750212 /* FilterProcedureTests.swift */; };
+		65931A541DAFEDC00067B0A4 /* Any.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65931A531DAFEDC00067B0A4 /* Any.swift */; };
+		65931A561DAFF3E20067B0A4 /* AnyProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65931A551DAFF3E20067B0A4 /* AnyProcedureTests.swift */; };
 		6594840E1DA98B8E0028F83B /* Reduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6594840D1DA98B8E0028F83B /* Reduce.swift */; };
 		659484101DA98E700028F83B /* ReduceProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6594840F1DA98E700028F83B /* ReduceProcedureTests.swift */; };
 		659484121DA993DB0028F83B /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659484111DA993DB0028F83B /* Map.swift */; };
@@ -372,6 +374,8 @@
 		6591B3011D74980900C2B57F /* GroupTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTestCase.swift; path = Sources/Testing/GroupTestCase.swift; sourceTree = "<group>"; };
 		6593008B1DA8E31900750212 /* TransformProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TransformProcedureTests.swift; path = Tests/TransformProcedureTests.swift; sourceTree = "<group>"; };
 		6593008D1DA8E32D00750212 /* FilterProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FilterProcedureTests.swift; path = Tests/FilterProcedureTests.swift; sourceTree = "<group>"; };
+		65931A531DAFEDC00067B0A4 /* Any.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Any.swift; path = Sources/Any.swift; sourceTree = "<group>"; };
+		65931A551DAFF3E20067B0A4 /* AnyProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AnyProcedureTests.swift; path = Tests/AnyProcedureTests.swift; sourceTree = "<group>"; };
 		6594840D1DA98B8E0028F83B /* Reduce.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reduce.swift; path = Sources/Reduce.swift; sourceTree = "<group>"; };
 		6594840F1DA98E700028F83B /* ReduceProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReduceProcedureTests.swift; path = Tests/ReduceProcedureTests.swift; sourceTree = "<group>"; };
 		659484111DA993DB0028F83B /* Map.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Map.swift; path = Sources/Map.swift; sourceTree = "<group>"; };
@@ -575,6 +579,7 @@
 		653C9FD91D6097E20070B7A2 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				65931A551DAFF3E20067B0A4 /* AnyProcedureTests.swift */,
 				652AFD401D8C745500793AF3 /* BlockConditionTests.swift */,
 				65958FD41D96B0AE00F542E2 /* BlockObserverTests.swift */,
 				65A0CB261D7D4CF1008FB37C /* BlockProcedureTests.swift */,
@@ -846,6 +851,7 @@
 		65EAC0141D8CA3BB000E4A42 /* Procedures */ = {
 			isa = PBXGroup;
 			children = (
+				65931A531DAFEDC00067B0A4 /* Any.swift */,
 				658740C61DAE70DA00E8D93E /* Block.swift */,
 				65A63B121DA03D1C00E90B9D /* Capability.swift */,
 				659E11A61D9856FB00C5D749 /* Composed.swift */,
@@ -1519,6 +1525,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				65931A541DAFEDC00067B0A4 /* Any.swift in Sources */,
 				652AFD361D8C5A5E00793AF3 /* NegatedCondition.swift in Sources */,
 				65A63B131DA03D1C00E90B9D /* Capability.swift in Sources */,
 				651FFDF01DA850FE00112220 /* Filter.swift in Sources */,
@@ -1560,6 +1567,7 @@
 			files = (
 				650182C91D8916EC0052CE90 /* DelayProcedureTests.swift in Sources */,
 				659484101DA98E700028F83B /* ReduceProcedureTests.swift in Sources */,
+				65931A561DAFF3E20067B0A4 /* AnyProcedureTests.swift in Sources */,
 				65245D251D724FC200340A2D /* LoggerTests.swift in Sources */,
 				6591B3001D74954E00C2B57F /* GroupTests.swift in Sources */,
 				652AFD411D8C745500793AF3 /* BlockConditionTests.swift in Sources */,

--- a/Sources/Any.swift
+++ b/Sources/Any.swift
@@ -44,6 +44,6 @@ public class AnyProcedure<Requirement, Result>: GroupProcedure, ResultInjectionP
 
     public init<Base>(underlyingQueue: DispatchQueue? = nil, _ base: Base) where Base: Procedure, Base: ResultInjectionProtocol, Result == Base.Result, Requirement == Base.Requirement {
         erased = AnyProcedureBox(underlyingQueue: underlyingQueue, base: base)
-        super.init(underlyingQueue: underlyingQueue, operations: [erased])
+        super.init(underlyingQueue: erased.underlyingQueue, operations: [erased])
     }
 }

--- a/Sources/Any.swift
+++ b/Sources/Any.swift
@@ -1,0 +1,49 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+class AnyProcedureBox_<Requirement, Result>: GroupProcedure, ResultInjectionProtocol {
+    var requirement: Requirement!
+    var result: Result! { return nil }
+}
+
+class AnyProcedureBox<Base: Procedure>: AnyProcedureBox_<Base.Requirement, Base.Result> where Base: ResultInjectionProtocol {
+
+    private var base: Base
+
+    public override var requirement: Base.Requirement! {
+        get { return base.requirement }
+        set { base.requirement = newValue }
+    }
+
+    public override var result: Base.Result! {
+        return base.result
+    }
+
+    public init(underlyingQueue: DispatchQueue? = nil, base: Base) {
+        self.base = base
+        super.init(underlyingQueue: underlyingQueue, operations: [base])
+    }
+}
+
+public class AnyProcedure<Requirement, Result>: GroupProcedure, ResultInjectionProtocol {
+    private typealias Erased = AnyProcedureBox_<Requirement, Result>
+
+    private var erased: Erased
+
+    public var requirement: Erased.Requirement {
+        get { return erased.requirement }
+        set { erased.requirement = newValue }
+    }
+
+    public var result: Erased.Result {
+        return erased.result
+    }
+
+    public init<Base>(underlyingQueue: DispatchQueue? = nil, _ base: Base) where Base: Procedure, Base: ResultInjectionProtocol, Result == Base.Result, Requirement == Base.Requirement {
+        erased = AnyProcedureBox(underlyingQueue: underlyingQueue, base: base)
+        super.init(underlyingQueue: underlyingQueue, operations: [erased])
+    }
+}

--- a/Sources/AnyObserver.swift
+++ b/Sources/AnyObserver.swift
@@ -4,12 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
-internal func _abstractMethod(file: StaticString = #file, line: UInt = #line) {
-    fatalError("Method must be overriden", file: file, line: line)
-}
-
 class AnyObserverBox_<Procedure: ProcedureProtocol>: ProcedureObserver {
     func didAttach(to procedure: Procedure) { _abstractMethod() }
     func will(execute procedure: Procedure) { _abstractMethod() }

--- a/Sources/Block.swift
+++ b/Sources/Block.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 open class BlockProcedure: Procedure {
 
     public typealias ThrowingVoidBlock = () throws -> Void

--- a/Sources/BlockCondition.swift
+++ b/Sources/BlockCondition.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public typealias ThrowingBoolBlock = () throws -> Bool
 
 /**

--- a/Sources/BlockObservers.swift
+++ b/Sources/BlockObservers.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public struct Observer<Procedure: ProcedureProtocol> {
 
     public typealias VoidBlock = (Procedure) -> Void

--- a/Sources/Capability.swift
+++ b/Sources/Capability.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 /**
  Defines the authorization status of a capability. Typically
  this will be an enum, like CLAuthorizationStatus. Note

--- a/Sources/Collection+ProcedureKit.swift
+++ b/Sources/Collection+ProcedureKit.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 extension Collection where Iterator.Element: Operation {
 
     internal var operationsAndProcedures: ([Operation], [Procedure]) {

--- a/Sources/Composed.swift
+++ b/Sources/Composed.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 open class ComposedProcedure<T: Operation>: GroupProcedure {
 
     public private(set) var operation: T

--- a/Sources/Condition.swift
+++ b/Sources/Condition.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 /**
  The result of a Condition. Either the condition is satisfied,
  indicated by `.satisfied` or it has failed. In the failure

--- a/Sources/Delay.swift
+++ b/Sources/Delay.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public enum Delay: Comparable {
 
     public static func == (lhs: Delay, rhs: Delay) -> Bool {

--- a/Sources/Errors.swift
+++ b/Sources/Errors.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public protocol ProcedureKitComponent {
     var name: String { get }
 }

--- a/Sources/Filter.swift
+++ b/Sources/Filter.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 open class FilterProcedure<Element>: ReduceProcedure<Element, Array<Element>> {
 
     public init<S: Sequence>(source: S, isIncluded: @escaping (Element) throws -> Bool) where S.Iterator.Element == Element, S.SubSequence: Sequence, S.SubSequence.Iterator.Element == Element, S.SubSequence.SubSequence == S.SubSequence {

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 // swiftlint:disable file_length
 
 /**

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -249,6 +249,15 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
 public extension GroupProcedure {
 
     /**
+     Access the underlying queue of the GroupProcedure.
+
+     - returns: the DispatchQueue of the groups private ProcedureQueue
+    */
+    final var underlyingQueue: DispatchQueue? {
+        return queue.underlyingQueue
+    }
+
+    /**
      The maximum number of child operations that can execute at the same time.
 
      The value in this property affects only the operations that the current GroupProcedure has

--- a/Sources/Identity.swift
+++ b/Sources/Identity.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public protocol Identifiable {
     var identifier: UUID { get }
 }

--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 /**
  Log Severity
 

--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 open class MapProcedure<Element, U>: ReduceProcedure<Element, Array<U>> {
 
     public init<S: Sequence>(source: S, transform: @escaping (Element) throws -> U) where S.Iterator.Element == Element, S.SubSequence: Sequence, S.SubSequence.Iterator.Element == Element, S.SubSequence.SubSequence == S.SubSequence {

--- a/Sources/MutualExclusion.swift
+++ b/Sources/MutualExclusion.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 /**
  A generic condition for describing operations that
  cannot be allowed to execute concurrently.

--- a/Sources/NegatedCondition.swift
+++ b/Sources/NegatedCondition.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public final class NegatedCondition<C: Condition>: ComposedCondition<C> {
 
     /// Public override of initializer.

--- a/Sources/NoFailedDependenciesCondition.swift
+++ b/Sources/NoFailedDependenciesCondition.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public class NoFailedDependenciesCondition: Condition {
 
     /// Options on how to handle cancellation

--- a/Sources/Operation+ProcedureKit.swift
+++ b/Sources/Operation+ProcedureKit.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 internal extension Operation {
 
     enum KeyPath: String {

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -5,9 +5,6 @@
 //
 
 // swiftlint:disable file_length
-
-import Foundation
-
 // swiftlint:disable type_body_length
 
 open class Procedure: Operation, ProcedureProtocol {

--- a/Sources/ProcedureObserver.swift
+++ b/Sources/ProcedureObserver.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 /**
  Types which conform to this protocol, can be attached to `Procedure` subclasses to receive
  events at state transitions.

--- a/Sources/ProcedureProcotol.swift
+++ b/Sources/ProcedureProcotol.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public protocol ProcedureProtocol: class {
 
     var procedureName: String { get }

--- a/Sources/ProcedureQueue.swift
+++ b/Sources/ProcedureQueue.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public protocol OperationQueueDelegate: class {
 
     /**

--- a/Sources/Reduce.swift
+++ b/Sources/Reduce.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 open class ReduceProcedure<Element, U>: Procedure, ResultInjectionProtocol {
 
     public var requirement: AnySequence<Element>

--- a/Sources/Repeat.swift
+++ b/Sources/Repeat.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public struct RepeatProcedurePayload<T: Operation> {
     public typealias ConfigureBlock = (T) -> Void
 

--- a/Sources/ResultInjection.swift
+++ b/Sources/ResultInjection.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public protocol ResultInjectionProtocol: class {
 
     associatedtype Requirement

--- a/Sources/Retry.swift
+++ b/Sources/Retry.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 public struct RetryFailureInfo<T: Operation> {
 
     /// - returns: the failed operation

--- a/Sources/SilentCondition.swift
+++ b/Sources/SilentCondition.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 /**
  A simple condition which suppresses its contained condition to not
  enqueue any dependencies. This is useful for verifying access to

--- a/Sources/Support.swift
+++ b/Sources/Support.swift
@@ -4,7 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
+internal func _abstractMethod(file: StaticString = #file, line: UInt = #line) {
+    fatalError("Method must be overriden", file: file, line: line)
+}
 
 extension Dictionary {
 

--- a/Sources/TimeoutObserver.swift
+++ b/Sources/TimeoutObserver.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 /**
  An observer which will automatically cancel (with an error)
  if it doesn't finish before a time interval is expired.

--- a/Sources/Transform.swift
+++ b/Sources/Transform.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-
 open class TransformProcedure<Requirement, Result>: Procedure, ResultInjectionProtocol {
 
     public typealias Transform = (Requirement) throws -> Result

--- a/Tests/AnyProcedureTests.swift
+++ b/Tests/AnyProcedureTests.swift
@@ -1,0 +1,74 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+import TestingProcedureKit
+@testable import ProcedureKit
+
+class Foo: Procedure, ResultInjectionProtocol {
+    var requirement: String = ""
+    var result: String = "Foo"
+    override func execute() {
+        result = "\(requirement)Foo"
+        finish()
+    }
+}
+
+class Bar: Procedure, ResultInjectionProtocol {
+    var requirement: String = ""
+    var result: String = "Bar"
+    override func execute() {
+        result = "\(requirement)Bar"
+        finish()
+    }
+}
+
+class Baz: Procedure, ResultInjectionProtocol {
+    var requirement: String = ""
+    var result: String = "Baz"
+    override func execute() {
+        result = "\(requirement)Baz"
+        finish()
+    }
+}
+
+class AnyProcedureTests: ProcedureKitTestCase {
+
+    func test__any_procedure() {
+        let anyProcedure = AnyProcedure(procedure)
+        wait(for: anyProcedure)
+        XCTAssertProcedureFinishedWithoutErrors(procedure)
+        XCTAssertProcedureFinishedWithoutErrors(anyProcedure)
+    }
+
+    func test__any_procedure_get_correct_result() {
+        let anyProcedure = AnyProcedure(procedure)
+        wait(for: anyProcedure)
+        XCTAssertProcedureFinishedWithoutErrors(procedure)
+        XCTAssertProcedureFinishedWithoutErrors(anyProcedure)
+        XCTAssertEqual(anyProcedure.result, "Hello World")
+    }
+
+    func test__array_of_any_procedures() {
+        let procedures = [AnyProcedure(Foo()), AnyProcedure(Bar()), AnyProcedure(Baz())]
+        let group = GroupProcedure(operations: procedures)
+        wait(for: group)
+        XCTAssertProcedureFinishedWithoutErrors(group)
+        XCTAssertEqual(procedures.map { $0.result }, ["Foo", "Bar", "Baz"])
+        XCTAssertEqual(procedures.map { $0.requirement }, ["", "", ""])
+    }
+
+    func test__setting_requirement() {
+        let foo = Foo()
+        let anyProcedure = AnyProcedure(foo)
+        anyProcedure.requirement = "Hello "
+        wait(for: anyProcedure)
+        XCTAssertProcedureFinishedWithoutErrors(foo)
+        XCTAssertProcedureFinishedWithoutErrors(anyProcedure)
+        XCTAssertEqual(anyProcedure.result, "Hello Foo")
+    }
+}
+


### PR DESCRIPTION
`Procedure` is an abstract class, conforming to a protocol, which means that it must be subclassed. Also, _ProcedureKit_ encourages a sort of functional ethos via result injection. So, often we want to work with `Procedure` subclasses which conform to `ResultInjectionProtocol` and have the same `Result`. But, we cannot groups such instances together in a homogeneous collection due to generics. What would be useful, would be a type erased `AnyProcedure<Result>: Procedure`.