### PR TITLE
Add NetworkUploadProcedure.

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0B15EDE91DCA0AFE0060D2D7 /* NetworkUpload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B15EDE71DCA07CB0060D2D7 /* NetworkUpload.swift */; };
+		0B15EDEC1DCA147C0060D2D7 /* NetworkUploadProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B15EDEA1DCA13810060D2D7 /* NetworkUploadProcedureTests.swift */; };
 		0B795A8C1DC9E52F00E03CE8 /* NetworkDownload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B795A8B1DC9E52F00E03CE8 /* NetworkDownload.swift */; };
 		0B795A8F1DC9EE6D00E03CE8 /* NetworkDownloadProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B795A8D1DC9EE2E00E03CE8 /* NetworkDownloadProcedureTests.swift */; };
 		650182C91D8916EC0052CE90 /* DelayProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650182C81D8916EC0052CE90 /* DelayProcedureTests.swift */; };
@@ -420,6 +422,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0B15EDE71DCA07CB0060D2D7 /* NetworkUpload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkUpload.swift; sourceTree = "<group>"; };
+		0B15EDEA1DCA13810060D2D7 /* NetworkUploadProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkUploadProcedureTests.swift; sourceTree = "<group>"; };
 		0B795A8B1DC9E52F00E03CE8 /* NetworkDownload.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkDownload.swift; sourceTree = "<group>"; };
 		0B795A8D1DC9EE2E00E03CE8 /* NetworkDownloadProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkDownloadProcedureTests.swift; sourceTree = "<group>"; };
 		650182C81D8916EC0052CE90 /* DelayProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DelayProcedureTests.swift; path = Tests/DelayProcedureTests.swift; sourceTree = "<group>"; };
@@ -1027,6 +1031,7 @@
 			children = (
 				65ECB2ED1DB4FDE000F96F46 /* NetworkData.swift */,
 				0B795A8B1DC9E52F00E03CE8 /* NetworkDownload.swift */,
+				0B15EDE71DCA07CB0060D2D7 /* NetworkUpload.swift */,
 				65ECB2EF1DB4FE9900F96F46 /* NetworkSupport.swift */,
 				65DFA4A61DBB9EEA009358CE /* NetworkResilience.swift */,
 			);
@@ -1042,6 +1047,7 @@
 				65ECB2E61DB4F16E00F96F46 /* ProcedureKitNetworkTests.swift */,
 				65DFA4A81DBBC0B0009358CE /* ResilientNetworkProcedureTests.swift */,
 				65DFA4841DB514DD009358CE /* URLTests.swift */,
+				0B15EDEA1DCA13810060D2D7 /* NetworkUploadProcedureTests.swift */,
 			);
 			name = "Network Tests";
 			path = Tests/Network;
@@ -1883,6 +1889,7 @@
 			files = (
 				0B795A8C1DC9E52F00E03CE8 /* NetworkDownload.swift in Sources */,
 				65ECB2F01DB4FE9900F96F46 /* NetworkSupport.swift in Sources */,
+				0B15EDE91DCA0AFE0060D2D7 /* NetworkUpload.swift in Sources */,
 				65DFA4A71DBB9EEA009358CE /* NetworkResilience.swift in Sources */,
 				65ECB2EE1DB4FDE000F96F46 /* NetworkData.swift in Sources */,
 			);
@@ -1897,6 +1904,7 @@
 				0B795A8F1DC9EE6D00E03CE8 /* NetworkDownloadProcedureTests.swift in Sources */,
 				65ECB2E71DB4F16E00F96F46 /* ProcedureKitNetworkTests.swift in Sources */,
 				65DFA4851DB514DD009358CE /* URLTests.swift in Sources */,
