### PR TITLE
Add Mutual Exclusivity concurrency testing

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		65ECB2FE1DB50BC500F96F46 /* TestingProcedureKit.framework in Copy Dependencies */ = {isa = PBXBuildFile; fileRef = 65CFC6161D60900000CAD875 /* TestingProcedureKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		65ECB3001DB50BD900F96F46 /* ProcedureKit.framework in Copy Dependencies */ = {isa = PBXBuildFile; fileRef = 65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		65ECB3011DB50BD900F96F46 /* TestingProcedureKit.framework in Copy Dependencies */ = {isa = PBXBuildFile; fileRef = 65CFC6161D60900000CAD875 /* TestingProcedureKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		EE6A68621DC0036300EAB112 /* ConcurrencyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE6A68611DC0036300EAB112 /* ConcurrencyTestCase.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -555,6 +556,7 @@
 		65ECB2ED1DB4FDE000F96F46 /* NetworkData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkData.swift; sourceTree = "<group>"; };
 		65ECB2EF1DB4FE9900F96F46 /* NetworkSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkSupport.swift; sourceTree = "<group>"; };
 		65ECB2F31DB5097500F96F46 /* NetworkDataProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkDataProcedureTests.swift; sourceTree = "<group>"; };
+		EE6A68611DC0036300EAB112 /* ConcurrencyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ConcurrencyTestCase.swift; path = Sources/Testing/ConcurrencyTestCase.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -766,6 +768,7 @@
 			isa = PBXGroup;
 			children = (
 				65A63B161DA0536200E90B9D /* CapabilityTestCase.swift */,
+				EE6A68611DC0036300EAB112 /* ConcurrencyTestCase.swift */,
 				6591B3011D74980900C2B57F /* GroupTestCase.swift */,
 				659E5FFB1D6E3BCF002B1D10 /* ProcedureKitTestCase.swift */,
 				65245D1A1D72129800340A2D /* QueueTestDelegate.swift */,
@@ -1857,6 +1860,7 @@
 				659E5FFC1D6E3BCF002B1D10 /* ProcedureKitTestCase.swift in Sources */,
 				65A63B171DA0536200E90B9D /* CapabilityTestCase.swift in Sources */,
 				65403ABA1D7C49C500D6036B /* XCTAsserts.swift in Sources */,
+				EE6A68621DC0036300EAB112 /* ConcurrencyTestCase.swift in Sources */,
 				655594F31D9E48A200B08990 /* RepeatTestCase.swift in Sources */,
 				65DFA4871DB51F60009358CE /* TestableNetwork.swift in Sources */,
 				6591B3021D74980900C2B57F /* GroupTestCase.swift in Sources */,

--- a/Sources/Testing/ConcurrencyTestCase.swift
+++ b/Sources/Testing/ConcurrencyTestCase.swift
@@ -57,7 +57,7 @@ open class ConcurrencyTestCase: ProcedureKitTestCase {
         }
     }
 
-    public func createProcedures(count: Int = 3, delayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withRegistrar registrar: Registrar) -> [TrackingProcedure] {
+    public func create(procedures count: Int = 3, delayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withRegistrar registrar: Registrar) -> [TrackingProcedure] {
         return (0..<count).map { i in
             let name = "TestConcurrencyTrackingProcedure: \(i)"
             return TestConcurrencyTrackingProcedure(name: name, microsecondsToSleep: delayMicroseconds, registrar: registrar)
@@ -76,7 +76,7 @@ open class ConcurrencyTestCase: ProcedureKitTestCase {
     public func concurrencyTest(operations: Int = 3, withDelayMicroseconds delayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withName name: String = #function, withTimeout timeout: TimeInterval = 3, withConfigureBlock configure: (TrackingProcedure) -> TrackingProcedure = { return $0 }, completionBlock completion: (TestResult) -> Void) {
 
         let registrar = Registrar()
-        let procedures = createProcedures(count: operations, delayMicroseconds: delayMicroseconds, withRegistrar: registrar).map {
+        let procedures = create(procedures: operations, delayMicroseconds: delayMicroseconds, withRegistrar: registrar).map {
             return configure($0)
         }
 
@@ -96,7 +96,7 @@ open class ConcurrencyTestCase: ProcedureKitTestCase {
                 XCTAssertTrue(i.element.isFinished, "Test procedure [\(i.offset)] did not finish")
             }
         }
-        // exact test for maxConcurrentOperationsDetectedCount
+        // exact test for registrar.maximumDetected
         if let checkExactDetected = expectations.checkExactDetected {
             XCTAssertEqual(results.registrar.maximumDetected, checkExactDetected, "maximumDetected concurrent operations (\(results.registrar.maximumDetected)) does not equal expected: \(checkExactDetected)")
         }

--- a/Sources/Testing/ConcurrencyTestCase.swift
+++ b/Sources/Testing/ConcurrencyTestCase.swift
@@ -1,0 +1,186 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+public protocol ConcurrencyTestResultProtocol {
+    var testProcedures: [TestConcurrencyTrackingProcedure] { get }
+    var duration: Double { get }
+    var concurrencyRegistrar: ConcurrencyRegistrar { get }
+}
+
+public class ConcurrencyTestResult: ConcurrencyTestResultProtocol {
+    public let testProcedures: [TestConcurrencyTrackingProcedure]
+    public let duration: Double
+    public let concurrencyRegistrar: ConcurrencyRegistrar
+    
+    public init(testProcedures: [TestConcurrencyTrackingProcedure], duration: Double, concurrencyRegistrar: ConcurrencyRegistrar) {
+        self.testProcedures = testProcedures
+        self.duration = duration
+        self.concurrencyRegistrar = concurrencyRegistrar
+    }
+}
+
+public struct ConcurrencyTestExpectations {
+    public let minConcurrentOperationsDetectedCount: Int?
+    public let maxConcurrentOperationsDetectedCount: Int?
+    public let allTestConcurrencyProceduresFinished: Bool?
+    public let minimumDurationInSeconds: Double?
+    public let exactMaxConcurrentOperationsDetectedCount: Int?
+    
+    public init(minConcurrentOperationsDetectedCount: Int? = .none, maxConcurrentOperationsDetectedCount: Int? = .none, allTestConcurrencyProceduresFinished: Bool? = .none, minimumDurationInSeconds: Double? = .none) {
+        if let minConcurrentOperationsDetectedCount = minConcurrentOperationsDetectedCount,
+            let maxConcurrentOperationsDetectedCount = maxConcurrentOperationsDetectedCount,
+            minConcurrentOperationsDetectedCount == maxConcurrentOperationsDetectedCount {
+            self.exactMaxConcurrentOperationsDetectedCount = minConcurrentOperationsDetectedCount
+        }
+        else {
+            self.exactMaxConcurrentOperationsDetectedCount = .none
+        }
+        self.minConcurrentOperationsDetectedCount = minConcurrentOperationsDetectedCount
+        self.maxConcurrentOperationsDetectedCount = maxConcurrentOperationsDetectedCount
+        self.allTestConcurrencyProceduresFinished = allTestConcurrencyProceduresFinished
+        self.minimumDurationInSeconds = minimumDurationInSeconds
+    }
+}
+
+// MARK: - ConcurrencyTestCase
+
+open class ConcurrencyTestCase: ProcedureKitTestCase {
+
+    public var concurrencyRegistrar: ConcurrencyRegistrar!
+
+    public func createTestProcedures(count: Int = 3, procedureDelayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withConcurrencyRegistrar registrar: ConcurrencyRegistrar) -> [TestConcurrencyTrackingProcedure] {
+        return (0..<count).map { i in
+            let name = "TestConcurrencyTrackingProcedure: \(i)"
+            return TestConcurrencyTrackingProcedure(name: name, microsecondsToSleep: procedureDelayMicroseconds, registrar: registrar)
+        }
+    }
+
+    public func concurrencyTest(operations: Int = 3, withProcedureDelayMicroseconds procedureDelayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withName name: String = #function, withTimeout timeout: TimeInterval = 3, withConfigureBlock configure: (TestConcurrencyTrackingProcedure) -> TestConcurrencyTrackingProcedure = { return $0 }, withExpectations expectations: ConcurrencyTestExpectations) {
+
+        concurrencyTest(operations: operations, withProcedureDelayMicroseconds: procedureDelayMicroseconds, withTimeout: timeout, withConfigureBlock: configure,
+            completionBlock: { (results) in
+                XCTAssertConcurrencyResults(results, matchExpectations: expectations)
+            }
+        )
+    }
+
+    public func concurrencyTest(operations: Int = 3, withProcedureDelayMicroseconds procedureDelayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withName name: String = #function, withTimeout timeout: TimeInterval = 3, withConfigureBlock configure: (TestConcurrencyTrackingProcedure) -> TestConcurrencyTrackingProcedure = { return $0 }, completionBlock completion: (ConcurrencyTestResult) -> Void) {
+
+        let concurrencyRegistrar = ConcurrencyRegistrar()
+        let testProcedures = createTestProcedures(count: operations, procedureDelayMicroseconds: procedureDelayMicroseconds, withConcurrencyRegistrar: concurrencyRegistrar).map {
+            return configure($0)
+        }
+
+        let startTime = CFAbsoluteTimeGetCurrent()
+        wait(forAll: testProcedures, withTimeout: timeout)
+        let endTime = CFAbsoluteTimeGetCurrent()
+        let duration = Double(endTime) - Double(startTime)
+
+        completion(ConcurrencyTestResult(testProcedures: testProcedures, duration: duration, concurrencyRegistrar: concurrencyRegistrar))
+    }
+
+    public func XCTAssertConcurrencyResults(_ results: ConcurrencyTestResultProtocol, matchExpectations expectations: ConcurrencyTestExpectations) {
+
+        // allTestConcurrencyProceduresFinished
+        if let allTestProceduresFinished = expectations.allTestConcurrencyProceduresFinished, allTestProceduresFinished {
+            for i in results.testProcedures.enumerated() {
+                XCTAssertTrue(i.element.isFinished, "Test operation [\(i.offset)] did not finish")
+            }
+        }
+        // exact test for maxConcurrentOperationsDetectedCount
+        if let exactMaxConcurrentOperationsExpected = expectations.exactMaxConcurrentOperationsDetectedCount {
+            XCTAssertEqual(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount, exactMaxConcurrentOperationsExpected, "maxConcurrentOperationsDetectedCount (\(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount)) does not equal expected: \(exactMaxConcurrentOperationsExpected)")
+        }
+        else {
+            // minConcurrentOperationsDetectedCount
+            if let minConcurrentOperationsExpected = expectations.minConcurrentOperationsDetectedCount {
+                XCTAssertGreaterThanOrEqual(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount, minConcurrentOperationsExpected, "maxConcurrentOperationsDetectedCount (\(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount)) is less than expected minimum: \(minConcurrentOperationsExpected)")
+            }
+            // maxConcurrentOperationsDetectedCount
+            if let maxConcurrentOperationsExpected = expectations.maxConcurrentOperationsDetectedCount {
+                XCTAssertLessThanOrEqual(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount, maxConcurrentOperationsExpected, "maxConcurrentOperationsDetectedCount (\(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount)) is greater than expected maximum: \(maxConcurrentOperationsExpected)")
+            }
+        }
+        // minimumDurationInSeconds
+        if let minimumDuration = expectations.minimumDurationInSeconds {
+            XCTAssertGreaterThanOrEqual(results.duration, minimumDuration, "Test duration exceeded minimum expected duration.")
+        }
+    }
+
+    open override func setUp() {
+        super.setUp()
+        concurrencyRegistrar = ConcurrencyRegistrar()
+    }
+
+    open override func tearDown() {
+        concurrencyRegistrar = nil
+        super.tearDown()
+    }
+}
+
+// MARK: - ConcurrencyRegistrar
+
+open class ConcurrencyRegistrar {
+    private let _sharedRunningOperations = Protector([Operation]())
+    private let _maxConcurrentOperationsDetectedCount = Protector(Int(0))
+    public var maxConcurrentOperationsDetectedCount: Int {
+        get {
+            return _maxConcurrentOperationsDetectedCount.read { $0 }
+        }
+    }
+    private func recordOperationsCount(_ currentOperationsCount: Int) {
+        _maxConcurrentOperationsDetectedCount.write { (ward) in
+            if currentOperationsCount > ward {
+                ward = currentOperationsCount
+            }
+        }
+    }
+    public func registerRunning(_ op: Operation) {
+        _sharedRunningOperations.write { (runningOperations) in
+            runningOperations.append(op)
+            self.recordOperationsCount(runningOperations.count)
+        }
+    }
+    public func deregisterRunning(_ op: Operation) {
+        _sharedRunningOperations.write { (runningOperations) in
+            if let foundOperation = runningOperations.index(of: op) {
+                runningOperations.remove(at: foundOperation)
+            }
+        }
+    }
+    public func atLeastOneOperationIsRunning(otherThan exception: Operation? = nil) -> Bool {
+        return _sharedRunningOperations.read { runningOperations -> Bool in
+            for op in runningOperations {
+                if op !== exception {
+                    return true
+                }
+            }
+            return false
+        }
+    }
+}
+
+// MARK: - TestConcurrencyTrackingProcedure
+
+open class TestConcurrencyTrackingProcedure: Procedure {
+    private weak var concurrencyRegistrar: ConcurrencyRegistrar?
+    private let microsecondsToSleep: useconds_t
+    init(name: String = "TestConcurrencyTrackingProcedure", microsecondsToSleep: useconds_t, registrar: ConcurrencyRegistrar) {
+        self.concurrencyRegistrar = registrar
+        self.microsecondsToSleep = microsecondsToSleep
+        super.init()
+        self.name = name
+    }
+    override open func execute() {
+        concurrencyRegistrar?.registerRunning(self)
+        usleep(microsecondsToSleep)
+        concurrencyRegistrar?.deregisterRunning(self)
+        finish()
+    }
+}

--- a/Sources/Testing/ConcurrencyTestCase.swift
+++ b/Sources/Testing/ConcurrencyTestCase.swift
@@ -8,118 +8,121 @@ import Foundation
 import XCTest
 
 public protocol ConcurrencyTestResultProtocol {
-    var testProcedures: [TestConcurrencyTrackingProcedure] { get }
+    var procedures: [TestConcurrencyTrackingProcedure] { get }
     var duration: Double { get }
-    var concurrencyRegistrar: ConcurrencyRegistrar { get }
-}
-
-public class ConcurrencyTestResult: ConcurrencyTestResultProtocol {
-    public let testProcedures: [TestConcurrencyTrackingProcedure]
-    public let duration: Double
-    public let concurrencyRegistrar: ConcurrencyRegistrar
-    
-    public init(testProcedures: [TestConcurrencyTrackingProcedure], duration: Double, concurrencyRegistrar: ConcurrencyRegistrar) {
-        self.testProcedures = testProcedures
-        self.duration = duration
-        self.concurrencyRegistrar = concurrencyRegistrar
-    }
-}
-
-public struct ConcurrencyTestExpectations {
-    public let minConcurrentOperationsDetectedCount: Int?
-    public let maxConcurrentOperationsDetectedCount: Int?
-    public let allTestConcurrencyProceduresFinished: Bool?
-    public let minimumDurationInSeconds: Double?
-    public let exactMaxConcurrentOperationsDetectedCount: Int?
-    
-    public init(minConcurrentOperationsDetectedCount: Int? = .none, maxConcurrentOperationsDetectedCount: Int? = .none, allTestConcurrencyProceduresFinished: Bool? = .none, minimumDurationInSeconds: Double? = .none) {
-        if let minConcurrentOperationsDetectedCount = minConcurrentOperationsDetectedCount,
-            let maxConcurrentOperationsDetectedCount = maxConcurrentOperationsDetectedCount,
-            minConcurrentOperationsDetectedCount == maxConcurrentOperationsDetectedCount {
-            self.exactMaxConcurrentOperationsDetectedCount = minConcurrentOperationsDetectedCount
-        }
-        else {
-            self.exactMaxConcurrentOperationsDetectedCount = .none
-        }
-        self.minConcurrentOperationsDetectedCount = minConcurrentOperationsDetectedCount
-        self.maxConcurrentOperationsDetectedCount = maxConcurrentOperationsDetectedCount
-        self.allTestConcurrencyProceduresFinished = allTestConcurrencyProceduresFinished
-        self.minimumDurationInSeconds = minimumDurationInSeconds
-    }
+    var registrar: ConcurrencyRegistrar { get }
 }
 
 // MARK: - ConcurrencyTestCase
 
 open class ConcurrencyTestCase: ProcedureKitTestCase {
 
-    public var concurrencyRegistrar: ConcurrencyRegistrar!
+    public typealias Registrar = ConcurrencyRegistrar
+    public typealias TrackingProcedure = TestConcurrencyTrackingProcedure
 
-    public func createTestProcedures(count: Int = 3, procedureDelayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withConcurrencyRegistrar registrar: ConcurrencyRegistrar) -> [TestConcurrencyTrackingProcedure] {
-        return (0..<count).map { i in
-            let name = "TestConcurrencyTrackingProcedure: \(i)"
-            return TestConcurrencyTrackingProcedure(name: name, microsecondsToSleep: procedureDelayMicroseconds, registrar: registrar)
+    public var registrar: Registrar!
+
+    public class TestResult: ConcurrencyTestResultProtocol {
+        public let procedures: [TrackingProcedure]
+        public let duration: TimeInterval
+        public let registrar: Registrar
+
+        public init(procedures: [TrackingProcedure], duration: TimeInterval, registrar: Registrar) {
+            self.procedures = procedures
+            self.duration = duration
+            self.registrar = registrar
         }
     }
 
-    public func concurrencyTest(operations: Int = 3, withProcedureDelayMicroseconds procedureDelayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withName name: String = #function, withTimeout timeout: TimeInterval = 3, withConfigureBlock configure: (TestConcurrencyTrackingProcedure) -> TestConcurrencyTrackingProcedure = { return $0 }, withExpectations expectations: ConcurrencyTestExpectations) {
+    public struct Expectations {
+        public let checkMinimumDetected: Int?
+        public let checkMaximumDetected: Int?
+        public let checkAllProceduresFinished: Bool?
+        public let checkMinimumDuration: TimeInterval?
+        public let checkExactDetected: Int?
 
-        concurrencyTest(operations: operations, withProcedureDelayMicroseconds: procedureDelayMicroseconds, withTimeout: timeout, withConfigureBlock: configure,
+        public init(checkMinimumDetected: Int? = .none, checkMaximumDetected: Int? = .none, checkAllProceduresFinished: Bool? = .none, checkMinimumDuration: TimeInterval? = .none) {
+            if let checkMinimumDetected = checkMinimumDetected,
+                let checkMaximumDetected = checkMaximumDetected,
+                checkMinimumDetected == checkMaximumDetected {
+                self.checkExactDetected = checkMinimumDetected
+            }
+            else {
+                self.checkExactDetected = .none
+            }
+            self.checkMinimumDetected = checkMinimumDetected
+            self.checkMaximumDetected = checkMaximumDetected
+            self.checkAllProceduresFinished = checkAllProceduresFinished
+            self.checkMinimumDuration = checkMinimumDuration
+        }
+    }
+
+    public func createProcedures(count: Int = 3, delayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withRegistrar registrar: Registrar) -> [TrackingProcedure] {
+        return (0..<count).map { i in
+            let name = "TestConcurrencyTrackingProcedure: \(i)"
+            return TestConcurrencyTrackingProcedure(name: name, microsecondsToSleep: delayMicroseconds, registrar: registrar)
+        }
+    }
+
+    public func concurrencyTest(operations: Int = 3, withDelayMicroseconds delayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withName name: String = #function, withTimeout timeout: TimeInterval = 3, withConfigureBlock configure: (TrackingProcedure) -> TrackingProcedure = { return $0 }, withExpectations expectations: Expectations) {
+
+        concurrencyTest(operations: operations, withDelayMicroseconds: delayMicroseconds, withTimeout: timeout, withConfigureBlock: configure,
             completionBlock: { (results) in
-                XCTAssertConcurrencyResults(results, matchExpectations: expectations)
+                XCTAssertResults(results, matchExpectations: expectations)
             }
         )
     }
 
-    public func concurrencyTest(operations: Int = 3, withProcedureDelayMicroseconds procedureDelayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withName name: String = #function, withTimeout timeout: TimeInterval = 3, withConfigureBlock configure: (TestConcurrencyTrackingProcedure) -> TestConcurrencyTrackingProcedure = { return $0 }, completionBlock completion: (ConcurrencyTestResult) -> Void) {
+    public func concurrencyTest(operations: Int = 3, withDelayMicroseconds delayMicroseconds: useconds_t = 500000 /* 0.5 seconds */, withName name: String = #function, withTimeout timeout: TimeInterval = 3, withConfigureBlock configure: (TrackingProcedure) -> TrackingProcedure = { return $0 }, completionBlock completion: (TestResult) -> Void) {
 
-        let concurrencyRegistrar = ConcurrencyRegistrar()
-        let testProcedures = createTestProcedures(count: operations, procedureDelayMicroseconds: procedureDelayMicroseconds, withConcurrencyRegistrar: concurrencyRegistrar).map {
+        let registrar = Registrar()
+        let procedures = createProcedures(count: operations, delayMicroseconds: delayMicroseconds, withRegistrar: registrar).map {
             return configure($0)
         }
 
         let startTime = CFAbsoluteTimeGetCurrent()
-        wait(forAll: testProcedures, withTimeout: timeout)
+        wait(forAll: procedures, withTimeout: timeout)
         let endTime = CFAbsoluteTimeGetCurrent()
         let duration = Double(endTime) - Double(startTime)
 
-        completion(ConcurrencyTestResult(testProcedures: testProcedures, duration: duration, concurrencyRegistrar: concurrencyRegistrar))
+        completion(TestResult(procedures: procedures, duration: duration, registrar: registrar))
     }
 
-    public func XCTAssertConcurrencyResults(_ results: ConcurrencyTestResultProtocol, matchExpectations expectations: ConcurrencyTestExpectations) {
+    public func XCTAssertResults(_ results: TestResult, matchExpectations expectations: Expectations) {
 
-        // allTestConcurrencyProceduresFinished
-        if let allTestProceduresFinished = expectations.allTestConcurrencyProceduresFinished, allTestProceduresFinished {
-            for i in results.testProcedures.enumerated() {
-                XCTAssertTrue(i.element.isFinished, "Test operation [\(i.offset)] did not finish")
+        // checkAllProceduresFinished
+        if let checkAllProceduresFinished = expectations.checkAllProceduresFinished, checkAllProceduresFinished {
+            for i in results.procedures.enumerated() {
+                XCTAssertTrue(i.element.isFinished, "Test procedure [\(i.offset)] did not finish")
             }
         }
         // exact test for maxConcurrentOperationsDetectedCount
-        if let exactMaxConcurrentOperationsExpected = expectations.exactMaxConcurrentOperationsDetectedCount {
-            XCTAssertEqual(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount, exactMaxConcurrentOperationsExpected, "maxConcurrentOperationsDetectedCount (\(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount)) does not equal expected: \(exactMaxConcurrentOperationsExpected)")
+        if let checkExactDetected = expectations.checkExactDetected {
+            XCTAssertEqual(results.registrar.maximumDetected, checkExactDetected, "maximumDetected concurrent operations (\(results.registrar.maximumDetected)) does not equal expected: \(checkExactDetected)")
         }
         else {
-            // minConcurrentOperationsDetectedCount
-            if let minConcurrentOperationsExpected = expectations.minConcurrentOperationsDetectedCount {
-                XCTAssertGreaterThanOrEqual(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount, minConcurrentOperationsExpected, "maxConcurrentOperationsDetectedCount (\(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount)) is less than expected minimum: \(minConcurrentOperationsExpected)")
+            // checkMinimumDetected
+            if let checkMinimumDetected = expectations.checkMinimumDetected {
+                XCTAssertGreaterThanOrEqual(results.registrar.maximumDetected, checkMinimumDetected, "maximumDetected concurrent operations (\(results.registrar.maximumDetected)) is less than expected minimum: \(checkMinimumDetected)")
             }
-            // maxConcurrentOperationsDetectedCount
-            if let maxConcurrentOperationsExpected = expectations.maxConcurrentOperationsDetectedCount {
-                XCTAssertLessThanOrEqual(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount, maxConcurrentOperationsExpected, "maxConcurrentOperationsDetectedCount (\(results.concurrencyRegistrar.maxConcurrentOperationsDetectedCount)) is greater than expected maximum: \(maxConcurrentOperationsExpected)")
+            // checkMaximumDetected
+            if let checkMaximumDetected = expectations.checkMaximumDetected {
+                XCTAssertLessThanOrEqual(results.registrar.maximumDetected, checkMaximumDetected, "maximumDetected concurrent operations (\(results.registrar.maximumDetected)) is greater than expected maximum: \(checkMaximumDetected)")
             }
         }
-        // minimumDurationInSeconds
-        if let minimumDuration = expectations.minimumDurationInSeconds {
-            XCTAssertGreaterThanOrEqual(results.duration, minimumDuration, "Test duration exceeded minimum expected duration.")
+        // checkMinimumDuration
+        if let checkMinimumDuration = expectations.checkMinimumDuration {
+            XCTAssertGreaterThanOrEqual(results.duration, checkMinimumDuration, "Test duration exceeded minimum expected duration.")
         }
     }
 
     open override func setUp() {
         super.setUp()
-        concurrencyRegistrar = ConcurrencyRegistrar()
+        registrar = Registrar()
     }
 
     open override func tearDown() {
-        concurrencyRegistrar = nil
+        registrar = nil
         super.tearDown()
     }
 }
@@ -127,41 +130,28 @@ open class ConcurrencyTestCase: ProcedureKitTestCase {
 // MARK: - ConcurrencyRegistrar
 
 open class ConcurrencyRegistrar {
-    private let _sharedRunningOperations = Protector([Operation]())
-    private let _maxConcurrentOperationsDetectedCount = Protector(Int(0))
-    public var maxConcurrentOperationsDetectedCount: Int {
-        get {
-            return _maxConcurrentOperationsDetectedCount.read { $0 }
-        }
+    private struct State {
+        var operations: [Operation] = []
+        var maximumDetected: Int = 0
     }
-    private func recordOperationsCount(_ currentOperationsCount: Int) {
-        _maxConcurrentOperationsDetectedCount.write { (ward) in
-            if currentOperationsCount > ward {
-                ward = currentOperationsCount
-            }
+    private let state = Protector(State())
+
+    public var maximumDetected: Int {
+        get {
+            return state.read { $0.maximumDetected }
         }
     }
     public func registerRunning(_ op: Operation) {
-        _sharedRunningOperations.write { (runningOperations) in
-            runningOperations.append(op)
-            self.recordOperationsCount(runningOperations.count)
+        state.write { ward in
+            ward.operations.append(op)
+            ward.maximumDetected = max(ward.operations.count, ward.maximumDetected)
         }
     }
     public func deregisterRunning(_ op: Operation) {
-        _sharedRunningOperations.write { (runningOperations) in
-            if let foundOperation = runningOperations.index(of: op) {
-                runningOperations.remove(at: foundOperation)
+        state.write { ward in
+            if let opIndex = ward.operations.index(of: op) {
+                ward.operations.remove(at: opIndex)
             }
-        }
-    }
-    public func atLeastOneOperationIsRunning(otherThan exception: Operation? = nil) -> Bool {
-        return _sharedRunningOperations.read { runningOperations -> Bool in
-            for op in runningOperations {
-                if op !== exception {
-                    return true
-                }
-            }
-            return false
         }
     }
 }

--- a/Tests/MutualExclusivityTests.swift
+++ b/Tests/MutualExclusivityTests.swift
@@ -145,7 +145,7 @@ class MutualExclusiveConcurrencyTests: ConcurrencyTestCase {
 
         queue.maxConcurrentOperationCount = numOperations
 
-        let procedures: [TrackingProcedure] = createProcedures(count: numOperations, delayMicroseconds: delayMicroseconds, withRegistrar: registrar).map {
+        let procedures: [TrackingProcedure] = create(procedures: numOperations, delayMicroseconds: delayMicroseconds, withRegistrar: registrar).map {
             let condition = MutuallyExclusive<TrackingProcedure>()
             $0.add(condition: condition)
             addCompletionBlockTo(procedure: $0, withExpectationDescription: "\($0.name), didFinish")


### PR DESCRIPTION
Add new ConcurrencyTestCase (and helper functionality) for concurrency testing.
Add Mutual Exclusivity concurrency testing that covers the normal cases, and also covers #543.

(The existing `test__mutually_exclusive_operation_are_run_exclusively` is not guaranteed to catch all cases because there is no guarantee that the two operations, even if scheduled to run concurrently, will actually modify the `text` var at the same time. Additionally, on failure, the test may crash instead of displaying failure information.)