### PR TITLE
Generate ProcedureKit podspecs

### DIFF
--- a/ProcedureKit.podspec
+++ b/ProcedureKit.podspec
@@ -26,7 +26,7 @@ session Advanced NSOperations: https://developer.apple.com/videos/wwdc/2015/?id=
   # Defaul spec is 'Standard'
   s.default_subspec   = 'Standard'
 
-  # Creates a framework suitable for an iOS, watchOS, tvOS or macOS application
+  # Default core framework suitable for an iOS, watchOS, tvOS or macOS application
   s.subspec 'Standard' do |ss|
     ss.source_files = ['Sources']
     ss.exclude_files = [
@@ -34,11 +34,46 @@ session Advanced NSOperations: https://developer.apple.com/videos/wwdc/2015/?id=
       'Sources/Mobile',
       'Sources/Mac',
       'Sources/TV',
+      'Sources/Network',
       'Sources/Cloud',
       'Sources/Location'
     ]
   end
 
+  # TestingProcedureKit
+  s.subspec 'Testing' do |ss|
+    ss.platforms = { :ios => "8.0", :tvos => "9.2", :osx => "10.10" }  
+  	ss.dependency 'ProcedureKit/Standard'  
+  	ss.frameworks = 'XCTest'  	
+  	ss.source_files = ['Sources/Testing']
+  end
+
+  # ProcedureKitNetwork
+  s.subspec 'Network' do |ss|
+  	ss.dependency 'ProcedureKit/Standard'
+  	ss.source_files = ['Sources/Network']
+  end
+
+  # ProcedureKitLocation
+  s.subspec 'Location' do |ss|
+  	ss.dependency 'ProcedureKit/Standard'
+  	ss.frameworks = 'CoreLocation', 'MapKit'
+  	ss.source_files = ['Sources/Location']
+  end
+
+  # ProcedureKitCloud
+  s.subspec 'Cloud' do |ss|
+  	ss.dependency 'ProcedureKit/Standard'
+  	ss.frameworks = 'CloudKit'
+  	ss.source_files = ['Sources/Cloud']
+  end
+
+  # ProcedureKitMobile
+  s.subspec 'Mobile' do |ss|
+    ss.platforms = { :ios => "8.0" }
+  	ss.dependency 'ProcedureKit/Standard'
+  	ss.source_files = ['Sources/Mobile']
+  end
 end
 
 

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -149,6 +149,48 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		6532DD4B1DBC18DF00B030F5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65CFC5E51D608A1A00CAD875 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65CFC5EF1D608A5500CAD875;
+			remoteInfo = ProcedureKit;
+		};
+		6532DD4D1DBC18F800B030F5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65CFC5E51D608A1A00CAD875 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65CFC5EF1D608A5500CAD875;
+			remoteInfo = ProcedureKit;
+		};
+		6532DD4F1DBC190000B030F5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65CFC5E51D608A1A00CAD875 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65CFC5EF1D608A5500CAD875;
+			remoteInfo = ProcedureKit;
+		};
+		6532DD511DBC190600B030F5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65CFC5E51D608A1A00CAD875 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65CFC5EF1D608A5500CAD875;
+			remoteInfo = ProcedureKit;
+		};
+		6532DD531DBC190A00B030F5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65CFC5E51D608A1A00CAD875 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65CFC5EF1D608A5500CAD875;
+			remoteInfo = ProcedureKit;
+		};
+		6532DD551DBC190F00B030F5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65CFC5E51D608A1A00CAD875 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65CFC5EF1D608A5500CAD875;
+			remoteInfo = ProcedureKit;
+		};
 		653C9FCB1D6097A40070B7A2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 65CFC5E51D608A1A00CAD875 /* Project object */;
@@ -1082,6 +1124,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6532DD521DBC190600B030F5 /* PBXTargetDependency */,
 				653C9FCC1D6097A40070B7A2 /* PBXTargetDependency */,
 			);
 			name = ProcedureKitMobileTests;
@@ -1119,6 +1162,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6532DD541DBC190A00B030F5 /* PBXTargetDependency */,
 				653CA0111D609FA50070B7A2 /* PBXTargetDependency */,
 				653C9FFE1D609E660070B7A2 /* PBXTargetDependency */,
 			);
@@ -1176,6 +1220,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6532DD561DBC190F00B030F5 /* PBXTargetDependency */,
 				653CA0521D60A70F0070B7A2 /* PBXTargetDependency */,
 				653CA03B1D60A5D10070B7A2 /* PBXTargetDependency */,
 			);
@@ -1215,6 +1260,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6532DD4E1DBC18F800B030F5 /* PBXTargetDependency */,
 				653CA07A1D60ABCE0070B7A2 /* PBXTargetDependency */,
 				653CA0651D60AA990070B7A2 /* PBXTargetDependency */,
 			);