+				0B15EDEC1DCA147C0060D2D7 /* NetworkUploadProcedureTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Network/NetworkSupport.swift
+++ b/Sources/Network/NetworkSupport.swift
@@ -13,19 +13,25 @@ public protocol URLSessionTaskProtocol {
 
 public protocol URLSessionDataTaskProtocol: URLSessionTaskProtocol { }
 public protocol URLSessionDownloadTaskProtocol: URLSessionTaskProtocol { }
+public protocol URLSessionUploadTaskProtocol: URLSessionTaskProtocol { }
 
 public protocol URLSessionTaskFactory {
     associatedtype DataTask: URLSessionDataTaskProtocol
     associatedtype DownloadTask: URLSessionDownloadTaskProtocol
+    associatedtype UploadTask: URLSessionUploadTaskProtocol
 
     func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> DataTask
 
     func downloadTask(with request: URLRequest, completionHandler: @escaping (URL?, URLResponse?, Error?) -> Void) -> DownloadTask
+
+    func uploadTask(with request: URLRequest, from bodyData: Data?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> UploadTask
 }
 
 extension URLSessionTask: URLSessionTaskProtocol { }
 extension URLSessionDataTask: URLSessionDataTaskProtocol {}
-extension URLSessionDownloadTask: URLSessionDownloadTaskProtocol {}
+extension URLSessionDownloadTask: URLSessionDownloadTaskProtocol { }
+extension URLSessionUploadTask: URLSessionUploadTaskProtocol { }
+
 extension URLSession: URLSessionTaskFactory { }
 
 extension URL: ExpressibleByStringLiteral {

--- a/Sources/Network/NetworkSupport.swift
+++ b/Sources/Network/NetworkSupport.swift
@@ -56,3 +56,11 @@ public struct HTTPResult<Payload: Equatable>: Equatable {
     public var payload: Payload
     public var response: HTTPURLResponse
 }
+
+public struct HTTPRequirement<Payload: Equatable>: Equatable {
+    public static func == (lhs: HTTPRequirement <Payload>, rhs: HTTPRequirement <Payload>) -> Bool {
+        return lhs.payload == rhs.payload && lhs.request == rhs.request
+    }
+    public var payload: Payload?
+    public var request: URLRequest
+}

--- a/Sources/Network/NetworkUpload.swift
+++ b/Sources/Network/NetworkUpload.swift
@@ -1,0 +1,71 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+/**
+ NetworkUploadProcedure is a simple procedure which will perform a upload task using
+ URLSession based APIs. It only supports the completion block style API, therefore
+ do not use this procedure if you wish to use delegate based APIs on URLSession.
+ */
+open class NetworkUploadProcedure<Session: URLSessionTaskFactory>: Procedure, ResultInjection {
+
+    public var requirement: PendingValue<(request: URLRequest, data: Data)>
+    public var result: PendingValue<HTTPResult<Data>> = .pending
+
+    public private(set) var session: Session
+    public let completion: (HTTPResult<Data>) -> Void
+
+    internal var task: Session.UploadTask? = nil
+
+    public init(session: Session, request: URLRequest? = nil, data: Data? = nil, completionHandler: @escaping (HTTPResult<Data>) -> Void = { _ in }) {
+
+        self.session = session
+
+        if let request = request, let data = data {
+            self.requirement = .ready((request: request, data: data))
+        } else {
+            self.requirement = .pending
+        }
+
+        self.completion = completionHandler
+
+        super.init()
+        addWillCancelBlockObserver { procedure, _ in
+            procedure.task?.cancel()
+        }
+
+    }
+
+    open override func execute() {
+        guard let tuple = requirement.value else {
+            finish(withError: ProcedureKitError.requirementNotSatisfied())
+            return
+        }
+
+        task = session.uploadTask(with: tuple.request, from: tuple.data) { [weak self] data, response, error in
+              guard let strongSelf = self else { return }
+
+
+            if let error = error {
+                strongSelf.finish(withError: error)
+                return
+            }
+
+            guard let data = data, let response = response as? HTTPURLResponse else {
+                strongSelf.finish(withError: ProcedureKitError.unknown)
+                return
+            }
+
+            let http = HTTPResult(payload: data, response: response)
+
+            strongSelf.result = .ready(http)
+            strongSelf.completion(http)
+            strongSelf.finish()
+        }
+
+        task?.resume()
+    }
+
+}

--- a/Sources/Testing/TestableNetwork.swift
+++ b/Sources/Testing/TestableNetwork.swift
@@ -48,6 +48,10 @@ public class TestableURLSessionTaskFactory {
     public var didReturnDownloadTask: TestableURLSessionTask? = nil
     public var returnedURL: URL? = URL(fileURLWithPath: "/var/tmp/hello/this/is/a/test/url")
 
+    // Upload
+    public var didReceiveUploadRequest: URLRequest? = nil
+    public var didReturnUploadTask: TestableURLSessionTask? = nil
+
     public init() { }
 
     public func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> TestableURLSessionTask {
@@ -69,6 +73,18 @@ public class TestableURLSessionTaskFactory {
             }
         }
         didReturnDownloadTask = task
+        return task
+    }
+
+    public func uploadTask(with request: URLRequest, from bodyData: Data?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> TestableURLSessionTask {
+
+        didReceiveUploadRequest = request
+        let task = TestableURLSessionTask {
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.delay) {
+                completionHandler(self.returnedData, self.returnedResponse, self.returnedError)
+            }
+        }
+        didReturnUploadTask = task
         return task
     }
 }

