### PR TITLE
Rename AuthorizationStatusProtocol

### DIFF
--- a/Sources/Capability.swift
+++ b/Sources/Capability.swift
@@ -11,7 +11,7 @@
  for another (or existing) types to be used to define granular
  levels of permissions. Use Void if not needed.
  */
-public protocol AuthorizationStatusProtocol {
+public protocol AuthorizationStatus {
 
     /// A generic type for the requirement
     associatedtype Requirement
@@ -41,7 +41,7 @@ public protocol AuthorizationStatusProtocol {
  */
 public protocol CapabilityProtocol {
 
-    associatedtype Status: AuthorizationStatusProtocol
+    associatedtype Status: AuthorizationStatus
 
     /**
      A requirement of the capability. E.g. for Location this
@@ -92,7 +92,7 @@ extension Capability {
      an authorization level, but still might not be available. For example
      PassKit. In which case, use VoidStatus as the nested Status type.
      */
-    public struct VoidStatus: AuthorizationStatusProtocol, Equatable {
+    public struct VoidStatus: AuthorizationStatus, Equatable {
 
         public static func == (_: VoidStatus, _: VoidStatus) -> Bool {
             return true
@@ -108,7 +108,7 @@ extension Capability {
 
 // MARK: - AnyCapability
 
-internal class AnyCapabilityBox_<Status: AuthorizationStatusProtocol>: CapabilityProtocol {
+internal class AnyCapabilityBox_<Status: AuthorizationStatus>: CapabilityProtocol {
     var requirement: Status.Requirement? { _abstractMethod(); return nil }
     func isAvailable() -> Bool { _abstractMethod(); return false }
     func getAuthorizationStatus(_ completion: @escaping (Status) -> Void) { _abstractMethod() }
@@ -135,7 +135,7 @@ internal class AnyCapabilityBox<Base: CapabilityProtocol>: AnyCapabilityBox_<Bas
     }
 }
 
-public struct AnyCapability<Status: AuthorizationStatusProtocol>: CapabilityProtocol {
+public struct AnyCapability<Status: AuthorizationStatus>: CapabilityProtocol {
     private typealias Erased = AnyCapabilityBox_<Status>
 
     private var box: Erased
@@ -162,7 +162,7 @@ public struct AnyCapability<Status: AuthorizationStatusProtocol>: CapabilityProt
  A generic procedure which will get the current authorization
  status for AnyCapability<Status>.
  */
-public class GetAuthorizationStatus<Status: AuthorizationStatusProtocol>: Procedure, ResultInjectionProtocol {
+public class GetAuthorizationStatus<Status: AuthorizationStatus>: Procedure, ResultInjectionProtocol {
 
     /// the StatusResponse is a tuple for the capabilities availability and status
     public typealias StatusResponse = (Bool, Status)
@@ -216,7 +216,7 @@ public class GetAuthorizationStatus<Status: AuthorizationStatusProtocol>: Proced
 }
 
 /// A generic procedure which will authorize a capability
-public class Authorize<Status: AuthorizationStatusProtocol>: GetAuthorizationStatus<Status> {
+public class Authorize<Status: AuthorizationStatus>: GetAuthorizationStatus<Status> {
 
     /**
      Initialize the operation with a base type which conforms to CapabilityProtocol
@@ -245,7 +245,7 @@ public class Authorize<Status: AuthorizationStatusProtocol>: GetAuthorizationSta
  which means that potentially the user will be prompted to grant
  authorization. Suppress this from happening with SilentCondition.
  */
-public class AuthorizedFor<Status: AuthorizationStatusProtocol>: Condition {
+public class AuthorizedFor<Status: AuthorizationStatus>: Condition {
 
     fileprivate let capability: AnyCapability<Status>
 

--- a/Sources/Location/LocationCapability.swift
+++ b/Sources/Location/LocationCapability.swift
@@ -11,7 +11,7 @@ public enum LocationUsage {
     case always
 }
 
-extension CLAuthorizationStatus: AuthorizationStatusProtocol {
+extension CLAuthorizationStatus: AuthorizationStatus {
 
     public func meets(requirement: LocationUsage?) -> Bool {
         switch (requirement, self) {

--- a/Sources/Testing/CapabilityTestCase.swift
+++ b/Sources/Testing/CapabilityTestCase.swift
@@ -10,7 +10,7 @@ import ProcedureKit
 
 public class TestableCapability: CapabilityProtocol {
 
-    public enum Status: AuthorizationStatusProtocol {
+    public enum Status: AuthorizationStatus {
         public enum Requirement { // swiftlint:disable:this nesting
             case minimum, maximum
         }
@@ -91,7 +91,7 @@ open class TestableCapabilityTestCase: ProcedureKitTestCase {
         super.tearDown()
     }
 
-    public func XCTAssertGetAuthorizationStatus<Status: AuthorizationStatusProtocol>(_ exp1: @autoclosure () throws -> (Bool, Status)?, expected exp2: @autoclosure () throws -> (Bool, Status), _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where Status: Equatable {
+    public func XCTAssertGetAuthorizationStatus<Status: AuthorizationStatus>(_ exp1: @autoclosure () throws -> (Bool, Status)?, expected exp2: @autoclosure () throws -> (Bool, Status), _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where Status: Equatable {
         __XCTEvaluateAssertion(testCase: self, message, file: file, line: line) {
             let result = try exp1()
             let expected = try exp2()


### PR DESCRIPTION
This can just be `AuthorizationStatus`. This addresses an issue raised in #512.