### PR TITLE
Fix Condition to support ResultInjection

### DIFF
--- a/Sources/Condition.swift
+++ b/Sources/Condition.swift
@@ -47,6 +47,25 @@ internal extension ConditionProtocol {
 
 public extension ProcedureKitError {
 
+    public struct FailedConditions: Error {
+        public let errors: [Error]
+
+        internal init(errors: [Error]) {
+            self.errors = errors
+        }
+
+        internal func append(error: Error) -> FailedConditions {
+            var errors = self.errors
+            if let failedConditions = error as? FailedConditions {
+                errors.append(contentsOf: failedConditions.errors)
+            }
+            else {
+                errors.append(error)
+            }
+            return FailedConditions(errors: errors)
+        }
+    }
+
     public struct FalseCondition: Error {
         internal init() { }
     }

--- a/Sources/Condition.swift
+++ b/Sources/Condition.swift
@@ -83,6 +83,8 @@ open class Condition: Procedure, ConditionProtocol {
         }
     }
 
+    public typealias Result = ConditionResult
+
     public var result: PendingValue<ConditionResult> = .pending
 
     open override func execute() {

--- a/Sources/NegatedCondition.swift
+++ b/Sources/NegatedCondition.swift
@@ -16,7 +16,6 @@ public final class NegatedCondition<C: Condition>: ComposedCondition<C> {
     public override func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {
         super.evaluate(procedure: procedure) { composedResult in
             switch composedResult {
-            case .pending: completion(.pending)
             case .satisfied:
                 completion(.failed(ProcedureKitError.conditionFailed()))
             case .ignored(_), .failed(_):

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -603,15 +603,15 @@ extension Procedure {
             case (_, .pending):
                 if errors.isEmpty { return self }
                 else { return .failed(errors) }
-            case let (_, .failed(conditionError)):
+            case let (_, .ready(.failed(conditionError))):
                 var errors = self.errors
                 errors.append(conditionError)
                 return .failed(errors)
             case (.failed(_), _):
                 return self
-            case (_, .ignored):
+            case (_, .ready(.ignored)):
                 return .ignored
-            case (.pending, .satisfied):
+            case (.pending, .ready(.satisfied)):
                 return .satisfied
             default:
                 return self

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -595,8 +595,8 @@ internal extension ConditionResult {
             assertionFailure("A pending ConditionResult cannot be void.")
             return .failed(ProcedureKitError.programmingError(reason: "A pending ConditionResult cannot be void."))
         case (_, .pending):
-            assertionFailure("Cannot evaluate a ConditionResult that is still pending.")
-            return .failed(ProcedureKitError.programmingError(reason: "Cannot evaluate a ConditionResult that is still pending."))
+            // other condition has been cancelled so, it is effectively ignored.
+            return self
         case let (_, .ready(result)):
             return evaluate(result: result)
         }

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -587,60 +587,73 @@ public extension Procedure {
 
 // MARK: Conditions
 
-extension Procedure {
+internal extension ConditionResult {
 
-    enum ConditionEvaluation {
-        case pending, satisfied, ignored
-        case failed([Error])
-
-        var errors: [Error] {
-            guard case let .failed(errors) = self else { return [] }
-            return errors
-        }
-
-        func evaluate(condition: Condition, withErrors errors: [Error]) -> ConditionEvaluation {
-            switch  (self, condition.result) {
-            case (_, .pending):
-                if errors.isEmpty { return self }
-                else { return .failed(errors) }
-            case let (_, .ready(.failed(conditionError))):
-                var errors = self.errors
-                errors.append(conditionError)
-                return .failed(errors)
-            case (.failed(_), _):
-                return self
-            case (_, .ready(.ignored)):
-                return .ignored
-            case (.pending, .ready(.satisfied)):
-                return .satisfied
-            default:
-                return self
-            }
+    func evaluate(result: PendingValue<ConditionResult>) -> ConditionResult {
+        switch (self, result) {
+        case (_, .void):
+            assertionFailure("A pending ConditionResult cannot be void.")
+            return .failed(ProcedureKitError.programmingError(reason: "A pending ConditionResult cannot be void."))
+        case (_, .pending):
+            assertionFailure("Cannot evaluate a ConditionResult that is still pending.")
+            return .failed(ProcedureKitError.programmingError(reason: "Cannot evaluate a ConditionResult that is still pending."))
+        case let (_, .ready(result)):
+            return evaluate(result: result)
         }
     }
 
-    class EvaluateConditions: GroupProcedure {
-        var requirement: [Condition] = []
-        var result: ConditionEvaluation = .pending
+    func evaluate(result: ConditionResult) -> ConditionResult {
+        switch (self, result) {
+        case let (.failed(error), .failed(anotherError)):
+            if let error = error as? ProcedureKitError.FailedConditions {
+                return .failed(error.append(error: anotherError))
+            }
+            else if let anotherError = anotherError as? ProcedureKitError.FailedConditions {
+                return .failed(anotherError.append(error: error))
+            }
+            else {
+                return .failed(ProcedureKitError.FailedConditions(errors: [error, anotherError]))
+            }
+        case (_, .failed(_)):
+            return result
+        case (.ignored, _):
+            return result
+        default:
+            return self
+        }
+    }
+}
+
+extension Procedure {
+
+    class EvaluateConditions: GroupProcedure, ResultInjection {
+        var requirement: PendingValue<[Condition]> = .pending
+        var result: PendingValue<ConditionResult> = .pending
 
         init(conditions: Set<Condition>) {
             let ops = Array(conditions)
-            requirement = ops
+            requirement = .ready(ops)
             super.init(operations: ops)
         }
 
         override func procedureWillFinish(withErrors errors: [Error]) {
-            process(withErrors: errors)
+            result = .ready(process(withErrors: errors))
         }
 
         override func procedureWillCancel(withErrors errors: [Error]) {
-            process(withErrors: errors)
+            result = .ready(process(withErrors: errors))
         }
 
-        private func process(withErrors errors: [Error]) {
-            result = requirement.reduce(.pending) { evaluation, condition in
-                log.verbose(message: "evaluating \(evaluation) with \(condition.result)")
-                return evaluation.evaluate(condition: condition, withErrors: errors)
+        private func process(withErrors errors: [Error]) -> ConditionResult {
+            guard errors.isEmpty else {
+                return .failed(ProcedureKitError.FailedConditions(errors: errors))
+            }
+            guard let conditions = requirement.value else {
+                fatalError("Conditions must be set before the evaluation is performed.")
+            }
+            return conditions.reduce(.ignored) { result, condition in
+                log.verbose(message: "evaluating \(result) with \(condition.result)")
+                return result.evaluate(result: condition.result)
             }
         }
     }
@@ -669,13 +682,20 @@ extension Procedure {
 
         // Add an observer to the evaluator to see if any of the conditions failed.
         evaluator.addWillFinishBlockObserver { [weak self] evaluator, _ in
-            switch evaluator.result {
-            case .pending, .satisfied:
+            guard let result = evaluator.result.value else { return }
+
+            switch result {
+            case .satisfied:
                 break
             case .ignored:
                 self?.cancel()
-            case let .failed(errors):
-                self?.cancel(withErrors: errors)
+            case let .failed(error):
+                if let failedConditions = error as? ProcedureKitError.FailedConditions {
+                    self?.cancel(withErrors: failedConditions.errors)
+                }
+                else {
+                    self?.cancel(withError: error)
+                }
             }
         }
 

--- a/Tests/CapabilityTests.swift
+++ b/Tests/CapabilityTests.swift
@@ -83,14 +83,14 @@ class AuthorizedForTests: TestableCapabilityTestCase {
     func test__fails_if_capability_is_not_available() {
         capability.serviceIsAvailable = false
         wait(for: procedure)
-        XCTAssertConditionResult(authorizedFor.result, failedWithError: ProcedureKitError.capabilityUnavailable())
+        XCTAssertConditionResult(authorizedFor.result.value ?? .satisfied, failedWithError: ProcedureKitError.capabilityUnavailable())
     }
 
     func test__async_fails_if_capability_is_not_available() {
         capability.isAsynchronous = true
         capability.serviceIsAvailable = false
         wait(for: procedure)
-        XCTAssertConditionResult(authorizedFor.result, failedWithError: ProcedureKitError.capabilityUnavailable())
+        XCTAssertConditionResult(authorizedFor.result.value ?? .satisfied, failedWithError: ProcedureKitError.capabilityUnavailable())
     }
 
     func test__fails_if_requirement_is_not_met() {
@@ -98,7 +98,7 @@ class AuthorizedForTests: TestableCapabilityTestCase {
         capability.responseAuthorizationStatus = .minimumAuthorized
 
         wait(for: procedure)
-        XCTAssertConditionResult(authorizedFor.result, failedWithError: ProcedureKitError.capabilityUnauthorized())
+        XCTAssertConditionResult(authorizedFor.result.value ?? .satisfied, failedWithError: ProcedureKitError.capabilityUnauthorized())
     }
 
     func test__async_fails_if_requirement_is_not_met() {
@@ -107,18 +107,18 @@ class AuthorizedForTests: TestableCapabilityTestCase {
         capability.responseAuthorizationStatus = .minimumAuthorized
 
         wait(for: procedure)
-        XCTAssertConditionResult(authorizedFor.result, failedWithError: ProcedureKitError.capabilityUnauthorized())
+        XCTAssertConditionResult(authorizedFor.result.value ?? .satisfied, failedWithError: ProcedureKitError.capabilityUnauthorized())
     }
 
     func test__suceeds_if_requirement_is_met() {
         wait(for: procedure)
-        XCTAssertConditionResultSatisfied(authorizedFor.result)
+        XCTAssertConditionResultSatisfied(authorizedFor.result.value ?? .ignored)
     }
 
     func test__async_suceeds_if_requirement_is_met() {
         capability.isAsynchronous = true
         wait(for: procedure)
-        XCTAssertConditionResultSatisfied(authorizedFor.result)
+        XCTAssertConditionResultSatisfied(authorizedFor.result.value ?? .ignored)
     }
 
 }

--- a/Tests/ConditionTests.swift
+++ b/Tests/ConditionTests.swift
@@ -204,7 +204,6 @@ class ConditionTests: ProcedureKitTestCase {
 
     func test__ignored_failing_condition_does_not_result_in_failure() {
         let procedure1 = TestProcedure(name: "Procedure 1")
-        procedure1.log.severity = .verbose
         procedure1.add(condition: IgnoredCondition(FalseCondition()))
 
         let procedure2 = TestProcedure(name: "Procedure 2")

--- a/Tests/ConditionTests.swift
+++ b/Tests/ConditionTests.swift
@@ -204,6 +204,7 @@ class ConditionTests: ProcedureKitTestCase {
 
     func test__ignored_failing_condition_does_not_result_in_failure() {
         let procedure1 = TestProcedure(name: "Procedure 1")
+        procedure1.log.severity = .verbose
         procedure1.add(condition: IgnoredCondition(FalseCondition()))
 
         let procedure2 = TestProcedure(name: "Procedure 2")


### PR DESCRIPTION
At the moment, `Condition` has a result property, which is not a `PendingValue<T>`. Subclasses cannot therefore conform to `ResultInjection`.