### PR TITLE
Move ProcedureKit imports to umbrella headers

### DIFF
--- a/Sources/Cloud/CloudKitCapability.swift
+++ b/Sources/Cloud/CloudKitCapability.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import ProcedureKit
-
 /**
  # Cloud Status
 

--- a/Sources/Cloud/CloudKitSupport.swift
+++ b/Sources/Cloud/CloudKitSupport.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import ProcedureKit
-
 protocol CloudKitContainerRegistrar {
 
     func pk_accountStatus(withCompletionHandler completionHandler: @escaping (CKAccountStatus, Error?) -> Void)

--- a/Sources/Location/LocationCapability.swift
+++ b/Sources/Location/LocationCapability.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import ProcedureKit
-
 public enum LocationUsage {
     case whenInUse
     case always

--- a/Sources/Location/LocationSupport.swift
+++ b/Sources/Location/LocationSupport.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import ProcedureKit
-
 struct ProcedureKitLocationComponent: ProcedureKitComponent {
     let name = "ProcedureKitLocation"
 }

--- a/Sources/Location/ReverseGeocode.swift
+++ b/Sources/Location/ReverseGeocode.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import ProcedureKit
-
 open class ReverseGeocodeProcedure: Procedure, ResultInjectionProtocol {
     public typealias CompletionBlock = (CLPlacemark) -> Void
 

--- a/Sources/Location/ReverseGeocodeUserLocation.swift
+++ b/Sources/Location/ReverseGeocodeUserLocation.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import ProcedureKit
-
 public struct UserLocationPlacemark: Equatable {
     public static func == (lhs: UserLocationPlacemark, rhs: UserLocationPlacemark) -> Bool {
         return lhs.location == rhs.location && lhs.placemark == rhs.placemark

--- a/Sources/Location/UserLocation.swift
+++ b/Sources/Location/UserLocation.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import ProcedureKit
-
 open class UserLocationProcedure: Procedure, ResultInjectionProtocol, CLLocationManagerDelegate {
     public typealias CompletionBlock = (CLLocation) -> Void
 

--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -199,7 +199,6 @@ public protocol LoggerProtocol {
     func log(message: @autoclosure () -> String, severity: LogSeverity, file: String, function: String, line: Int)
 }
 
-
 public extension LoggerProtocol {
 
     /// Access the minimum `LogSeverity` severity.

--- a/Sources/Mobile/BackgroundObserver.swift
+++ b/Sources/Mobile/BackgroundObserver.swift
@@ -4,9 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import UIKit
-import ProcedureKit
-
 internal protocol BackgroundTaskApplicationProtocol {
 
     var applicationState: UIApplicationState { get }

--- a/Sources/Mobile/NetworkObserver.swift
+++ b/Sources/Mobile/NetworkObserver.swift
@@ -4,9 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import UIKit
-import ProcedureKit
-
 protocol NetworkActivityIndicatorProtocol {
     var networkActivityIndicatorVisible: Bool { get set }
 }

--- a/Sources/Network/NetworkData.swift
+++ b/Sources/Network/NetworkData.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import ProcedureKit
-
 /**
  NetworkDataProcedure is a simple procedure which will perform a data task using
  URLSession based APIs. It only supports the completion block style API, therefore

--- a/Sources/Network/NetworkSupport.swift
+++ b/Sources/Network/NetworkSupport.swift
@@ -4,8 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import ProcedureKit
-
 // MARK: - URLSession
 
 public protocol URLSessionTaskProtocol {

--- a/Sources/Testing/QueueTestDelegate.swift
+++ b/Sources/Testing/QueueTestDelegate.swift
@@ -22,7 +22,6 @@ public class QueueTestDelegate: ProcedureQueueDelegate, OperationQueueDelegate {
     public var procedureQueueWillFinishOperation = [ProcedureQueueCheckTypeWithErrors]()
     public var procedureQueueDidFinishOperation = [ProcedureQueueCheckTypeWithErrors]()
 
-
     public func operationQueue(_ queue: OperationQueue, willAddOperation operation: Operation) {
         operationQueueWillAddOperation.append((queue, operation))
     }

--- a/Supporting Files/ProcedureKitCloud.h
+++ b/Supporting Files/ProcedureKitCloud.h
@@ -4,7 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+@import Foundation;
 @import CloudKit;
+@import ProcedureKit;
 
 //! Project version number for ProcedureKitCloud.
 FOUNDATION_EXPORT double ProcedureKitCloudVersionNumber;

--- a/Supporting Files/ProcedureKitLocation.h
+++ b/Supporting Files/ProcedureKitLocation.h
@@ -6,6 +6,8 @@
 
 @import Foundation;
 @import CoreLocation;
+@import MapKit;
+@import ProcedureKit;
 
 //! Project version number for ProcedureKitLocation.
 FOUNDATION_EXPORT double ProcedureKitLocationVersionNumber;

--- a/Supporting Files/ProcedureKitMac.h
+++ b/Supporting Files/ProcedureKitMac.h
@@ -5,6 +5,7 @@
 //
 
 @import Cocoa;
+@import ProcedureKit;
 
 //! Project version number for ProcedureKitMac.
 FOUNDATION_EXPORT double ProcedureKitMacVersionNumber;

--- a/Supporting Files/ProcedureKitMobile.h
+++ b/Supporting Files/ProcedureKitMobile.h
@@ -5,6 +5,7 @@
 //
 
 @import UIKit;
+@import ProcedureKit;
 
 //! Project version number for ProcedureKitMobile.
 FOUNDATION_EXPORT double ProcedureKitMobileVersionNumber;

--- a/Supporting Files/ProcedureKitNetwork.h
+++ b/Supporting Files/ProcedureKitNetwork.h
@@ -5,6 +5,7 @@
 //
 
 @import Foundation;
+@import ProcedureKit;
 
 //! Project version number for ProcedureKitNetwork.
 FOUNDATION_EXPORT double ProcedureKitNetworkVersionNumber;

--- a/Supporting Files/ProcedureKitTV.h
+++ b/Supporting Files/ProcedureKitTV.h
@@ -5,6 +5,7 @@
 //
 
 @import UIKit;
+@import ProcedureKit;
 
 //! Project version number for ProcedureKitTV.
 FOUNDATION_EXPORT double ProcedureKitTVVersionNumber;

--- a/Supporting Files/TestingProcedureKit.h
+++ b/Supporting Files/TestingProcedureKit.h
@@ -5,7 +5,6 @@
 //
 
 @import Foundation;
-@import ProcedureKit;
 
 //! Project version number for TestingProcedureKit.
 FOUNDATION_EXPORT double TestingProcedureKitVersionNumber;

--- a/Supporting Files/TestingProcedureKit.h
+++ b/Supporting Files/TestingProcedureKit.h
@@ -5,6 +5,7 @@
 //
 
 @import Foundation;
+@import ProcedureKit;
 
 //! Project version number for TestingProcedureKit.
 FOUNDATION_EXPORT double TestingProcedureKitVersionNumber;


### PR DESCRIPTION
This is to support subspaces with CocoaPods where all classes will get put into a single ProcedureKit module.