### PR TITLE
Add transform block result injection API

### DIFF
--- a/Sources/Location/ReverseGeocodeUserLocation.swift
+++ b/Sources/Location/ReverseGeocodeUserLocation.swift
@@ -70,7 +70,7 @@ open class ReverseGeocodeUserLocationProcedure: GroupProcedure, ResultInjectionP
 
         userLocation = UserLocationProcedure(timeout: timeout, accuracy: accuracy)
 
-        reverseGeocodeLocation = ReverseGeocodeProcedure(timeout: timeout).injectResultFrom(dependency: userLocation)
+        reverseGeocodeLocation = ReverseGeocodeProcedure(timeout: timeout).injectResult(from: userLocation)
 
         finishing.inject(dependency: userLocation) { procedure, userLocation, errors in
             guard let location = userLocation.location, errors.isEmpty else {

--- a/Sources/ResultInjection.swift
+++ b/Sources/ResultInjection.swift
@@ -63,7 +63,7 @@ public extension ProcedureProtocol where Self: ResultInjectionProtocol {
     }
 
     @discardableResult func injectResult<Dependency: ProcedureProtocol>(from dependency: Dependency) -> Self where Dependency: ResultInjectionProtocol, Dependency.Result == Requirement {
-        return injectResult(from: dependency, via: { return $0 })
+        return injectResult(from: dependency, via: { $0 })
     }
 
     @discardableResult func requireResult<Dependency: ProcedureProtocol>(from dependency: Dependency) -> Self where Dependency: ResultInjectionProtocol, Dependency.Result == Optional<Requirement> {

--- a/Sources/ResultInjection.swift
+++ b/Sources/ResultInjection.swift
@@ -45,29 +45,31 @@ public extension ProcedureProtocol {
     }
 }
 
-
 public extension ProcedureProtocol where Self: ResultInjectionProtocol {
 
-    @discardableResult func injectResultFrom<Dependency: ProcedureProtocol>(dependency: Dependency) -> Self where Dependency: ResultInjectionProtocol, Dependency.Result == Requirement {
+    @discardableResult public func injectResult<Dependency: ProcedureProtocol>(from dependency: Dependency, via block: @escaping (Dependency.Result) throws -> Requirement) -> Self where Dependency: ResultInjectionProtocol {
 
         return inject(dependency: dependency) { procedure, dependency, errors in
             guard errors.isEmpty else {
                 procedure.cancel(withError: ProcedureKitError.dependency(finishedWithErrors: errors)); return
             }
-            procedure.requirement = dependency.result
+            do {
+                procedure.requirement = try block(dependency.result)
+            }
+            catch {
+                procedure.cancel(withError: ProcedureKitError.dependency(finishedWithErrors: errors)); return
+            }
         }
     }
 
-    @discardableResult func requireResultFrom<Dependency: ProcedureProtocol>(dependency: Dependency) -> Self where Dependency: ResultInjectionProtocol, Dependency.Result == Optional<Requirement> {
+    @discardableResult func injectResult<Dependency: ProcedureProtocol>(from dependency: Dependency) -> Self where Dependency: ResultInjectionProtocol, Dependency.Result == Requirement {
+        return injectResult(from: dependency, via: { return $0 })
+    }
 
-        return inject(dependency: dependency) { procedure, dependency, errors in
-            guard errors.isEmpty else {
-                procedure.cancel(withError: ProcedureKitError.dependency(finishedWithErrors: errors)); return
-            }
-            guard let requirement = dependency.result else {
-                procedure.cancel(withError: ProcedureKitError.requirementNotSatisfied()); return
-            }
-            procedure.requirement = requirement
+    @discardableResult func requireResult<Dependency: ProcedureProtocol>(from dependency: Dependency) -> Self where Dependency: ResultInjectionProtocol, Dependency.Result == Optional<Requirement> {
+        return injectResult(from: dependency) { result in
+            guard let requirement = result else { throw ProcedureKitError.requirementNotSatisfied() }
+            return requirement
         }
     }
 }

--- a/Tests/ResultInjectionTests.swift
+++ b/Tests/ResultInjectionTests.swift
@@ -66,7 +66,7 @@ class ResultInjectionTests: ResultInjectionTestCase {
     }
 
     func test__automatic_requirement_is_injected() {
-        processing.injectResultFrom(dependency: procedure)
+        processing.injectResult(from: procedure)
         wait(for: processing, procedure)
         XCTAssertProcedureFinishedWithoutErrors(processing)
     }
@@ -74,7 +74,7 @@ class ResultInjectionTests: ResultInjectionTestCase {
     func test__receiver_cancels_with_error_if_dependency_errors() {
         let error = TestError()
         procedure = TestProcedure(error: error)
-        processing.injectResultFrom(dependency: procedure)
+        processing.injectResult(from: procedure)
         processing.addDidCancelBlockObserver { processing, errors in
             XCTAssertEqual(errors.count, 1)
             guard let procedureKitError = errors.first as? ProcedureKitError else {
@@ -90,7 +90,7 @@ class ResultInjectionTests: ResultInjectionTestCase {
     func test__receiver_cancels_with_error_if_dependency_errors_2() {
         let error = TestError()
         procedure = TestProcedure(error: error)
-        printing.requireResultFrom(dependency: procedure)
+        printing.requireResult(from: procedure)
         printing.addDidCancelBlockObserver { processing, errors in
             XCTAssertEqual(errors.count, 1)
             guard let procedureKitError = errors.first as? ProcedureKitError else {
@@ -105,27 +105,27 @@ class ResultInjectionTests: ResultInjectionTestCase {
 
 
     func test__requirement_is_injected() {
-        printing.requireResultFrom(dependency: procedure)
+        printing.requireResult(from: procedure)
         wait(for: procedure, printing)
         XCTAssertEqual(printing.requirement, procedure.result ?? "not what we expect")
     }
 
     func test__receiver_cancels_with_errors_if_requirement_not_met() {
         procedure.result = nil
-        printing.requireResultFrom(dependency: procedure)
+        printing.requireResult(from: procedure)
         printing.addDidCancelBlockObserver { printing, errors in
             XCTAssertEqual(errors.count, 1)
             guard let procedureKitError = errors.first as? ProcedureKitError else {
                 XCTFail("Incorrect error received"); return
             }
-            XCTAssertEqual(procedureKitError.context, .requirementNotSatisfied)
+            XCTAssertEqual(procedureKitError.context, .dependencyFinishedWithErrors)
         }
         wait(for: printing, procedure)
         XCTAssertProcedureCancelledWithErrors(printing, count: 1)
     }
 
     func test__receiver_cancels_if_dependency_is_cancelled() {
-        processing.injectResultFrom(dependency: procedure)
+        processing.injectResult(from: procedure)
         processing.addDidCancelBlockObserver { printing, errors in
             XCTAssertEqual(errors.count, 1)
             guard let procedureKitError = errors.first as? ProcedureKitError else {


### PR DESCRIPTION
Because a lot of the result injection procedures currently necessitate the use of explicitly unwrapped optionals - it's increasingly tricky to use result injection.