@@ -1254,6 +1300,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6532DD501DBC190000B030F5 /* PBXTargetDependency */,
 				6594844A1DAAB5340028F83B /* PBXTargetDependency */,
 				659484291DAAA2B90028F83B /* PBXTargetDependency */,
 			);
@@ -1351,6 +1398,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6532DD4C1DBC18DF00B030F5 /* PBXTargetDependency */,
 				65ECB2F81DB50B7300F96F46 /* PBXTargetDependency */,
 				65ECB2D81DB4F0C000F96F46 /* PBXTargetDependency */,
 			);
@@ -1825,6 +1873,36 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		6532DD4C1DBC18DF00B030F5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65CFC5EF1D608A5500CAD875 /* ProcedureKit */;
+			targetProxy = 6532DD4B1DBC18DF00B030F5 /* PBXContainerItemProxy */;
+		};
+		6532DD4E1DBC18F800B030F5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65CFC5EF1D608A5500CAD875 /* ProcedureKit */;
+			targetProxy = 6532DD4D1DBC18F800B030F5 /* PBXContainerItemProxy */;
+		};
+		6532DD501DBC190000B030F5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65CFC5EF1D608A5500CAD875 /* ProcedureKit */;
+			targetProxy = 6532DD4F1DBC190000B030F5 /* PBXContainerItemProxy */;
+		};
+		6532DD521DBC190600B030F5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65CFC5EF1D608A5500CAD875 /* ProcedureKit */;
+			targetProxy = 6532DD511DBC190600B030F5 /* PBXContainerItemProxy */;
+		};
+		6532DD541DBC190A00B030F5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65CFC5EF1D608A5500CAD875 /* ProcedureKit */;
+			targetProxy = 6532DD531DBC190A00B030F5 /* PBXContainerItemProxy */;
+		};
+		6532DD561DBC190F00B030F5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65CFC5EF1D608A5500CAD875 /* ProcedureKit */;
+			targetProxy = 6532DD551DBC190F00B030F5 /* PBXContainerItemProxy */;
+		};
 		653C9FCC1D6097A40070B7A2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 653C9FC01D6097A40070B7A2 /* ProcedureKitMobile */;

