### PR TITLE
Refactor ResultInjection - again

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -193,6 +193,13 @@
 			remoteGlobalIDString = 65CFC5EF1D608A5500CAD875;
 			remoteInfo = ProcedureKit;
 		};
+		6532DD571DBCDB3400B030F5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65CFC5E51D608A1A00CAD875 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65CFC6151D60900000CAD875;
+			remoteInfo = TestingProcedureKit;
+		};
 		653C9FCB1D6097A40070B7A2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 65CFC5E51D608A1A00CAD875 /* Project object */;
@@ -563,8 +570,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				653C9FE21D6099260070B7A2 /* TestingProcedureKit.framework in Frameworks */,
 				653C9FCA1D6097A40070B7A2 /* ProcedureKitMobile.framework in Frameworks */,
+				653C9FE21D6099260070B7A2 /* TestingProcedureKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -623,8 +630,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				653CA07B1D60ABD30070B7A2 /* TestingProcedureKit.framework in Frameworks */,
 				653CA0631D60AA990070B7A2 /* ProcedureKitCloud.framework in Frameworks */,
+				653CA07B1D60ABD30070B7A2 /* TestingProcedureKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1132,6 +1139,7 @@
 			dependencies = (
 				6532DD521DBC190600B030F5 /* PBXTargetDependency */,
 				653C9FCC1D6097A40070B7A2 /* PBXTargetDependency */,
+				6532DD581DBCDB3400B030F5 /* PBXTargetDependency */,
 			);
 			name = ProcedureKitMobileTests;
 			productName = "ProcedureKit iOSTests";
@@ -1169,8 +1177,8 @@
 			);
 			dependencies = (
 				6532DD541DBC190A00B030F5 /* PBXTargetDependency */,
-				653CA0111D609FA50070B7A2 /* PBXTargetDependency */,
 				653C9FFE1D609E660070B7A2 /* PBXTargetDependency */,
+				653CA0111D609FA50070B7A2 /* PBXTargetDependency */,
 			);
 			name = ProcedureKitTVTests;
 			productName = ProcedureKitTVTests;
@@ -1227,8 +1235,8 @@
 			);
 			dependencies = (
 				6532DD561DBC190F00B030F5 /* PBXTargetDependency */,
-				653CA0521D60A70F0070B7A2 /* PBXTargetDependency */,
 				653CA03B1D60A5D10070B7A2 /* PBXTargetDependency */,
+				653CA0521D60A70F0070B7A2 /* PBXTargetDependency */,
 			);
 			name = ProcedureKitMacTests;
 			productName = ProcedureKitMacTests;
@@ -1267,8 +1275,8 @@
 			);
 			dependencies = (
 				6532DD4E1DBC18F800B030F5 /* PBXTargetDependency */,
-				653CA07A1D60ABCE0070B7A2 /* PBXTargetDependency */,
 				653CA0651D60AA990070B7A2 /* PBXTargetDependency */,
+				653CA07A1D60ABCE0070B7A2 /* PBXTargetDependency */,
 			);
 			name = ProcedureKitCloudTests;
 			productName = ProcedureKitCloudTests;
@@ -1307,8 +1315,8 @@
 			);
 			dependencies = (
 				6532DD501DBC190000B030F5 /* PBXTargetDependency */,
-				6594844A1DAAB5340028F83B /* PBXTargetDependency */,
 				659484291DAAA2B90028F83B /* PBXTargetDependency */,
+				6594844A1DAAB5340028F83B /* PBXTargetDependency */,
 			);
 			name = ProcedureKitLocationTests;
 			productName = ProcedureKitLocationTests;
@@ -1910,6 +1918,11 @@
 			isa = PBXTargetDependency;
 			target = 65CFC5EF1D608A5500CAD875 /* ProcedureKit */;
 			targetProxy = 6532DD551DBC190F00B030F5 /* PBXContainerItemProxy */;
+		};
+		6532DD581DBCDB3400B030F5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65CFC6151D60900000CAD875 /* TestingProcedureKit */;
+			targetProxy = 6532DD571DBCDB3400B030F5 /* PBXContainerItemProxy */;
 		};
 		653C9FCC1D6097A40070B7A2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/Sources/Any.swift
