### PR TITLE
Fix ExclusivityManager synchronization bug (#543)

### DIFF
--- a/Sources/MutualExclusion.swift
+++ b/Sources/MutualExclusion.swift
@@ -27,7 +27,7 @@ public class ExclusivityManager {
 
     static let sharedInstance = ExclusivityManager()
 
-    fileprivate let queue = DispatchQueue.initiated
+    fileprivate let queue = DispatchQueue(label: "run.kit.procedure.ProcedureKit.Exclusivity", qos: DispatchQoS.userInitiated) // serial dispatch queue
     fileprivate var procedures: [String: [Procedure]] = [:]
 
     private init() {


### PR DESCRIPTION
The ExclusivityManager was using `DispatchQueue.initiated`, which returns a global queue that is a **concurrent** queue, however its internals are dependent upon **serial** execution of add/remove.
Fixed to create and use a serial queue.

(Reported by @myexec in #543.)