### PR TITLE
Fix mistake in Fastfile

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -115,12 +115,6 @@ platform :ios do
       destination: "platform=iOS Simulator,OS=10.0,name=iPhone 6s"
     )
 
-    scan(
-      project: "ProcedureKit.xcodeproj",
-      scheme: "ProcedureKitLocation",
-      destination: "platform=iOS Simulator,OS=10.0,name=iPhone 6s"
-    )
-
   end
 
   desc "ProcedureKitLocation: tvOS"

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -111,7 +111,7 @@ platform :ios do
 
     scan(
       project: "ProcedureKit.xcodeproj",
-      scheme: "ProcedureKitMobile",
+      scheme: "ProcedureKitLocation",
       destination: "platform=iOS Simulator,OS=10.0,name=iPhone 6s"
     )
 


### PR DESCRIPTION
The `Location (iOS)` CI job, actually runs the `Mobile (iOS)` scheme. Whoops.