+++ b/Sources/Any.swift
@@ -5,20 +5,20 @@
 //
 
 class AnyProcedureBox_<Requirement, Result>: GroupProcedure, ResultInjectionProtocol {
-    var requirement: Requirement!
-    var result: Result! { return nil }
+    var requirement: PendingValue<Requirement> = .pending
+    var result: PendingValue<Result> { return .pending }
 }
 
 class AnyProcedureBox<Base: Procedure>: AnyProcedureBox_<Base.Requirement, Base.Result> where Base: ResultInjectionProtocol {
 
     private var base: Base
 
-    public override var requirement: Base.Requirement! {
+    public override var requirement: PendingValue<Base.Requirement> {
         get { return base.requirement }
         set { base.requirement = newValue }
     }
 
-    public override var result: Base.Result! {
+    public override var result: PendingValue<Base.Result> {
         return base.result
     }
 
@@ -34,12 +34,12 @@ public class AnyProcedure<Requirement, Result>: GroupProcedure, ResultInjectionP
 
     private var erased: Erased
 
-    public var requirement: Erased.Requirement {
+    public var requirement: PendingValue<Erased.Requirement> {
         get { return erased.requirement }
         set { erased.requirement = newValue }
     }
 
-    public var result: Erased.Result {
+    public var result: PendingValue<Erased.Result> {
         return erased.result
     }
 

--- a/Sources/Any.swift
+++ b/Sources/Any.swift
@@ -4,12 +4,12 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-class AnyProcedureBox_<Requirement, Result>: GroupProcedure, ResultInjectionProtocol {
+class AnyProcedureBox_<Requirement, Result>: GroupProcedure, ResultInjection {
     var requirement: PendingValue<Requirement> = .pending
     var result: PendingValue<Result> { return .pending }
 }
 
-class AnyProcedureBox<Base: Procedure>: AnyProcedureBox_<Base.Requirement, Base.Result> where Base: ResultInjectionProtocol {
+class AnyProcedureBox<Base: Procedure>: AnyProcedureBox_<Base.Requirement, Base.Result> where Base: ResultInjection {
 
     private var base: Base
 
@@ -29,7 +29,7 @@ class AnyProcedureBox<Base: Procedure>: AnyProcedureBox_<Base.Requirement, Base.
     }
 }
 
-public class AnyProcedure<Requirement, Result>: GroupProcedure, ResultInjectionProtocol {
+public class AnyProcedure<Requirement, Result>: GroupProcedure, ResultInjection {
     private typealias Erased = AnyProcedureBox_<Requirement, Result>
 
     private var erased: Erased
@@ -43,7 +43,7 @@ public class AnyProcedure<Requirement, Result>: GroupProcedure, ResultInjectionP
         return erased.result
     }
 
-    public init<Base>(underlyingQueue: DispatchQueue? = nil, _ base: Base) where Base: Procedure, Base: ResultInjectionProtocol, Result == Base.Result, Requirement == Base.Requirement {
+    public init<Base>(underlyingQueue: DispatchQueue? = nil, _ base: Base) where Base: Procedure, Base: ResultInjection, Result == Base.Result, Requirement == Base.Requirement {
         erased = AnyProcedureBox(underlyingQueue: underlyingQueue, base: base)
         super.init(underlyingQueue: erased.underlyingQueue, operations: [erased])
         log.enabled = false

--- a/Sources/Capability.swift
+++ b/Sources/Capability.swift
@@ -162,7 +162,7 @@ public struct AnyCapability<Status: AuthorizationStatus>: CapabilityProtocol {
  A generic procedure which will get the current authorization
  status for AnyCapability<Status>.
  */
-public class GetAuthorizationStatusProcedure<Status: AuthorizationStatus>: Procedure, ResultInjectionProtocol {
+public class GetAuthorizationStatusProcedure<Status: AuthorizationStatus>: Procedure, ResultInjection {
 
     /// the StatusResponse is a tuple for the capabilities availability and status
     public typealias StatusResponse = (Bool, Status)

--- a/Sources/Capability.swift
+++ b/Sources/Capability.swift
@@ -171,7 +171,7 @@ public class GetAuthorizationStatusProcedure<Status: AuthorizationStatus>: Proce
     public typealias Completion = (StatusResponse) -> Void
 
     public typealias Requirement = Void
-    public typealias Result = StatusResponse?
+    public typealias Result = StatusResponse
 
     /**
      After the procedure has executed, this property will be set
@@ -179,9 +179,9 @@ public class GetAuthorizationStatusProcedure<Status: AuthorizationStatus>: Proce
 
      - returns: a StatusResponse
      */
-    public var result: StatusResponse? = nil
+    public var result: PendingValue<StatusResponse> = .pending
 
-    public var requirement: Requirement = ()
+    public var requirement: PendingValue<Void> = .ready(())
 
     fileprivate let capability: AnyCapability<Status>
     fileprivate let completion: Completion?
@@ -201,7 +201,7 @@ public class GetAuthorizationStatusProcedure<Status: AuthorizationStatus>: Proce
 
     public override func execute() {
         determineStatus { status in
-            self.result = status
+            self.result = .ready(status)
             self.completion?(status)
             self.finish()
         }

--- a/Sources/Collection+ProcedureKit.swift
+++ b/Sources/Collection+ProcedureKit.swift
@@ -23,7 +23,7 @@ extension Collection where Iterator.Element: Operation {
         return flatMap { $0 as? Condition }
     }
 
-    internal var userIntent: Procedure.UserIntent {
+    internal var userIntent: UserIntent {
         get {
             let (_, procedures) = operationsAndProcedures
             return procedures.map { $0.userIntent }.max { $0.rawValue < $1.rawValue } ?? .none

--- a/Sources/Filter.swift
+++ b/Sources/Filter.swift
@@ -18,7 +18,7 @@ open class FilterProcedure<Element>: ReduceProcedure<Element, Array<Element>> {
     }
 }
 
-public extension ProcedureProtocol where Self: ResultInjectionProtocol, Self.Result: Sequence {
+public extension ProcedureProtocol where Self: ResultInjection, Self.Result: Sequence {
 
     func filter(includeElement: @escaping (Result.Iterator.Element) throws -> Bool) -> FilterProcedure<Result.Iterator.Element> {
         return injectRequirement(FilterProcedure(isIncluded: includeElement))

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -322,7 +322,7 @@ public extension GroupProcedure {
     }
 
     /// Override of Procedure.userIntent
-    public override var userIntent: Procedure.UserIntent {
+    public override var userIntent: UserIntent {
         didSet {
             let (operations, procedures) = children.operationsAndProcedures
             operations.forEach { $0.setQualityOfService(fromUserIntent: userIntent) }

--- a/Sources/Location/ReverseGeocode.swift
+++ b/Sources/Location/ReverseGeocode.swift
@@ -7,7 +7,7 @@
 import CoreLocation
 import MapKit
 
-open class ReverseGeocodeProcedure: Procedure, ResultInjectionProtocol {
+open class ReverseGeocodeProcedure: Procedure, ResultInjection {
     public typealias CompletionBlock = (CLPlacemark) -> Void
 
     public var requirement: PendingValue<CLLocation> = .pending

--- a/Sources/Location/ReverseGeocodeUserLocation.swift
+++ b/Sources/Location/ReverseGeocodeUserLocation.swift
@@ -15,7 +15,7 @@ public struct UserLocationPlacemark: Equatable {
     public let placemark: CLPlacemark
 }
 
-open class ReverseGeocodeUserLocationProcedure: GroupProcedure, ResultInjectionProtocol {
+open class ReverseGeocodeUserLocationProcedure: GroupProcedure, ResultInjection {
 
     public typealias CompletionBlock = (UserLocationPlacemark) -> Void
 

--- a/Sources/Location/UserLocation.swift
+++ b/Sources/Location/UserLocation.swift
@@ -12,11 +12,12 @@ open class UserLocationProcedure: Procedure, ResultInjectionProtocol, CLLocation
 
     public let accuracy: CLLocationAccuracy
     public let completion: CompletionBlock?
-    public private(set) var location: CLLocation? = nil
 
-    public var requirement: Void = ()
-    public var result: CLLocation? {
-        return location
+    public var requirement: PendingValue<Void> = .void
+    public var result: PendingValue<CLLocation> = .pending
+
+    public var location: CLLocation? {
+        return result.value
     }
 
     internal var capability = Capability.Location()
@@ -73,14 +74,14 @@ open class UserLocationProcedure: Procedure, ResultInjectionProtocol, CLLocation
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard !isFinished, let location = locations.last else { return }
         guard shouldFinish(afterReceivingLocation: location) else {
-            self.location = location
+            result = .ready(location)
             return
         }
         log.info(message: "Updated last location: \(location)")
         DispatchQueue.main.async { [weak self] in
             guard let weakSelf = self, !weakSelf.isFinished else { return }
             weakSelf.stopLocationUpdates()
-            weakSelf.location = location
+            weakSelf.result = .ready(location)
             weakSelf.completion?(location)
             weakSelf.finish()
         }

--- a/Sources/Location/UserLocation.swift
+++ b/Sources/Location/UserLocation.swift
@@ -7,7 +7,7 @@
 import CoreLocation
 import MapKit
 
-open class UserLocationProcedure: Procedure, ResultInjectionProtocol, CLLocationManagerDelegate {
+open class UserLocationProcedure: Procedure, ResultInjection, CLLocationManagerDelegate {
     public typealias CompletionBlock = (CLLocation) -> Void
 
     public let accuracy: CLLocationAccuracy

--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -19,7 +19,7 @@ open class MapProcedure<Element, U>: ReduceProcedure<Element, Array<U>> {
     }
 }
 
-public extension ProcedureProtocol where Self: ResultInjectionProtocol, Self.Result: Sequence {
+public extension ProcedureProtocol where Self: ResultInjection, Self.Result: Sequence {
 
     func map<U>(transform: @escaping (Result.Iterator.Element) throws -> U) -> MapProcedure<Result.Iterator.Element, U> {
         return injectRequirement(MapProcedure(transform: transform))
@@ -40,7 +40,7 @@ open class FlatMapProcedure<Element, U>: ReduceProcedure<Element, Array<U>> {
     }
 }
 
-public extension ProcedureProtocol where Self: ResultInjectionProtocol, Self.Result: Sequence {
+public extension ProcedureProtocol where Self: ResultInjection, Self.Result: Sequence {
 
     func flatMap<U>(transform: @escaping (Result.Iterator.Element) throws -> U?) -> FlatMapProcedure<Result.Iterator.Element, U> {
         return injectRequirement(FlatMapProcedure(transform: transform))

--- a/Sources/Network/NetworkData.swift
+++ b/Sources/Network/NetworkData.swift
@@ -9,7 +9,7 @@
  URLSession based APIs. It only supports the completion block style API, therefore
  do not use this procedure if you wish to use delegate based APIs on URLSession.
 */
-open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, ResultInjectionProtocol {
+open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, ResultInjection {
 
     public var requirement: PendingValue<URLRequest> = .pending
     public var result: PendingValue<(Data, HTTPURLResponse)> = .pending

--- a/Sources/Network/NetworkData.swift
+++ b/Sources/Network/NetworkData.swift
@@ -11,8 +11,8 @@
 */
 open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, ResultInjectionProtocol {
 
-    public var requirement: URLRequest? = nil
-    public var result: (Data, HTTPURLResponse)? = nil
+    public var requirement: PendingValue<URLRequest> = .pending
+    public var result: PendingValue<(Data, HTTPURLResponse)> = .pending
 
     public private(set) var session: Session
     public let completion: (Data, HTTPURLResponse) -> Void
@@ -21,7 +21,7 @@ open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, Resu
 
     public init(session: Session, request: URLRequest? = nil, completionHandler: @escaping (Data, HTTPURLResponse) -> Void = { _, _ in }) {
         self.session = session
-        self.requirement = request
+        self.requirement = request.flatMap { .ready($0) } ?? .pending
         self.completion = completionHandler
         super.init()
         addWillCancelBlockObserver { procedure, _ in
@@ -30,7 +30,7 @@ open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, Resu
     }
 
     open override func execute() {
-        guard let request = requirement else {
+        guard let request = requirement.value else {
             finish(withError: ProcedureKitError.requirementNotSatisfied())
             return
         }
@@ -48,7 +48,7 @@ open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, Resu
                 return
             }
 
-            strongSelf.result = (data, response)
+            strongSelf.result = .ready((data, response))
             strongSelf.completion(data, response)
             strongSelf.finish()
         }

--- a/Sources/Network/NetworkResilience.swift
+++ b/Sources/Network/NetworkResilience.swift
@@ -53,7 +53,7 @@ public protocol ResilientNetworkBehavior {
     func retryRequest(forResponseWithStatusCode statusCode: Int, errorCode: Int?) -> Bool
 }
 
-internal class ResilientNetworkRecovery<T: Operation> where T: ResultInjectionProtocol, T.Result == (Data, HTTPURLResponse) {
+internal class ResilientNetworkRecovery<T: Operation> where T: ResultInjection, T.Result == (Data, HTTPURLResponse) {
 
     typealias ConfigurationBlock = (T) -> Void
     typealias Payload = RepeatProcedurePayload<T>
@@ -92,11 +92,11 @@ public enum ProcedureKitNetworkResiliencyError: Error {
  encapsulated by the ResilientNetworkBehavior protocol. Clients should implement this on
  a type, which it uses to initialize the procedure with.
 
- For the actual network request, this can be any operation (which conforms to ResultInjectionProtocol)
+ For the actual network request, this can be any operation (which conforms to ResultInjection)
  where the result is (Data, HTTPURLResponse)?. For example, see NetworkDataProcedure.
 
  */
-open class ResilientNetworkProcedure<T: Operation>: RetryProcedure<T> where T: ResultInjectionProtocol, T.Result == (Data, HTTPURLResponse) {
+open class ResilientNetworkProcedure<T: Operation>: RetryProcedure<T> where T: ResultInjection, T.Result == (Data, HTTPURLResponse) {
 
     internal private(set) var recovery: ResilientNetworkRecovery<T>
 
@@ -130,7 +130,7 @@ open class ResilientNetworkProcedure<T: Operation>: RetryProcedure<T> where T: R
     }
 }
 
-extension ResilientNetworkProcedure: ResultInjectionProtocol {
+extension ResilientNetworkProcedure: ResultInjection {
 
     public var requirement: PendingValue<T.Requirement> {
         get { return current.requirement }

--- a/Sources/Operation+ProcedureKit.swift
+++ b/Sources/Operation+ProcedureKit.swift
@@ -57,7 +57,7 @@ public extension Operation {
      Sets the quality of service of the Operation from `UserIntent`
      - parameter userIntent: a UserIntent value
      */
-    func setQualityOfService(fromUserIntent userIntent: Procedure.UserIntent) {
+    func setQualityOfService(fromUserIntent userIntent: UserIntent) {
         qualityOfService = userIntent.qualityOfService
     }
 

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -7,13 +7,13 @@
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length
 
-open class Procedure: Operation, ProcedureProtocol {
+internal struct ProcedureKit {
 
-    private enum FinishingFrom {
+    fileprivate enum FinishingFrom {
         case main, cancel, finish
     }
 
-    private enum State: Int, Comparable {
+    fileprivate enum State: Int, Comparable {
 
         static func < (lhs: State, rhs: State) -> Bool {
             return lhs.rawValue < rhs.rawValue
@@ -47,26 +47,31 @@ open class Procedure: Operation, ProcedureProtocol {
         }
     }
 
-    /**
-     Type to express the intent of the user in regards to executing an Operation instance
+    private init() { }
+}
 
-     - see: https://developer.apple.com/library/ios/documentation/Performance/Conceptual/EnergyGuide-iOS/PrioritizeWorkWithQoS.html#//apple_ref/doc/uid/TP40015243-CH39
-     */
-    @objc public enum UserIntent: Int {
-        case none = 0, sideEffect, initiated
+/**
+ Type to express the intent of the user in regards to executing an Operation instance
 
-        internal var qualityOfService: QualityOfService {
-            switch self {
-            case .initiated, .sideEffect:
-                return .userInitiated
-            default:
-                return .default
-            }
+ - see: https://developer.apple.com/library/ios/documentation/Performance/Conceptual/EnergyGuide-iOS/PrioritizeWorkWithQoS.html#//apple_ref/doc/uid/TP40015243-CH39
+ */
+@objc public enum UserIntent: Int {
+    case none = 0, sideEffect, initiated
+
+    internal var qualityOfService: QualityOfService {
+        switch self {
+        case .initiated, .sideEffect:
+            return .userInitiated
+        default:
+            return .default
         }
     }
+}
+
+open class Procedure: Operation, ProcedureProtocol {
 
     private var _isTransitioningToExecuting = false
-    private var _isFinishingFrom: FinishingFrom? = nil
+    private var _isFinishingFrom: ProcedureKit.FinishingFrom? = nil
     private var _isHandlingCancel = false
     private var _isCancelled = false  // should always be set by .cancel()
 
@@ -95,10 +100,10 @@ open class Procedure: Operation, ProcedureProtocol {
 
     // MARK: State
 
-    private var _state = State.initialized
+    private var _state = ProcedureKit.State.initialized
     private let _stateLock = NSRecursiveLock()
 
-    fileprivate var state: State {
+    fileprivate var state: ProcedureKit.State {
         get {
             return _stateLock.withCriticalScope { _state }
         }
@@ -184,8 +189,6 @@ open class Procedure: Operation, ProcedureProtocol {
             }
         }
     }
-
-
 
     // MARK: Observers
 
@@ -302,7 +305,7 @@ open class Procedure: Operation, ProcedureProtocol {
     public final override func main() {
 
         // Prevent concurrent execution
-        func getNextState() -> State? {
+        func getNextState() -> ProcedureKit.State? {
             return _stateLock.withCriticalScope {
 
                 // Check to see if the procedure is already attempting to execute
@@ -330,7 +333,7 @@ open class Procedure: Operation, ProcedureProtocol {
         }
 
         // Check the state again, as it could have changed in another queue via finish
-        func getNextStateAgain() -> State? {
+        func getNextStateAgain() -> ProcedureKit.State? {
             return _stateLock.withCriticalScope {
                 guard state <= .pending else { return nil }
 
@@ -474,7 +477,7 @@ open class Procedure: Operation, ProcedureProtocol {
         _finish(withErrors: errors, from: .finish)
     }
 
-    private func shouldFinish(from source: FinishingFrom) -> Bool {
+    private func shouldFinish(from source: ProcedureKit.FinishingFrom) -> Bool {
         return _stateLock.withCriticalScope {
             // Do not finish is already finishing or finished
             guard state <= .finishing else { return false }
@@ -494,7 +497,7 @@ open class Procedure: Operation, ProcedureProtocol {
         }
     }
 
-    private final func _finish(withErrors receivedErrors: [Error], from source: FinishingFrom) {
+    private final func _finish(withErrors receivedErrors: [Error], from source: ProcedureKit.FinishingFrom) {
         guard shouldFinish(from: source) else { return }
 
         // NOTE:

--- a/Sources/Reduce.swift
+++ b/Sources/Reduce.swift
@@ -4,7 +4,7 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-open class ReduceProcedure<Element, U>: Procedure, ResultInjectionProtocol {
+open class ReduceProcedure<Element, U>: Procedure, ResultInjection {
 
     public let initial: U
     public let nextPartialResult: (U, Element) throws -> U
@@ -35,9 +35,9 @@ open class ReduceProcedure<Element, U>: Procedure, ResultInjectionProtocol {
     }
 }
 
-internal extension ProcedureProtocol where Self: ResultInjectionProtocol, Self.Result: Sequence {
+internal extension ProcedureProtocol where Self: ResultInjection, Self.Result: Sequence {
 
-    func injectRequirement<P: ProcedureProtocol>(_ procedure: P) -> P where P: ResultInjectionProtocol, P.Requirement == AnySequence<Self.Result.Iterator.Element> {
+    func injectRequirement<P: ProcedureProtocol>(_ procedure: P) -> P where P: ResultInjection, P.Requirement == AnySequence<Self.Result.Iterator.Element> {
         procedure.inject(dependency: self) { procedure, dependency, errors in
             guard errors.isEmpty else {
                 procedure.cancel(withError: ProcedureKitError.dependency(finishedWithErrors: errors)); return
@@ -51,7 +51,7 @@ internal extension ProcedureProtocol where Self: ResultInjectionProtocol, Self.R
     }
 }
 
-public extension ProcedureProtocol where Self: ResultInjectionProtocol, Self.Result: Sequence {
+public extension ProcedureProtocol where Self: ResultInjection, Self.Result: Sequence {
 
     func reduce<U>(_ initial: U, nextPartialResult: @escaping (U, Result.Iterator.Element) throws -> U) -> ReduceProcedure<Result.Iterator.Element, U> {
         return injectRequirement(ReduceProcedure(initial: initial, nextPartialResult: nextPartialResult))

--- a/Sources/ResultInjection.swift
+++ b/Sources/ResultInjection.swift
@@ -15,7 +15,7 @@ public enum PendingValue<T> {
     }
 }
 
-public protocol ResultInjectionProtocol: class {
+public protocol ResultInjection: class {
 
     associatedtype Requirement
     associatedtype Result
@@ -56,9 +56,9 @@ public extension ProcedureProtocol {
     }
 }
 
-public extension ProcedureProtocol where Self: ResultInjectionProtocol {
+public extension ProcedureProtocol where Self: ResultInjection {
 
-    @discardableResult public func injectResult<Dependency: ProcedureProtocol>(from dependency: Dependency, via block: @escaping (Dependency.Result) throws -> Requirement) -> Self where Dependency: ResultInjectionProtocol {
+    @discardableResult public func injectResult<Dependency: ProcedureProtocol>(from dependency: Dependency, via block: @escaping (Dependency.Result) throws -> Requirement) -> Self where Dependency: ResultInjection {
 
         return inject(dependency: dependency) { procedure, dependency, errors in
             guard errors.isEmpty else {
@@ -76,7 +76,7 @@ public extension ProcedureProtocol where Self: ResultInjectionProtocol {
         }
     }
 
-    @discardableResult func injectResult<Dependency: ProcedureProtocol>(from dependency: Dependency) -> Self where Dependency: ResultInjectionProtocol, Dependency.Result == Requirement {
+    @discardableResult func injectResult<Dependency: ProcedureProtocol>(from dependency: Dependency) -> Self where Dependency: ResultInjection, Dependency.Result == Requirement {
         return injectResult(from: dependency, via: { $0 })
     }
 }

--- a/Sources/Testing/TestProcedure.swift
+++ b/Sources/Testing/TestProcedure.swift
@@ -17,7 +17,7 @@ public struct TestError: Error, Equatable {
     public init() { }
 }
 
-open class TestProcedure: Procedure, ResultInjectionProtocol {
+open class TestProcedure: Procedure, ResultInjection {
 
     public let delay: TimeInterval
     public let error: Error?

--- a/Sources/Testing/TestProcedure.swift
+++ b/Sources/Testing/TestProcedure.swift
@@ -22,8 +22,8 @@ open class TestProcedure: Procedure, ResultInjectionProtocol {
     public let delay: TimeInterval
     public let error: Error?
     public let producedOperation: Operation?
-    public var requirement: Void = ()
-    public var result: String? = "Hello World"
+    public var requirement: PendingValue<Void> = .void
+    public var result: PendingValue<String> = .ready("Hello World")
     public private(set) var executedAt: CFAbsoluteTime = 0
     public private(set) var didExecute = false
     public private(set) var procedureWillFinishCalled = false

--- a/Sources/Transform.swift
+++ b/Sources/Transform.swift
@@ -10,8 +10,8 @@ open class TransformProcedure<Requirement, Result>: Procedure, ResultInjectionPr
 
     private let transform: Transform
 
-    public var requirement: Requirement! = nil
-    public var result: Result? = nil
+    public var requirement: PendingValue<Requirement> = .pending
+    public var result: PendingValue<Result> = .pending
 
     public init(transform: @escaping Transform) {
         self.transform = transform
@@ -22,10 +22,10 @@ open class TransformProcedure<Requirement, Result>: Procedure, ResultInjectionPr
         var finishingError: Error? = nil
         defer { finish(withError: finishingError) }
         do {
-            guard let requirement = requirement else {
+            guard let requirement = requirement.value else {
                 throw ProcedureKitError.requirementNotSatisfied()
             }
-            result = try transform(requirement)
+            result = .ready(try transform(requirement))
         }
         catch { finishingError = error }
     }

--- a/Sources/Transform.swift
+++ b/Sources/Transform.swift
@@ -4,7 +4,7 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-open class TransformProcedure<Requirement, Result>: Procedure, ResultInjectionProtocol {
+open class TransformProcedure<Requirement, Result>: Procedure, ResultInjection {
 
     public typealias Transform = (Requirement) throws -> Result
 

--- a/Tests/AnyProcedureTests.swift
+++ b/Tests/AnyProcedureTests.swift
@@ -9,28 +9,34 @@ import TestingProcedureKit
 @testable import ProcedureKit
 
 class Foo: Procedure, ResultInjectionProtocol {
-    var requirement: String = ""
-    var result: String = "Foo"
+    var requirement: PendingValue<String> = .ready("")
+    var result: PendingValue<String> = .pending
     override func execute() {
-        result = "\(requirement)Foo"
+        if let requirement = requirement.value {
+            result = .ready("\(requirement)Foo")
+        }
         finish()
     }
 }
 
 class Bar: Procedure, ResultInjectionProtocol {
-    var requirement: String = ""
-    var result: String = "Bar"
+    var requirement: PendingValue<String> = .ready("")
+    var result: PendingValue<String> = .pending
     override func execute() {
-        result = "\(requirement)Bar"
+        if let requirement = requirement.value {
+            result = .ready("\(requirement)Bar")
+        }
         finish()
     }
 }
 
 class Baz: Procedure, ResultInjectionProtocol {
-    var requirement: String = ""
-    var result: String = "Baz"
+    var requirement: PendingValue<String> = .ready("")
+    var result: PendingValue<String> = .pending
     override func execute() {
-        result = "\(requirement)Baz"
+        if let requirement = requirement.value {
+            result = .ready("\(requirement)Baz")
+        }
         finish()
     }
 }
@@ -49,7 +55,7 @@ class AnyProcedureTests: ProcedureKitTestCase {
         wait(for: anyProcedure)
         XCTAssertProcedureFinishedWithoutErrors(procedure)
         XCTAssertProcedureFinishedWithoutErrors(anyProcedure)
-        XCTAssertEqual(anyProcedure.result, "Hello World")
+        XCTAssertEqual(anyProcedure.result.value, "Hello World")
     }
 
     func test__array_of_any_procedures() {
@@ -57,18 +63,17 @@ class AnyProcedureTests: ProcedureKitTestCase {
         let group = GroupProcedure(operations: procedures)
         wait(for: group)
         XCTAssertProcedureFinishedWithoutErrors(group)
-        XCTAssertEqual(procedures.map { $0.result }, ["Foo", "Bar", "Baz"])
-        XCTAssertEqual(procedures.map { $0.requirement }, ["", "", ""])
+        XCTAssertEqual(procedures.map { $0.result.value ?? "" }, ["Foo", "Bar", "Baz"])
     }
 
     func test__setting_requirement() {
         let foo = Foo()
         let anyProcedure = AnyProcedure(foo)
-        anyProcedure.requirement = "Hello "
+        anyProcedure.requirement = .ready("Hello ")
         wait(for: anyProcedure)
         XCTAssertProcedureFinishedWithoutErrors(foo)
         XCTAssertProcedureFinishedWithoutErrors(anyProcedure)
-        XCTAssertEqual(anyProcedure.result, "Hello Foo")
+        XCTAssertEqual(anyProcedure.result.value ?? "Not Hello Foo", "Hello Foo")
     }
 }
 

--- a/Tests/AnyProcedureTests.swift
+++ b/Tests/AnyProcedureTests.swift
@@ -8,7 +8,7 @@ import XCTest
 import TestingProcedureKit
 @testable import ProcedureKit
 
-class Foo: Procedure, ResultInjectionProtocol {
+class Foo: Procedure, ResultInjection {
     var requirement: PendingValue<String> = .ready("")
     var result: PendingValue<String> = .pending
     override func execute() {
@@ -19,7 +19,7 @@ class Foo: Procedure, ResultInjectionProtocol {
     }
 }
 
-class Bar: Procedure, ResultInjectionProtocol {
+class Bar: Procedure, ResultInjection {
     var requirement: PendingValue<String> = .ready("")
     var result: PendingValue<String> = .pending
     override func execute() {
@@ -30,7 +30,7 @@ class Bar: Procedure, ResultInjectionProtocol {
     }
 }
 
-class Baz: Procedure, ResultInjectionProtocol {
+class Baz: Procedure, ResultInjection {
     var requirement: PendingValue<String> = .ready("")
     var result: PendingValue<String> = .pending
     override func execute() {

--- a/Tests/CapabilityTests.swift
+++ b/Tests/CapabilityTests.swift
@@ -12,19 +12,19 @@ class GetAuthorizationStatusTests: TestableCapabilityTestCase {
 
     func test__sets_result() {
         wait(for: getAuthorizationStatus)
-        XCTAssertGetAuthorizationStatus(getAuthorizationStatus.result, expected: (true, .unknown))
+        XCTAssertGetAuthorizationStatus(getAuthorizationStatus.result.value, expected: (true, .unknown))
         XCTAssertTestCapabilityStatusChecked()
     }
 
     func test__async_sets_result() {
         capability.isAsynchronous = true
         wait(for: getAuthorizationStatus)
-        XCTAssertGetAuthorizationStatus(getAuthorizationStatus.result, expected: (true, .unknown))
+        XCTAssertGetAuthorizationStatus(getAuthorizationStatus.result.value, expected: (true, .unknown))
         XCTAssertTestCapabilityStatusChecked()
     }
 
     func test__runs_completion_block() {
-        var completedWithResult: GetAuthorizationStatusProcedure<TestableCapability.Status>.Result = nil
+        var completedWithResult: GetAuthorizationStatusProcedure<TestableCapability.Status>.Result = (false, .unknown)
         getAuthorizationStatus = GetAuthorizationStatusProcedure(capability) { completedWithResult = $0 }
 
         wait(for: getAuthorizationStatus)
@@ -34,7 +34,7 @@ class GetAuthorizationStatusTests: TestableCapabilityTestCase {
 
     func test__async_runs_completion_block() {
         capability.isAsynchronous = true
-        var completedWithResult: GetAuthorizationStatusProcedure<TestableCapability.Status>.Result = nil
+        var completedWithResult: GetAuthorizationStatusProcedure<TestableCapability.Status>.Result = (false, .unknown)
 
         getAuthorizationStatus = GetAuthorizationStatusProcedure(capability) { result in
             completedWithResult = result

--- a/Tests/FilterProcedureTests.swift
+++ b/Tests/FilterProcedureTests.swift
@@ -14,7 +14,7 @@ class FilterProcedureTests: ProcedureKitTestCase {
         let functional = FilterProcedure(source: [0,1,2,3,4,5,6,7]) { $0 % 2 == 0 }
         wait(for: functional)
         XCTAssertProcedureFinishedWithoutErrors(functional)
-        XCTAssertEqual(functional.result, [0,2,4,6])
+        XCTAssertEqual(functional.result.value ?? [0,1,2,3,4,5,6,7], [0,2,4,6])
     }
 
     func test__finishes_with_error_if_block_throws() {
@@ -29,7 +29,7 @@ class FilterProcedureTests: ProcedureKitTestCase {
         wait(for: numbers, functional)
         XCTAssertProcedureFinishedWithoutErrors(numbers)
         XCTAssertProcedureFinishedWithoutErrors(functional)
-        XCTAssertEqual(functional.result, [0,2,4,6,8])
+        XCTAssertEqual(functional.result.value ?? [0,1,2,3,4,5,6,7], [0,2,4,6,8])
     }
 
     func test__filter_dependency_which_finishes_with_errors() {

--- a/Tests/Location/ReverseGeocodeProcedureTests.swift
+++ b/Tests/Location/ReverseGeocodeProcedureTests.swift
@@ -43,8 +43,8 @@ class ReverseGeocodeProcedureTests: LocationProcedureTestCase {
         procedure.geocoder = geocoder
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors(procedure)
-        XCTAssertNotNil(procedure.result)
-        XCTAssertEqual(procedure.result, geocoder.placemarks?.first)
+        XCTAssertNotNil(procedure.result.value)
+        XCTAssertEqual(procedure.result.value, geocoder.placemarks?.first)
     }
 
     func test__completion_is_executed_and_receives_placemark() {

--- a/Tests/Location/UserLocationProcedureTests.swift
+++ b/Tests/Location/UserLocationProcedureTests.swift
@@ -18,7 +18,7 @@ class UserLocationProcedureTests: LocationProcedureTestCase {
         procedure.manager = manager
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors(procedure)
-        XCTAssertEqual(procedure.result, location)
+        XCTAssertEqual(procedure.result.value, location)
         XCTAssertEqual(manager.didSetDesiredAccuracy, accuracy)
         XCTAssertTrue(manager.didSetDelegate)
         XCTAssertTrue(manager.didStartUpdatingLocation)

--- a/Tests/MapProcedureTests.swift
+++ b/Tests/MapProcedureTests.swift
@@ -14,7 +14,7 @@ class MapProcedureTests: ProcedureKitTestCase {
         let functional = MapProcedure(source: [0,1,2,3,4,5,6,7]) { $0 * 2 }
         wait(for: functional)
         XCTAssertProcedureFinishedWithoutErrors(functional)
-        XCTAssertEqual(functional.result, [0,2,4,6,8,10,12,14])
+        XCTAssertEqual(functional.result.value ?? [0,1,2,3,4,5,6,7], [0,2,4,6,8,10,12,14])
     }
 
     func test__finishes_with_error_if_block_throws() {
@@ -29,7 +29,7 @@ class MapProcedureTests: ProcedureKitTestCase {
         wait(for: numbers, functional)
         XCTAssertProcedureFinishedWithoutErrors(numbers)
         XCTAssertProcedureFinishedWithoutErrors(functional)
-        XCTAssertEqual(functional.result, [0,2,4,6,8,10,12,14,16,18])
+        XCTAssertEqual(functional.result.value ?? [0,1,2,3,4,5,6,7], [0,2,4,6,8,10,12,14,16,18])
     }
 
     func test__map_dependency_which_finishes_with_errors() {
@@ -51,7 +51,7 @@ class FlatMapProcedureTests: ProcedureKitTestCase {
         }
         wait(for: functional)
         XCTAssertProcedureFinishedWithoutErrors(functional)
-        XCTAssertEqual(functional.result, [0,4,8,12,16])
+        XCTAssertEqual(functional.result.value ?? [0,1,2,3,4,5,6,7,8,9], [0,4,8,12,16])
     }
 
     func test__finishes_with_error_if_block_throws() {
@@ -69,7 +69,7 @@ class FlatMapProcedureTests: ProcedureKitTestCase {
         wait(for: numbers, functional)
         XCTAssertProcedureFinishedWithoutErrors(numbers)
         XCTAssertProcedureFinishedWithoutErrors(functional)
-        XCTAssertEqual(functional.result, [0,4,8,12,16])
+        XCTAssertEqual(functional.result.value ?? [0,1,2,3,4,5,6,7,8,9], [0,4,8,12,16])
     }
 
     func test__flat_map_dependency_which_finishes_with_errors() {

--- a/Tests/ProcedureTests.swift
+++ b/Tests/ProcedureTests.swift
@@ -95,7 +95,7 @@ class UserIntentTests: ProcedureKitTestCase {
     }
 
     func test__user_intent__equality() {
-        XCTAssertNotEqual(Procedure.UserIntent.initiated, Procedure.UserIntent.sideEffect)
+        XCTAssertNotEqual(UserIntent.initiated, UserIntent.sideEffect)
     }
 }
 

--- a/Tests/ReduceProcedureTests.swift
+++ b/Tests/ReduceProcedureTests.swift
@@ -8,7 +8,7 @@ import XCTest
 import TestingProcedureKit
 @testable import ProcedureKit
 
-class NumbersProcedure: Procedure, ResultInjectionProtocol {
+class NumbersProcedure: Procedure, ResultInjection {
 
     var requirement: PendingValue<Void> = .void
     var result: PendingValue<Array<Int>> = .ready([])

--- a/Tests/ReduceProcedureTests.swift
+++ b/Tests/ReduceProcedureTests.swift
@@ -10,8 +10,8 @@ import TestingProcedureKit
 
 class NumbersProcedure: Procedure, ResultInjectionProtocol {
 
-    var requirement: Void = ()
-    var result: Array<Int> = []
+    var requirement: PendingValue<Void> = .void
+    var result: PendingValue<Array<Int>> = .ready([])
     var error: Error? = nil
 
     init(error: Error? = nil) {
@@ -24,7 +24,7 @@ class NumbersProcedure: Procedure, ResultInjectionProtocol {
             finish(withError: error)
         }
         else {
-            result = [0, 1, 2, 3, 4, 5 , 6 , 7, 8, 9]
+            result = .ready([0, 1, 2, 3, 4, 5 , 6 , 7, 8, 9])
             finish()
         }
     }
@@ -36,7 +36,7 @@ class ReduceProcedureTests: ProcedureKitTestCase {
         let reduced = ReduceProcedure(source: [0, 1, 2, 3, 4, 5 , 6 , 7, 8, 9], initial: 0, nextPartialResult: +)
         wait(for: reduced)
         XCTAssertProcedureFinishedWithoutErrors(reduced)
-        XCTAssertEqual(reduced.result, 45)
+        XCTAssertEqual(reduced.result.value ?? 0, 45)
     }
 
     func test__finishes_with_error_if_block_throws() {
@@ -51,7 +51,7 @@ class ReduceProcedureTests: ProcedureKitTestCase {
         wait(for: numbers, reduced)
         XCTAssertProcedureFinishedWithoutErrors(numbers)
         XCTAssertProcedureFinishedWithoutErrors(reduced)
-        XCTAssertEqual(reduced.result, 45)
+        XCTAssertEqual(reduced.result.value ?? 0, 45)
     }
 
     func test__reduce_dependency_which_finishes_with_error() {

--- a/Tests/ResultInjectionTests.swift
+++ b/Tests/ResultInjectionTests.swift
@@ -8,7 +8,7 @@ import XCTest
 import TestingProcedureKit
 @testable import ProcedureKit
 
-class DataProcessing: Procedure, ResultInjectionProtocol {
+class DataProcessing: Procedure, ResultInjection {
     let result: PendingValue<Void> = .void
     var requirement: PendingValue<String> = .pending
 
@@ -22,7 +22,7 @@ class DataProcessing: Procedure, ResultInjectionProtocol {
     }
 }
 
-class Printing: Procedure, ResultInjectionProtocol {
+class Printing: Procedure, ResultInjection {
     let result: PendingValue<Void> = .void
     var requirement: PendingValue<String> = .ready("Default Requirement")
 

--- a/Tests/ResultInjectionTests.swift
+++ b/Tests/ResultInjectionTests.swift
@@ -9,11 +9,11 @@ import TestingProcedureKit
 @testable import ProcedureKit
 
 class DataProcessing: Procedure, ResultInjectionProtocol {
-    let result: Void = ()
-    var requirement: String? = nil
+    let result: PendingValue<Void> = .void
+    var requirement: PendingValue<String> = .pending
 
     override func execute() {
-        guard let output = requirement else {
+        guard let output = requirement.value else {
             finish(withError: ProcedureKitError.requirementNotSatisfied())
             return
         }
@@ -23,11 +23,13 @@ class DataProcessing: Procedure, ResultInjectionProtocol {
 }
 
 class Printing: Procedure, ResultInjectionProtocol {
-    let result: Void = ()
-    var requirement: String = "Default Requirement"
+    let result: PendingValue<Void> = .void
+    var requirement: PendingValue<String> = .ready("Default Requirement")
 
     override func execute() {
-        log.info(message: requirement)
+        if let message = requirement.value {
+            log.info(message: message)
+        }
         finish()
     }
 }
@@ -87,38 +89,15 @@ class ResultInjectionTests: ResultInjectionTestCase {
         XCTAssertProcedureCancelledWithErrors(processing, count: 1)
     }
 
-    func test__receiver_cancels_with_error_if_dependency_errors_2() {
-        let error = TestError()
-        procedure = TestProcedure(error: error)
-        printing.requireResult(from: procedure)
-        printing.addDidCancelBlockObserver { processing, errors in
-            XCTAssertEqual(errors.count, 1)
-            guard let procedureKitError = errors.first as? ProcedureKitError else {
-                XCTFail("Incorrect error received"); return
-            }
-            XCTAssertEqual(procedureKitError.context, .dependencyFinishedWithErrors)
-            XCTAssertTrue(TestError.verify(errors: procedureKitError.errors, contains: error))
-        }
-        wait(for: printing, procedure)
-        XCTAssertProcedureCancelledWithErrors(printing, count: 1)
-    }
-
-
-    func test__requirement_is_injected() {
-        printing.requireResult(from: procedure)
-        wait(for: procedure, printing)
-        XCTAssertEqual(printing.requirement, procedure.result ?? "not what we expect")
-    }
-
     func test__receiver_cancels_with_errors_if_requirement_not_met() {
-        procedure.result = nil
-        printing.requireResult(from: procedure)
+        procedure.result = .pending
+        printing.injectResult(from: procedure)
         printing.addDidCancelBlockObserver { printing, errors in
             XCTAssertEqual(errors.count, 1)
             guard let procedureKitError = errors.first as? ProcedureKitError else {
                 XCTFail("Incorrect error received"); return
             }
-            XCTAssertEqual(procedureKitError.context, .dependencyFinishedWithErrors)
+            XCTAssertEqual(procedureKitError.context, .requirementNotSatisfied)
         }
         wait(for: printing, procedure)
         XCTAssertProcedureCancelledWithErrors(printing, count: 1)

--- a/Tests/TransformProcedureTests.swift
+++ b/Tests/TransformProcedureTests.swift
@@ -12,10 +12,10 @@ class TransformProcedureTests: ProcedureKitTestCase {
 
     func test__requirement_is_transformed_to_result() {
         let timesTwo = TransformProcedure<Int, Int> { return $0 * 2 }
-        timesTwo.requirement = 2
+        timesTwo.requirement = .ready(2)
         wait(for: timesTwo)
         XCTAssertProcedureFinishedWithoutErrors(timesTwo)
-        XCTAssertEqual(timesTwo.result, 4)
+        XCTAssertEqual(timesTwo.result.value ?? 0, 4)
     }
 
     func test__requirement_is_nil_finishes_with_error() {


### PR DESCRIPTION
There is a particular issue with result injection, which is a result of Swift's initialisation strategy, which means that `requirement` and `result` often need to be explicitly unwrapped optionals.

A better way to manage this is to define a different either type, a `PendingValue` e.g.

```swift
enum PendingValue<T> {
    case pending
    case value(T)
}
```

This will allow both `requirement` and `result` properties to now be `PendingValue<T>` properties, and ultimately remove the complications of `!` all over the place. 