### PR TITLE
Create a struct for NetworkDataProcedure

### DIFF
--- a/Sources/Network/NetworkSupport.swift
+++ b/Sources/Network/NetworkSupport.swift
@@ -42,3 +42,11 @@ extension URL: ExpressibleByStringLiteral {
         self.init(string: value)!
     }
 }
+
+public struct HTTPResult<Payload: Equatable>: Equatable {
+    public static func == (lhs: HTTPResult<Payload>, rhs: HTTPResult<Payload>) -> Bool {
+        return lhs.payload == rhs.payload && lhs.response == rhs.response
+    }
+    public var payload: Payload
+    public var response: HTTPURLResponse
+}

--- a/Tests/Network/NetworkDataProcedureTests.swift
+++ b/Tests/Network/NetworkDataProcedureTests.swift
@@ -55,7 +55,7 @@ class NetworkDataProcedureTests: ProcedureKitTestCase {
     }
 
     func test__no_requirement__finishes_with_error() {
-        download = NetworkDataProcedure(session: session) { _, _ in }
+        download = NetworkDataProcedure(session: session) { _ in }
         wait(for: download)
         XCTAssertProcedureFinishedWithErrors(download, count: 1)
         XCTAssertEqual(download.errors.first as? ProcedureKitError, ProcedureKitError.requirementNotSatisfied())
@@ -76,9 +76,9 @@ class NetworkDataProcedureTests: ProcedureKitTestCase {
 
     func test__completion_handler_receives_data_and_response() {
         var completionHandlerDidExecute = false
-        download = NetworkDataProcedure(session: session, request: request) { data, response in
-            XCTAssertEqual(data, self.session.returnedData)
-            XCTAssertEqual(response, self.session.returnedResponse)
+        download = NetworkDataProcedure(session: session, request: request) { result in            
+            XCTAssertEqual(result.payload, self.session.returnedData)
+            XCTAssertEqual(result.response, self.session.returnedResponse)
             completionHandlerDidExecute = true
         }
         wait(for: download)


### PR DESCRIPTION
With Swift 3.0 it's kinda annoying that tuples can no longer have labels. Grr, which means that we can't have `(data: Data, response: HTTPURLResponse)`.