### PR TITLE
BlockProcedure StressTest fixes/enhancements

### DIFF
--- a/Tests/Stress Tests/BlockProcedureStressTests.swift
+++ b/Tests/Stress Tests/BlockProcedureStressTests.swift
@@ -13,10 +13,19 @@ class CancelBlockProcedureStessTests: StressTestCase {
     func test__cancel_block_procedure() {
 
         stress(level: .custom(10, 5_000)) { batch, _ in
-            batch.dispatchGroup.enter()
-            let block = BlockProcedure { }
+            batch.dispatchGroup.enter() // enter once for cancel
+            batch.dispatchGroup.enter() // enter once for finish
+            let semaphore = DispatchSemaphore(value: 0)
+            let block = BlockProcedure {
+                // prevent the BlockProcedure from finishing before it is cancelled
+                semaphore.wait()
+            }
             block.addDidCancelBlockObserver { _, _ in
-                batch.dispatchGroup.leave()
+                batch.dispatchGroup.leave() // leave once for cancel
+                semaphore.signal()
+            }
+            block.addDidFinishBlockObserver { _, _ in
+                batch.dispatchGroup.leave() // leave once for finish
             }
             batch.queue.add(operation: block)
             block.cancel()

--- a/Tests/Stress Tests/BlockProcedureStressTests.swift
+++ b/Tests/Stress Tests/BlockProcedureStressTests.swift
@@ -31,4 +31,23 @@ class CancelBlockProcedureStessTests: StressTestCase {
             block.cancel()
         }
     }
+
+    func test_cancel_or_finish_block_procedure() {
+
+        // NOTE:
+        // It is possible for a BlockProcedure to finish prior to the call to
+        // `block.cancel()` (depending on timing) and thus not all of the
+        // BlockProcedures created below may be effectively cancelled.
+        // However, all of the BlockProcedures should finish.
+
+        stress(level: .custom(10, 5_000)) { batch, _ in
+            batch.dispatchGroup.enter()
+            let block = BlockProcedure { }
+            block.addDidFinishBlockObserver { _, _ in
+                batch.dispatchGroup.leave()
+            }
+            batch.queue.add(operation: block)
+            block.cancel()
+        }
+    }
 }


### PR DESCRIPTION
**Fix `test__cancel_block_procedure()` failures:**
It was possible for the testing BlockProcedure to finish prior to the `block.cancel()` call, which would result in some of the BlockProcedures never cancelling (as they had finished first), and a failing test.
Fixed by using a semaphore inside the BlockProcedure’s block.
Additionally, the test now waits for all BlockProcedures to cancel *and* finish.

**Add a new stress test for BlockProcedure cancelling & finishing behavior:**
This test, `test_cancel_or_finish_block_procedure()`, allows for possible races between cancelling and finishing (which the previous cancellation test now does not).