### PR TITLE
Rename attach(condition: Condition) back to add

### DIFF
--- a/Sources/Composed.swift
+++ b/Sources/Composed.swift
@@ -26,6 +26,6 @@ open class GatedProcedure<T: Operation>: ComposedProcedure<T> {
 
     public init(operation: T, gate: @escaping ThrowingBoolBlock) {
         super.init(operation: operation)
-        attach(condition: IgnoredCondition(BlockCondition(block: gate)))
+        add(condition: IgnoredCondition(BlockCondition(block: gate)))
     }
 }

--- a/Sources/Location/ReverseGeocode.swift
+++ b/Sources/Location/ReverseGeocode.swift
@@ -29,7 +29,7 @@ open class ReverseGeocodeProcedure: Procedure, ResultInjectionProtocol {
         self.requirement = location
         self.completion = completion
         super.init()
-        attach(condition: MutuallyExclusive<ReverseGeocodeProcedure>())
+        add(condition: MutuallyExclusive<ReverseGeocodeProcedure>())
         add(observer: TimeoutObserver(by: timeout))
         addDidCancelBlockObserver { [weak self] _, errors in
             DispatchQueue.main.async {

--- a/Sources/Location/UserLocation.swift
+++ b/Sources/Location/UserLocation.swift
@@ -33,8 +33,8 @@ open class UserLocationProcedure: Procedure, ResultInjectionProtocol, CLLocation
         self.accuracy = accuracy
         self.completion = completion
         super.init()
-        attach(condition: AuthorizedFor(capability))
-        attach(condition: MutuallyExclusive<UserLocationProcedure>())
+        add(condition: AuthorizedFor(capability))
+        add(condition: MutuallyExclusive<UserLocationProcedure>())
         add(observer: TimeoutObserver(by: timeout))
         addDidCancelBlockObserver { [weak self] _, errors in
             DispatchQueue.main.async {

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -580,9 +580,9 @@ public extension Procedure {
 
 // MARK: Conditions
 
-public extension Procedure {
+extension Procedure {
 
-    internal enum ConditionEvaluation {
+    enum ConditionEvaluation {
         case pending, satisfied, ignored
         case failed([Error])
 
@@ -612,7 +612,7 @@ public extension Procedure {
         }
     }
 
-    internal class EvaluateConditions: GroupProcedure {
+    class EvaluateConditions: GroupProcedure {
         var requirement: [Condition] = []
         var result: ConditionEvaluation = .pending
 
@@ -638,7 +638,7 @@ public extension Procedure {
         }
     }
 
-    internal func evaluateConditions() -> Procedure {
+    func evaluateConditions() -> Procedure {
 
         func createEvaluateConditionsProcedure() -> EvaluateConditions {
             // Set the procedure on each condition
@@ -675,24 +675,24 @@ public extension Procedure {
         return evaluator
     }
 
-    internal func add(dependencyOnPreviousMutuallyExclusiveProcedure procedure: Procedure) {
+    func add(dependencyOnPreviousMutuallyExclusiveProcedure procedure: Procedure) {
         precondition(state <= .executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
         super.addDependency(procedure)
     }
 
-    internal func add(directDependency: Operation) {
+    func add(directDependency: Operation) {
         precondition(state <= .executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
         directDependencies.insert(directDependency)
         super.addDependency(directDependency)
     }
 
-    internal func remove(directDependency: Operation) {
+    func remove(directDependency: Operation) {
         precondition(state <= .executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
         directDependencies.remove(directDependency)
         super.removeDependency(directDependency)
     }
 
-    final override var dependencies: [Operation] {
+    public final override var dependencies: [Operation] {
         return Array(directDependencies.union(indirectDependencies))
     }
 
@@ -705,7 +705,7 @@ public extension Procedure {
      to a queue, or is waiting on dependencies.
      - parameter operation: a `Operation` instance.
      */
-    final override func addDependency(_ operation: Operation) {
+    public final override func addDependency(_ operation: Operation) {
         precondition(state <= .executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
         add(directDependency: operation)
     }
@@ -720,7 +720,7 @@ public extension Procedure {
      to a queue, or is waiting on dependencies.
      - parameter operation: a `Operation` instance.
      */
-    final override func removeDependency(_ operation: Operation) {
+    public final override func removeDependency(_ operation: Operation) {
         precondition(state <= .executing, "Dependencies cannot be modified after execution has begun, current state: \(state).")
         remove(directDependency: operation)
     }
@@ -730,7 +730,7 @@ public extension Procedure {
 
      - parameter condition: a `Condition` which must be satisfied for the procedure to be executed.
      */
-    func attach(condition: Condition) {
+    public func add(condition: Condition) {
         assert(state < .executing, "Cannot modify conditions after operation has begun executing, current state: \(state).")
         conditions.insert(condition)
     }

--- a/Sources/Testing/CapabilityTestCase.swift
+++ b/Sources/Testing/CapabilityTestCase.swift
@@ -78,7 +78,7 @@ open class TestableCapabilityTestCase: ProcedureKitTestCase {
         getAuthorizationStatus = GetAuthorizationStatusProcedure(capability)
         authorize = AuthorizeCapabilityProcedure(capability)
         authorizedFor = AuthorizedFor(capability)
-        procedure.attach(condition: authorizedFor)
+        procedure.add(condition: authorizedFor)
     }
 
     open override func tearDown() {

--- a/Sources/Testing/RepeatTestCase.swift
+++ b/Sources/Testing/RepeatTestCase.swift
@@ -46,7 +46,7 @@ open class RetryTestCase: ProcedureKitTestCase {
         let info = RetryTestCaseInfo()
         return AnyIterator {
             let procedure = TestProcedure()
-            procedure.attach(condition: BlockCondition { info.numberOfFailures == failureThreshold })
+            procedure.add(condition: BlockCondition { info.numberOfFailures == failureThreshold })
             procedure.addWillFinishBlockObserver { test in
                 info.numberOfExecuctions += 1
                 info.numberOfFailures += 1
@@ -59,7 +59,7 @@ open class RetryTestCase: ProcedureKitTestCase {
         let info = RetryTestCaseInfo()
         return AnyIterator {
             let procedure = TestProcedure()
-            procedure.attach(condition: BlockCondition { info.numberOfFailures == failureThreshold })
+            procedure.add(condition: BlockCondition { info.numberOfFailures == failureThreshold })
             procedure.addWillFinishBlockObserver { test in
                 info.numberOfExecuctions += 1
                 info.numberOfFailures += 1

--- a/Tests/BlockConditionTests.swift
+++ b/Tests/BlockConditionTests.swift
@@ -11,19 +11,19 @@ import TestingProcedureKit
 class BlockConditionTests: ProcedureKitTestCase {
 
     func test__procedure_with_successfull_block_finishes() {
-        procedure.attach(condition: BlockCondition { true })
+        procedure.add(condition: BlockCondition { true })
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors()
     }
 
     func test__procedure_with_unsuccessful_block_cancels() {
-        procedure.attach(condition: BlockCondition { false })
+        procedure.add(condition: BlockCondition { false })
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }
 
     func test__procedure_with_throwing_block_cancels_with_error() {
-        procedure.attach(condition: BlockCondition { throw TestError() })
+        procedure.add(condition: BlockCondition { throw TestError() })
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }

--- a/Tests/ConditionTests.swift
+++ b/Tests/ConditionTests.swift
@@ -40,13 +40,13 @@ class ConditionTests: ProcedureKitTestCase {
     // MARK: - Single Attachment
 
     func test__single_condition_which_is_satisfied() {
-        procedure.attach(condition: TrueCondition())
+        procedure.add(condition: TrueCondition())
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors()
     }
 
     func test__single_condition_which_is_failed() {
-        procedure.attach(condition: FalseCondition())
+        procedure.add(condition: FalseCondition())
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors()
     }
@@ -54,33 +54,33 @@ class ConditionTests: ProcedureKitTestCase {
     // MARK: - Multiple Attachment
 
     func test__multiple_conditions_where_all_are_satisfied() {
-        procedure.attach(condition: TrueCondition())
-        procedure.attach(condition: TrueCondition())
-        procedure.attach(condition: TrueCondition())
+        procedure.add(condition: TrueCondition())
+        procedure.add(condition: TrueCondition())
+        procedure.add(condition: TrueCondition())
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors()
     }
 
     func test__multiple_conditions_where_all_fail() {
-        procedure.attach(condition: FalseCondition())
-        procedure.attach(condition: FalseCondition())
-        procedure.attach(condition: FalseCondition())
+        procedure.add(condition: FalseCondition())
+        procedure.add(condition: FalseCondition())
+        procedure.add(condition: FalseCondition())
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors(count: 3)
     }
 
     func test__multiple_conditions_where_one_succeeds() {
-        procedure.attach(condition: TrueCondition())
-        procedure.attach(condition: FalseCondition())
-        procedure.attach(condition: FalseCondition())
+        procedure.add(condition: TrueCondition())
+        procedure.add(condition: FalseCondition())
+        procedure.add(condition: FalseCondition())
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors(count: 2)
     }
 
     func test__multiple_conditions_where_one_fails() {
-        procedure.attach(condition: TrueCondition())
-        procedure.attach(condition: TrueCondition())
-        procedure.attach(condition: FalseCondition())
+        procedure.add(condition: TrueCondition())
+        procedure.add(condition: TrueCondition())
+        procedure.add(condition: FalseCondition())
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }
@@ -89,16 +89,16 @@ class ConditionTests: ProcedureKitTestCase {
 
     func test__single_condition_with_single_condition_which_both_succeed__executes() {
         let condition = TrueCondition()
-        condition.attach(condition: TrueCondition())
-        procedure.attach(condition: condition)
+        condition.add(condition: TrueCondition())
+        procedure.add(condition: condition)
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors()
     }
 
     func test__single_condition_which_succeeds_with_single_condition_which_fails__cancelled() {
         let condition = TrueCondition(name: "Condition 1")
-        condition.attach(condition: FalseCondition(name: "Nested Condition 1"))
-        procedure.attach(condition: condition)
+        condition.add(condition: FalseCondition(name: "Nested Condition 1"))
+        procedure.add(condition: condition)
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }
@@ -130,8 +130,8 @@ class ConditionTests: ProcedureKitTestCase {
         let condition2 = TrueCondition(name: "Condition 2")
         condition2.add(dependency: conditionDependency2)
 
-        procedure.attach(condition: condition1)
-        procedure.attach(condition: condition2)
+        procedure.add(condition: condition1)
+        procedure.add(condition: condition2)
 
         run(operations: dependency1, dependency2)
         wait(for: procedure)
@@ -152,8 +152,8 @@ class ConditionTests: ProcedureKitTestCase {
 
         procedure.add(dependency: dependency1)
         procedure.add(dependency: dependency2)
-        procedure.attach(condition: condition1)
-        procedure.attach(condition: condition2)
+        procedure.add(condition: condition1)
+        procedure.add(condition: condition2)
 
         run(operations: dependency1, dependency2)
         wait(for: procedure)
@@ -166,7 +166,7 @@ class ConditionTests: ProcedureKitTestCase {
         let condition = TrueCondition(name: "Condition")
         condition.add(dependency: dependency)
 
-        procedure.attach(condition: condition)
+        procedure.add(condition: condition)
         procedure.add(dependency: dependency)
 
         wait(for: dependency, procedure)
@@ -183,14 +183,14 @@ class ConditionTests: ProcedureKitTestCase {
         condition1.add(dependency: dependency)
 
         let procedure1 = TestProcedure(name: "Procedure 1")
-        procedure1.attach(condition: condition1)
+        procedure1.add(condition: condition1)
         procedure1.add(dependency: dependency)
 
         let condition2 = TrueCondition(name: "Condition 2")
         condition2.add(dependency: dependency)
 
         let procedure2 = TestProcedure(name: "Procedure 2")
-        procedure2.attach(condition: condition2)
+        procedure2.add(condition: condition2)
         procedure2.add(dependency: procedure1)
 
         wait(for: procedure1, dependency, procedure2)
@@ -204,10 +204,10 @@ class ConditionTests: ProcedureKitTestCase {
 
     func test__ignored_failing_condition_does_not_result_in_failure() {
         let procedure1 = TestProcedure(name: "Procedure 1")
-        procedure1.attach(condition: IgnoredCondition(FalseCondition()))
+        procedure1.add(condition: IgnoredCondition(FalseCondition()))
 
         let procedure2 = TestProcedure(name: "Procedure 2")
-        procedure2.attach(condition: FalseCondition())
+        procedure2.add(condition: FalseCondition())
 
         wait(for: procedure1, procedure2)
 
@@ -217,10 +217,10 @@ class ConditionTests: ProcedureKitTestCase {
 
     func test__ignored_satisfied_condition_does_not_result_in_failure() {
         let procedure1 = TestProcedure(name: "Procedure 1")
-        procedure1.attach(condition: IgnoredCondition(TrueCondition()))
+        procedure1.add(condition: IgnoredCondition(TrueCondition()))
 
         let procedure2 = TestProcedure(name: "Procedure 2")
-        procedure2.attach(condition: TrueCondition())
+        procedure2.add(condition: TrueCondition())
 
         wait(for: procedure1, procedure2)
 
@@ -230,7 +230,7 @@ class ConditionTests: ProcedureKitTestCase {
     }
 
     func test__ignored_ignored_condition_does_not_result_in_failure() {
-        procedure.attach(condition: IgnoredCondition(IgnoredCondition(FalseCondition())))
+        procedure.add(condition: IgnoredCondition(IgnoredCondition(FalseCondition())))
         wait(for: procedure)
         XCTAssertProcedureCancelledWithoutErrors()
     }

--- a/Tests/MutualExclusivityTests.swift
+++ b/Tests/MutualExclusivityTests.swift
@@ -42,8 +42,8 @@ class MutualExclusiveTests: ProcedureKitTestCase {
         procedure1.name = "Procedure 1"
         let condition1A = MutuallyExclusive<BlockProcedure>()
         let condition1B = MutuallyExclusive<TestProcedure>()
-        procedure1.attach(condition: condition1A)
-        procedure1.attach(condition: condition1B)
+        procedure1.add(condition: condition1A)
+        procedure1.add(condition: condition1B)
 
         let procedure2 = BlockProcedure {
             XCTAssertEqual(text, "Star Wars\nA long time ago")
@@ -52,8 +52,8 @@ class MutualExclusiveTests: ProcedureKitTestCase {
         procedure2.name = "Procedure 2"
         let condition2A = MutuallyExclusive<BlockProcedure>()
         let condition2B = MutuallyExclusive<TestProcedure>()
-        procedure2.attach(condition: condition2A)
-        procedure2.attach(condition: condition2B)
+        procedure2.add(condition: condition2A)
+        procedure2.add(condition: condition2B)
 
         wait(for: procedure1, procedure2)
 
@@ -73,7 +73,7 @@ class MutualExclusiveTests: ProcedureKitTestCase {
         condition1.add(dependency: conditionDependency1)
 
         let procedure1 = TestProcedure(name: "Procedure 1")
-        procedure1.attach(condition: condition1)
+        procedure1.add(condition: condition1)
 
         let procedure1Dependency = TestProcedure(name: "Dependency 1")
         procedure1.add(dependency: procedure1Dependency)
@@ -88,7 +88,7 @@ class MutualExclusiveTests: ProcedureKitTestCase {
         condition2.add(dependency: conditionDependency2)
 
         let procedure2 = TestProcedure()
-        procedure2.attach(condition: condition2)
+        procedure2.add(condition: condition2)
 
         let procedure2Dependency = TestProcedure(name: "Dependency 2")
         procedure2.add(dependency: procedure2Dependency)
@@ -101,11 +101,11 @@ class MutualExclusiveTests: ProcedureKitTestCase {
     func test__mutually_exclusive_operations_can_be_executed() {
         let procedure1 = TestProcedure()
         procedure1.name = "Procedure 1"
-        procedure1.attach(condition: MutuallyExclusive<TestProcedure>())
+        procedure1.add(condition: MutuallyExclusive<TestProcedure>())
 
         let procedure2 = TestProcedure()
         procedure2.name = "Procedure 2"
-        procedure2.attach(condition: MutuallyExclusive<TestProcedure>())
+        procedure2.add(condition: MutuallyExclusive<TestProcedure>())
 
         wait(for: procedure1, procedure2)
     }

--- a/Tests/NegatedConditionTests.swift
+++ b/Tests/NegatedConditionTests.swift
@@ -11,19 +11,19 @@ import TestingProcedureKit
 class NegatedConditionTests: ProcedureKitTestCase {
 
     func test__procedure_with_negated_successful_condition_fails() {
-        procedure.attach(condition: NegatedCondition(TrueCondition()))
+        procedure.add(condition: NegatedCondition(TrueCondition()))
         wait(for: procedure)
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }
 
     func test__procedure_with_negated_failed_condition_succeeds() {
-        procedure.attach(condition: NegatedCondition(FalseCondition()))
+        procedure.add(condition: NegatedCondition(FalseCondition()))
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors()
     }
 
     func test__procedure_with_negated_ignored_condition_succeeds() {
-        procedure.attach(condition: NegatedCondition(IgnoredCondition(FalseCondition())))
+        procedure.add(condition: NegatedCondition(IgnoredCondition(FalseCondition())))
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors()
     }

--- a/Tests/NoFailedDependenciesConditionTests.swift
+++ b/Tests/NoFailedDependenciesConditionTests.swift
@@ -11,7 +11,7 @@ import TestingProcedureKit
 class NoFailedDependenciesConditionTests: ProcedureKitTestCase {
 
     func test__procedure_with_no_dependencies_succeeds() {
-        procedure.attach(condition: NoFailedDependenciesCondition())
+        procedure.add(condition: NoFailedDependenciesCondition())
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors()
     }
@@ -19,7 +19,7 @@ class NoFailedDependenciesConditionTests: ProcedureKitTestCase {
     func test__procedure_with_successful_dependency_succeeds() {
         let dependency = TestProcedure()
         procedure.add(dependency: dependency)
-        procedure.attach(condition: NoFailedDependenciesCondition())
+        procedure.add(condition: NoFailedDependenciesCondition())
         wait(for: procedure, dependency)
         XCTAssertProcedureFinishedWithoutErrors()
     }
@@ -27,7 +27,7 @@ class NoFailedDependenciesConditionTests: ProcedureKitTestCase {
     func test__procedure_with_cancelled_dependency_fails() {
         let dependency = createCancellingProcedure()
         procedure.add(dependency: dependency)
-        procedure.attach(condition: NoFailedDependenciesCondition())
+        procedure.add(condition: NoFailedDependenciesCondition())
         wait(for: procedure, dependency)
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }
@@ -38,7 +38,7 @@ class NoFailedDependenciesConditionTests: ProcedureKitTestCase {
 
         procedure.add(dependency: dependency1)
         procedure.add(dependency: dependency2)
-        procedure.attach(condition: NoFailedDependenciesCondition())
+        procedure.add(condition: NoFailedDependenciesCondition())
         wait(for: procedure, dependency1, dependency2)
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }
@@ -46,7 +46,7 @@ class NoFailedDependenciesConditionTests: ProcedureKitTestCase {
     func test__procedure_with_errored_dependency_fails() {
         let dependency = TestProcedure(error: TestError())
         procedure.add(dependency: dependency)
-        procedure.attach(condition: NoFailedDependenciesCondition())
+        procedure.add(condition: NoFailedDependenciesCondition())
         wait(for: procedure, dependency)
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }
@@ -54,7 +54,7 @@ class NoFailedDependenciesConditionTests: ProcedureKitTestCase {
     func test__procedure_with_group_dependency_with_errored_child_fails() {
         let dependency = GroupProcedure(operations: [TestProcedure(error: TestError())])
         procedure.add(dependency: dependency)
-        procedure.attach(condition: NoFailedDependenciesCondition())
+        procedure.add(condition: NoFailedDependenciesCondition())
         wait(for: procedure, dependency)
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }
@@ -62,7 +62,7 @@ class NoFailedDependenciesConditionTests: ProcedureKitTestCase {
     func test__procedure_with_ignored_cancellations() {
         let dependency = createCancellingProcedure()
         procedure.add(dependency: dependency)
-        procedure.attach(condition: NoFailedDependenciesCondition(ignoreCancellations: true))
+        procedure.add(condition: NoFailedDependenciesCondition(ignoreCancellations: true))
         wait(for: procedure, dependency)
         XCTAssertProcedureCancelledWithoutErrors()
     }
@@ -78,7 +78,7 @@ class NoFailedDependenciesConditionTests: ProcedureKitTestCase {
         let dependency3 = TestProcedure()
         procedure.add(dependency: dependency3)
 
-        procedure.attach(condition: NoFailedDependenciesCondition(ignoreCancellations: true))
+        procedure.add(condition: NoFailedDependenciesCondition(ignoreCancellations: true))
         wait(for: procedure, dependency1, dependency2, dependency3)
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }

--- a/Tests/Stress Tests/ProcedureStressTests.swift
+++ b/Tests/Stress Tests/ProcedureStressTests.swift
@@ -43,7 +43,7 @@ class ProcedureConditionStressTest: StressTestCase {
     func test__adding_many_conditions() {
 
         StressLevel.custom(1, 10_000).forEach { _, _ in
-            procedure.attach(condition: TrueCondition())
+            procedure.add(condition: TrueCondition())
         }
         wait(for: procedure, withTimeout: 10)
         XCTAssertProcedureFinishedWithoutErrors()
@@ -52,7 +52,7 @@ class ProcedureConditionStressTest: StressTestCase {
     func test__adding_many_conditions_each_with_single_dependency() {
 
         StressLevel.custom(1, 10_000).forEach { _, _ in
-            procedure.attach(condition: TestCondition(dependencies: [TestProcedure()]) { .satisfied })
+            procedure.add(condition: TestCondition(dependencies: [TestProcedure()]) { .satisfied })
         }
         wait(for: procedure, withTimeout: 10)
         XCTAssertProcedureFinishedWithoutErrors()
@@ -88,7 +88,7 @@ class ProcedureConditionsWillFinishObserverCancelThreadSafety: StressTestCase {
         stress { batch, iteration in
             batch.dispatchGroup.enter()
             let procedure = TestProcedure()
-            procedure.attach(condition: FalseCondition())
+            procedure.add(condition: FalseCondition())
             procedure.addDidFinishBlockObserver { _, _ in
                 batch.dispatchGroup.leave()
             }


### PR DESCRIPTION
I think, in retrospect, that it's more discoverable if the API is `add`