### PR TITLE
Investigate issue with NetworkDataProcedure

### DIFF
--- a/Sources/Collection+ProcedureKit.swift
+++ b/Sources/Collection+ProcedureKit.swift
@@ -58,7 +58,7 @@ extension Collection where Iterator.Element: Operation {
 
     /**
      Add the last operation of the receiver as a dependency of each element
-     of the argument. An Array of the receiver extended by the argument is 
+     of the argument. An Array of the receiver extended by the argument is
      returned.
      - parameter operations: a variable argument of Iterator.Element instance(s) to
          add the receiver as a dependency.

--- a/Sources/Network/NetworkData.swift
+++ b/Sources/Network/NetworkData.swift
@@ -6,6 +6,11 @@
 
 import ProcedureKit
 
+/**
+ NetworkDataProcedure is a simple procedure which will perform a data task using
+ URLSession based APIs. It only supports the completion block style API, therefore
+ do not use this procedure if you wish to use delegate based APIs on URLSession.
+*/
 open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, ResultInjectionProtocol {
 
     public var requirement: URLRequest? = nil
@@ -16,8 +21,7 @@ open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, Resu
 
     internal var task: Session.DataTask? = nil
 
-    //swiftlint:disable:next force_cast
-    public init(session: Session = URLSession.shared as! Session, request: URLRequest? = nil, completionHandler: @escaping (Data, URLResponse) -> Void = { _, _ in }) {
+    public init(session: Session, request: URLRequest? = nil, completionHandler: @escaping (Data, URLResponse) -> Void = { _, _ in }) {
         self.session = session
         self.requirement = request
         self.completion = completionHandler


### PR DESCRIPTION
Possibly there is a bug here, as `URLSession` is a class cluster, so force casting the result of `URLSession.shared` will possibly not work. 