### PR TITLE
Procedure.add(observer:) performance/thread-safety tweak

### DIFF
--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -192,10 +192,10 @@ open class Procedure: Operation, ProcedureProtocol {
 
     // MARK: Observers
 
-    fileprivate var _observers = Protector([AnyObserver<Procedure>]())
+    fileprivate var procedureObservers = Protector([AnyObserver<Procedure>]())
 
     var observers: [AnyObserver<Procedure>] {
-        get { return _observers.read { $0 } }
+        get { return procedureObservers.read { $0 } }
     }
 
 
@@ -561,7 +561,7 @@ public extension Procedure {
      */
     func add<Observer: ProcedureObserver>(observer: Observer) where Observer.Procedure == Procedure {
 
-        _observers.append(AnyObserver(base: observer))
+        procedureObservers.append(AnyObserver(base: observer))
 
         observer.didAttach(to: self)
     }

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -192,15 +192,10 @@ open class Procedure: Operation, ProcedureProtocol {
 
     // MARK: Observers
 
-    private var _observers = Protector([AnyObserver<Procedure>]())
+    fileprivate var _observers = Protector([AnyObserver<Procedure>]())
 
-    fileprivate(set) var observers: [AnyObserver<Procedure>] {
+    var observers: [AnyObserver<Procedure>] {
         get { return _observers.read { $0 } }
-        set {
-            _observers.write { (ward: inout [AnyObserver<Procedure>]) in
-                ward = newValue
-            }
-        }
     }
 
 
@@ -566,7 +561,7 @@ public extension Procedure {
      */
     func add<Observer: ProcedureObserver>(observer: Observer) where Observer.Procedure == Procedure {
 
-        observers.append(AnyObserver(base: observer))
+        _observers.append(AnyObserver(base: observer))
 
         observer.didAttach(to: self)
     }


### PR DESCRIPTION
Append directly to the protected observers array.
This avoids a get (read) -> copy -> append to copy -> set (write) chain that introduces a performance penalty and a race condition.