### PR TITLE
Bug with how GroupProcedure manages the errors of its children.

### DIFF
--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -140,10 +140,6 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
 
     // MARK - OperationQueueDelegate
 
-    public func operationQueue(_ queue: OperationQueue, willAddOperation operation: Operation) { /* no op */ }
-
-    public func operationQueue(_ queue: OperationQueue, willFinishOperation operation: Operation) { /* no op */ }
-
     public func operationQueue(_ queue: OperationQueue, didFinishOperation operation: Operation) {
         guard queue === self.queue else { return }
 
@@ -224,6 +220,9 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
      */
     public func procedureQueue(_ queue: ProcedureQueue, willFinishOperation operation: Operation, withErrors errors: [Error]) {
         guard queue === self.queue else { return }
+
+        /// If the group is cancelled, exit early
+        guard !isCancelled else { return }
 
         /// If the operation is a Procedure.EvaluateConditions - exit early.
         if operation is Procedure.EvaluateConditions { return }

--- a/Sources/ProcedureQueue.swift
+++ b/Sources/ProcedureQueue.swift
@@ -90,8 +90,6 @@ public extension ProcedureQueueDelegate {
 
     func procedureQueue(_ queue: ProcedureQueue, willAddOperation operation: Operation) { /* default no-op */ }
 
-    func procedureQueue(_ queue: ProcedureQueue, willFinishOperation operation: Operation, withErrors errors: [Error]) { /* default no-op */ }
-
     func procedureQueue(_ queue: ProcedureQueue, willProduceOperation operation: Operation) { /* default no-op */ }
 }
 

--- a/Tests/GroupTests.swift
+++ b/Tests/GroupTests.swift
@@ -167,6 +167,11 @@ class GroupTests: GroupTestCase {
         XCTAssertTrue(group.isFinished)
     }
 
+    func test__group_cancel_with_errors_does_not_collect_errors_sent_to_children() {
+        check(procedure: group) { $0.cancel(withError: TestError()) }
+        XCTAssertProcedureCancelledWithErrors(group, count: 1)
+    }
+
     // MARK: - Finishing Tests
 
     func test__group_does_not_finish_before_all_children_finish() {

--- a/Tests/Location/ReverseGeocodeUserLocationProcedureTests.swift
+++ b/Tests/Location/ReverseGeocodeUserLocationProcedureTests.swift
@@ -46,8 +46,6 @@ class ReverseGeocodeUserLocationProcedureTests: LocationProcedureTestCase {
         manager.returnedLocation = nil
         let procedure = ReverseGeocodeUserLocationProcedure(timeout: 1).set(manager: manager).set(geocoder: geocoder)
         wait(for: procedure)
-        // There are actually 4 errors here, because the UserLocation fails with
-        // a timeout error, which then triggers cancellations
-        XCTAssertProcedureCancelledWithErrors(procedure, count: 4)
+        XCTAssertProcedureCancelledWithErrors(procedure, count: 1)
     }
 }


### PR DESCRIPTION
There is a bug in the way that `GroupProcedure` manages the errors from its children. The scenario is this:

1. The group is cancelled - possibly because of a failed condition.
2. The group's internal will cancel observer kicks in, and cancels all of its children with an error (`.parentDidCancel`).
3. The children all finish with an error
4. The group, acting as the queue's delegate, receives the finishing, and records all the errors of the children.

This makes diagnosing errors actually quite tricky as while its important that the children receive the correct error, from outside the `GroupProcedure` it is more important that these are suppressed.

So, I think all that is needed is some checks on `isCancelled` in the appropriate queue delegate methods.

- [x] Unit test which exposes the bug
- [x] Bug fix