### PR TITLE
CloudKit programming model question

### DIFF
--- a/Sources/Testing/ProcedureKitTestCase.swift
+++ b/Sources/Testing/ProcedureKitTestCase.swift
@@ -45,6 +45,10 @@ open class ProcedureKitTestCase: XCTestCase {
     }
 
     public func wait(for procedures: Procedure..., withTimeout timeout: TimeInterval = 3, withExpectationDescription expectationDescription: String = #function, handler: XCWaitCompletionHandler? = nil) {
+        wait(forAll: procedures, withTimeout: timeout, withExpectationDescription: expectationDescription, handler: handler)
+    }
+
+    public func wait(forAll procedures: [Procedure], withTimeout timeout: TimeInterval = 3, withExpectationDescription expectationDescription: String = #function, handler: XCWaitCompletionHandler? = nil) {
         for (i, procedure) in procedures.enumerated() {
             addCompletionBlockTo(procedure: procedure, withExpectationDescription: "\(i), \(expectationDescription)")
         }


### PR DESCRIPTION
My Swift 3 app is heavily using CloudKit. Based on beta 3 I tried to migrate the CloudKit fetches at app launch to ProcedureKit. I wrapped each of those fetches in a BlockOperation and run them as part of a group procedure. However due to the asynchronous nature of CloudKit those fetches are kicked of to CloudKit and return immediately triggering the group procedure finished observer. Problem is that the fetched results delivered by CloudKit arrive after that. I was thinking that I would need to add something like a lock to the group procedure that the results block would then remove. Only after all block operations are executed and all locks are removed the finish observer would run. 

I just don't understand yet how I would build such a lock with ProcedureKit? Or should i rather wait for CloudKitProcedure in beta 4? And if so, how would I then approach this problem?