### PR TITLE
Make ProcedureQueue.add(operation: Operation) method open for subclassing

### DIFF
--- a/Sources/ProcedureQueue.swift
+++ b/Sources/ProcedureQueue.swift
@@ -132,7 +132,7 @@ open class ProcedureQueue: OperationQueue {
      - parameter op: an `Operation` instance.
      */
     // swiftlint:disable function_body_length
-    public func add(operation: Operation) {
+    open func add(operation: Operation) {
 
         defer {
             super.addOperation(operation)


### PR DESCRIPTION
This is useful to enable overriding in test code.

Notes: 

* `NSOperationQueue.addOperation`  is already `open`
* All other methods in this file are `open`