--- a/Sources/Cloud/CloudKitCapability.swift
+++ b/Sources/Cloud/CloudKitCapability.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import CloudKit
+
 /**
  # Cloud Status
 

--- a/Sources/Cloud/CloudKitSupport.swift
+++ b/Sources/Cloud/CloudKitSupport.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import CloudKit
+
 protocol CloudKitContainerRegistrar {
 
     func pk_accountStatus(withCompletionHandler completionHandler: @escaping (CKAccountStatus, Error?) -> Void)

--- a/Sources/Location/LocationCapability.swift
+++ b/Sources/Location/LocationCapability.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import CoreLocation
+import MapKit
+
 public enum LocationUsage {
     case whenInUse
     case always

--- a/Sources/Location/LocationSupport.swift
+++ b/Sources/Location/LocationSupport.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import CoreLocation
+import MapKit
+
 struct ProcedureKitLocationComponent: ProcedureKitComponent {
     let name = "ProcedureKitLocation"
 }

--- a/Sources/Location/ReverseGeocode.swift
+++ b/Sources/Location/ReverseGeocode.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import CoreLocation
+import MapKit
+
 open class ReverseGeocodeProcedure: Procedure, ResultInjectionProtocol {
     public typealias CompletionBlock = (CLPlacemark) -> Void
 

--- a/Sources/Location/ReverseGeocodeUserLocation.swift
+++ b/Sources/Location/ReverseGeocodeUserLocation.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import CoreLocation
+import MapKit
+
 public struct UserLocationPlacemark: Equatable {
     public static func == (lhs: UserLocationPlacemark, rhs: UserLocationPlacemark) -> Bool {
         return lhs.location == rhs.location && lhs.placemark == rhs.placemark

--- a/Sources/Location/UserLocation.swift
+++ b/Sources/Location/UserLocation.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import CoreLocation
+import MapKit
+
 open class UserLocationProcedure: Procedure, ResultInjectionProtocol, CLLocationManagerDelegate {
     public typealias CompletionBlock = (CLLocation) -> Void
 

--- a/Sources/Testing/CapabilityTestCase.swift
+++ b/Sources/Testing/CapabilityTestCase.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import XCTest
-import ProcedureKit
 
 public class TestableCapability: CapabilityProtocol {
 

--- a/Sources/Testing/GroupTestCase.swift
+++ b/Sources/Testing/GroupTestCase.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import XCTest
-import ProcedureKit
 
 open class TestGroupProcedure: GroupProcedure {
     public private(set) var didExecute = false

--- a/Sources/Testing/ProcedureKitTestCase.swift
+++ b/Sources/Testing/ProcedureKitTestCase.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import XCTest
-import ProcedureKit
 
 open class ProcedureKitTestCase: XCTestCase {
 

--- a/Sources/Testing/QueueTestDelegate.swift
+++ b/Sources/Testing/QueueTestDelegate.swift
@@ -5,7 +5,6 @@
 //
 
 import Foundation
-import ProcedureKit
 
 public class QueueTestDelegate: ProcedureQueueDelegate, OperationQueueDelegate {
 

--- a/Sources/Testing/RepeatTestCase.swift
+++ b/Sources/Testing/RepeatTestCase.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import XCTest
-import ProcedureKit
 
 open class RepeatTestCase: ProcedureKitTestCase {
     public var repeatProcedure: RepeatProcedure<TestProcedure>!

--- a/Sources/Testing/StressTestCase.swift
+++ b/Sources/Testing/StressTestCase.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import XCTest
-import ProcedureKit
 
 public class Counter {
     private(set) var _count: Int32 = 0 // swiftlint:disable:this variable_name

--- a/Sources/Testing/TestCondition.swift
+++ b/Sources/Testing/TestCondition.swift
@@ -4,9 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-import ProcedureKit
-
 open class TestCondition: Condition {
 
     let evaluate: () throws -> ConditionResult

--- a/Sources/Testing/TestProcedure.swift
+++ b/Sources/Testing/TestProcedure.swift
@@ -4,9 +4,6 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
-import ProcedureKit
-
 public struct TestError: Error, Equatable {
     public static func == (lhs: TestError, rhs: TestError) -> Bool {
         return lhs.uuid == rhs.uuid

--- a/Sources/Testing/TestableNetwork.swift
+++ b/Sources/Testing/TestableNetwork.swift
@@ -5,7 +5,6 @@
 //
 
 import XCTest
-import ProcedureKit
 
 public class TestableURLSessionTask: Equatable {
 

--- a/Sources/Testing/XCTAsserts.swift
+++ b/Sources/Testing/XCTAsserts.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import XCTest
-import ProcedureKit
 
 internal enum __XCTAssertionResult {
     case success

--- a/Supporting Files/ProcedureKitCloud.h
+++ b/Supporting Files/ProcedureKitCloud.h
@@ -5,7 +5,6 @@
 //
 
 @import Foundation;
-@import CloudKit;
 @import ProcedureKit;
 
 //! Project version number for ProcedureKitCloud.

--- a/Supporting Files/ProcedureKitLocation.h
+++ b/Supporting Files/ProcedureKitLocation.h
@@ -5,8 +5,6 @@
 //
 
 @import Foundation;
-@import CoreLocation;
-@import MapKit;
 @import ProcedureKit;
 
 //! Project version number for ProcedureKitLocation.

--- a/Supporting Files/TestingProcedureKit.h
+++ b/Supporting Files/TestingProcedureKit.h
@@ -5,6 +5,7 @@
 //
 
 @import Foundation;
+@import ProcedureKit;
 
 //! Project version number for TestingProcedureKit.
 FOUNDATION_EXPORT double TestingProcedureKitVersionNumber;

--- a/Tests/Cloud/TestableCloudKitContainer.swift
+++ b/Tests/Cloud/TestableCloudKitContainer.swift
@@ -5,6 +5,7 @@
 //
 
 import XCTest
+import CloudKit
 import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitCloud

--- a/Tests/Location/LocationCapabilityTests.swift
+++ b/Tests/Location/LocationCapabilityTests.swift
@@ -5,6 +5,8 @@
 //
 
 import XCTest
+import CoreLocation
+import MapKit
 import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitLocation

--- a/Tests/Location/ReverseGeocodeProcedureTests.swift
+++ b/Tests/Location/ReverseGeocodeProcedureTests.swift
@@ -5,6 +5,8 @@
 //
 
 import XCTest
+import CoreLocation
+import MapKit
 import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitLocation

--- a/Tests/Location/UserLocationProcedureTests.swift
+++ b/Tests/Location/UserLocationProcedureTests.swift
@@ -5,6 +5,8 @@
 //
 
 import XCTest
+import CoreLocation
+import MapKit
 import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitLocation

--- a/Tests/LoggerTests.swift
+++ b/Tests/LoggerTests.swift
@@ -5,8 +5,8 @@
 //
 
 import XCTest
-import TestingProcedureKit
 @testable import ProcedureKit
+import TestingProcedureKit
 
 class LoggingTests: ProcedureKitTestCase {
 


### PR DESCRIPTION
Need to create ~subspecs~ podspecs for the "sub modules". The way CocoaPods subspaces work, means that there is a single module for each pod, and the subspec just defines what goes in the module. This actually is a great, but it's not a compatible setup with Carthage/SPM/Manual. Because it means that code in say `ProcedureKitNetwork` will have `import ProcedureKit` inside it, which throws up a warning.

So, I think what we need is to have multiple podspecs for each framework.

- `ProcedureKit` the default
- `TestingProcedureKit`
- `ProcedureKitMobile`
- `ProcedureKitLocation`