--- a/Tests/Network/NetworkUploadProcedureTests.swift
+++ b/Tests/Network/NetworkUploadProcedureTests.swift
@@ -1,0 +1,93 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+import ProcedureKit
+import TestingProcedureKit
+@testable import ProcedureKitNetwork
+
+class NetworkUploadProcedureTests: ProcedureKitTestCase {
+    
+    var url: URL!
+    var request: URLRequest!
+    var sendingData: Data!
+    var session: TestableURLSessionTaskFactory!
+    var upload: NetworkUploadProcedure<TestableURLSessionTaskFactory>!
+
+    override func setUp() {
+        super.setUp()
+        url = "http://procedure.kit.run"
+        sendingData = "hello world".data(using: .utf8)
+
+        request = URLRequest(url: url)
+        session = TestableURLSessionTaskFactory()
+        upload = NetworkUploadProcedure(session: session, request: request, data: sendingData)
+    }
+
+    func test__session_receives_request() {
+        wait(for: upload)
+        XCTAssertProcedureFinishedWithoutErrors(upload)
+        XCTAssertEqual(session.didReceiveUploadRequest?.url, url)
+    }
+
+    func test__session_creates_upload_task() {
+        wait(for: upload)
+        XCTAssertProcedureFinishedWithoutErrors(upload)
+        XCTAssertNotNil(session.didReturnUploadTask)
+        XCTAssertEqual(session.didReturnUploadTask, upload.task)
+    }
+
+    func test__upload_resumes_data_task() {
+        wait(for: upload)
+        XCTAssertProcedureFinishedWithoutErrors(upload)
+        XCTAssertTrue(session.didReturnUploadTask?.didResume ?? false)
+    }
+
+
+    func test__upload_cancels_data_task_is_cancelled() {
+        session.delay = 2.0
+        let delay = DelayProcedure(by: 0.1)
+        delay.addDidFinishBlockObserver { _ in
+            self.upload.cancel()
+        }
+        wait(for: upload, delay)
+        XCTAssertProcedureCancelledWithoutErrors(upload)
+        XCTAssertTrue(session.didReturnUploadTask?.didCancel ?? false)
+    }
+
+    func test__no_requirement__finishes_with_error() {
+        upload = NetworkUploadProcedure(session: session) { _ in }
+        wait(for: upload)
+        XCTAssertProcedureFinishedWithErrors(upload, count: 1)
+        XCTAssertEqual(upload.errors.first as? ProcedureKitError, ProcedureKitError.requirementNotSatisfied())
+    }
+
+    func test__no_data__finishes_with_error() {
+        session.returnedData = nil
+        wait(for: upload)
+        XCTAssertProcedureFinishedWithErrors(upload, count: 1)
+    }
+
+    func test__session_error__finishes_with_error() {
+        session.returnedError = TestError()
+        wait(for: upload)
+        XCTAssertProcedureFinishedWithErrors(upload, count: 1)
+        XCTAssertEqual(upload.errors.first as? TestError, session.returnedError as? TestError)
+    }
+
+    func test__completion_handler_receives_data_and_response() {
+        var completionHandlerDidExecute = false
+        upload = NetworkUploadProcedure(session: session, request: request, data: sendingData) { result in
+            XCTAssertEqual(result.payload, self.session.returnedData)
+            XCTAssertEqual(result.response, self.session.returnedResponse)
+            completionHandlerDidExecute = true
+        }
+        wait(for: upload)
+        XCTAssertProcedureFinishedWithoutErrors(upload)
+        XCTAssertTrue(completionHandlerDidExecute)
+    }
+
+}

--- a/Tests/Network/ProcedureKitNetworkTests.swift
+++ b/Tests/Network/ProcedureKitNetworkTests.swift
@@ -9,7 +9,7 @@ import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitNetwork
 
-extension TestableURLSessionTask: URLSessionTaskProtocol, URLSessionDataTaskProtocol, URLSessionDownloadTaskProtocol { }
+extension TestableURLSessionTask: URLSessionTaskProtocol, URLSessionDataTaskProtocol, URLSessionDownloadTaskProtocol, URLSessionUploadTaskProtocol { }
 extension TestableURLSessionTaskFactory: URLSessionTaskFactory { }
 
 class TestSuiteRuns: XCTestCase {


### PR DESCRIPTION
The implementation class and test has been largely inspired by
`NetworkDataProcedure`.

The requirement type is currently a pending value of a tuple.
Maybe would it make more sense to create a dedicated struct to add more
clarity in the case of dependencies injection ?