### PR TITLE
Proposal to fix #585.

### DIFF
--- a/Sources/Network/NetworkSupport.swift
+++ b/Sources/Network/NetworkSupport.swift
@@ -61,6 +61,12 @@ public struct HTTPRequirement<Payload: Equatable>: Equatable {
     public static func == (lhs: HTTPRequirement <Payload>, rhs: HTTPRequirement <Payload>) -> Bool {
         return lhs.payload == rhs.payload && lhs.request == rhs.request
     }
-    public var payload: Payload?
+
+    public init(request: URLRequest, payload: Payload? = nil) {
+        self.request = request
+        self.payload = payload
+    }
+
     public var request: URLRequest
+    public var payload: Payload?
 }

--- a/Sources/Network/NetworkUpload.swift
+++ b/Sources/Network/NetworkUpload.swift
@@ -22,7 +22,7 @@ open class NetworkUploadProcedure<Session: URLSessionTaskFactory>: Procedure, Re
     public init(session: Session, request: URLRequest? = nil, data: Data? = nil, completionHandler: @escaping (HTTPResult<Data>) -> Void = { _ in }) {
 
         self.session = session
-        self.requirement = request.flatMap { .ready(HTTPRequirement(payload: data, request: $0)) } ?? .pending
+        self.requirement = request.flatMap { .ready(HTTPRequirement(request: $0, payload: data)) } ?? .pending
         self.completion = completionHandler
 
         super.init()


### PR DESCRIPTION
Fix for #585.
Declaring a constructor for the `HTTPRequirement` allows the
construction of the struct without any issue. 