### PR TITLE
ReachableProcedure

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,4 +8,11 @@ disabled_rules:
 file_length:
   warning: 500
   error: 1200
-  
+variable_name:
+  excluded:
+    - id
+    - URL
+    - of
+    - in
+    - x
+    - y  

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -127,6 +127,10 @@
 		65881B791D880ACB00C212C8 /* MutualExclusivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65881B781D880ACB00C212C8 /* MutualExclusivityTests.swift */; };
 		658A7B4B1D74DCCD00F897C8 /* ProcedureStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658A7B4A1D74DCCD00F897C8 /* ProcedureStressTests.swift */; };
 		658A7B4F1D74E54800F897C8 /* GroupStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658A7B4E1D74E54800F897C8 /* GroupStressTests.swift */; };
+		658B144D1DDDE41A00D63100 /* NetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B144C1DDDE41A00D63100 /* NetworkReachability.swift */; };
+		658B14511DDDFD1400D63100 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14501DDDFD1400D63100 /* Reachability.swift */; };
+		658B14521DDDFD1400D63100 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14501DDDFD1400D63100 /* Reachability.swift */; };
+		658B14541DDDFE6D00D63100 /* ReachabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14531DDDFE6D00D63100 /* ReachabilityTests.swift */; };
 		6591B3001D74954E00C2B57F /* GroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B2FE1D74953A00C2B57F /* GroupTests.swift */; };
 		6591B3021D74980900C2B57F /* GroupTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B3011D74980900C2B57F /* GroupTestCase.swift */; };
 		6593008C1DA8E31900750212 /* TransformProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6593008B1DA8E31900750212 /* TransformProcedureTests.swift */; };
@@ -592,6 +596,9 @@
 		65881B781D880ACB00C212C8 /* MutualExclusivityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MutualExclusivityTests.swift; path = Tests/MutualExclusivityTests.swift; sourceTree = "<group>"; };
 		658A7B4A1D74DCCD00F897C8 /* ProcedureStressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProcedureStressTests.swift; path = "Tests/Stress Tests/ProcedureStressTests.swift"; sourceTree = "<group>"; };
 		658A7B4E1D74E54800F897C8 /* GroupStressTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupStressTests.swift; path = "Tests/Stress Tests/GroupStressTests.swift"; sourceTree = "<group>"; };
+		658B144C1DDDE41A00D63100 /* NetworkReachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachability.swift; sourceTree = "<group>"; };
+		658B14501DDDFD1400D63100 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reachability.swift; path = Sources/Reachability.swift; sourceTree = "<group>"; };
+		658B14531DDDFE6D00D63100 /* ReachabilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReachabilityTests.swift; path = Tests/ReachabilityTests.swift; sourceTree = "<group>"; };
 		6591B2FE1D74953A00C2B57F /* GroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTests.swift; path = Tests/GroupTests.swift; sourceTree = "<group>"; };
 		6591B3011D74980900C2B57F /* GroupTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTestCase.swift; path = Sources/Testing/GroupTestCase.swift; sourceTree = "<group>"; };
 		6593008B1DA8E31900750212 /* TransformProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TransformProcedureTests.swift; path = Tests/TransformProcedureTests.swift; sourceTree = "<group>"; };
@@ -882,12 +889,13 @@
 			children = (
 				6584AF441D74770C0030DBB3 /* Errors.swift */,
 				65245D221D723A6B00340A2D /* Logging.swift */,
+				658B14501DDDFD1400D63100 /* Reachability.swift */,
 				655E86461D67BA9C000FBA6C /* Support.swift */,
-				658A7B491D74D5B900F897C8 /* Core */,
 				652AFD371D8C5A6200793AF3 /* Conditions */,
+				658A7B491D74D5B900F897C8 /* Core */,
+				65B83EB81D731DF2007EFBFA /* Extensions */,
 				65EAC0131D8CA3A3000E4A42 /* Observers */,
 				65EAC0141D8CA3BB000E4A42 /* Procedures */,
-				65B83EB81D731DF2007EFBFA /* Extensions */,
 			);
 			name = ProcedureKit;
 			sourceTree = "<group>";
@@ -915,6 +923,7 @@
 				653C9FE81D6099F10070B7A2 /* ProcedureKitTests.swift */,
 				65245D1C1D721A7100340A2D /* ProcedureTests.swift */,
 				0B7922301DCCD88A000AC3CA /* ProfilerTests.swift */,
+				658B14531DDDFE6D00D63100 /* ReachabilityTests.swift */,
 				6594840F1DA98E700028F83B /* ReduceProcedureTests.swift */,
 				655594F01D9E482D00B08990 /* RepeatProcedureTests.swift */,
 				65403ABD1D7C9E7600D6036B /* ResultInjectionTests.swift */,
@@ -1200,9 +1209,10 @@
 			children = (
 				65ECB2ED1DB4FDE000F96F46 /* NetworkData.swift */,
 				0B795A8B1DC9E52F00E03CE8 /* NetworkDownload.swift */,
-				0B15EDE71DCA07CB0060D2D7 /* NetworkUpload.swift */,
-				65ECB2EF1DB4FE9900F96F46 /* NetworkSupport.swift */,
+				658B144C1DDDE41A00D63100 /* NetworkReachability.swift */,
 				65DFA4A61DBB9EEA009358CE /* NetworkResilience.swift */,
+				65ECB2EF1DB4FE9900F96F46 /* NetworkSupport.swift */,
+				0B15EDE71DCA07CB0060D2D7 /* NetworkUpload.swift */,
 			);
 			name = Network;
 			path = Sources/Network;
@@ -1213,10 +1223,10 @@
 			children = (
 				65ECB2F31DB5097500F96F46 /* NetworkDataProcedureTests.swift */,
 				0B795A8D1DC9EE2E00E03CE8 /* NetworkDownloadProcedureTests.swift */,
+				0B15EDEA1DCA13810060D2D7 /* NetworkUploadProcedureTests.swift */,
 				65ECB2E61DB4F16E00F96F46 /* ProcedureKitNetworkTests.swift */,
 				65DFA4A81DBBC0B0009358CE /* ResilientNetworkProcedureTests.swift */,
 				65DFA4841DB514DD009358CE /* URLTests.swift */,
-				0B15EDEA1DCA13810060D2D7 /* NetworkUploadProcedureTests.swift */,
 			);
 			name = "Network Tests";
 			path = Tests/Network;
@@ -2035,6 +2045,7 @@
 				65245D271D7258E400340A2D /* Group.swift in Sources */,
 				658740C71DAE70DA00E8D93E /* Block.swift in Sources */,
 				65A2D8021D6A05D800FB067C /* ProcedureProcotol.swift in Sources */,
+				658B14511DDDFD1400D63100 /* Reachability.swift in Sources */,
 				6584AF451D74770C0030DBB3 /* Errors.swift in Sources */,
 				65B97DB51D65138F00AC3B5D /* Procedure.swift in Sources */,
 				6518D5E31D7B3A2800A12EF4 /* Condition.swift in Sources */,
@@ -2074,6 +2085,7 @@
 				655594F11D9E482D00B08990 /* RepeatProcedureTests.swift in Sources */,
 				6593008E1DA8E32D00750212 /* FilterProcedureTests.swift in Sources */,
 				659E11AA1D985B9300C5D749 /* ComposedProcedureTests.swift in Sources */,
+				658B14541DDDFE6D00D63100 /* ReachabilityTests.swift in Sources */,
 				6583F95F1D8C4C7F00000A8D /* NoFailedDependenciesConditionTests.swift in Sources */,
 				65245D211D72345000340A2D /* FinishingTests.swift in Sources */,
 				6593008C1DA8E31900750212 /* TransformProcedureTests.swift in Sources */,
@@ -2110,6 +2122,7 @@
 			files = (
 				0B795A8C1DC9E52F00E03CE8 /* NetworkDownload.swift in Sources */,
 				65ECB2F01DB4FE9900F96F46 /* NetworkSupport.swift in Sources */,
+				658B144D1DDDE41A00D63100 /* NetworkReachability.swift in Sources */,
 				0B15EDE91DCA0AFE0060D2D7 /* NetworkUpload.swift in Sources */,
 				65DFA4A71DBB9EEA009358CE /* NetworkResilience.swift in Sources */,
 				65ECB2EE1DB4FDE000F96F46 /* NetworkData.swift in Sources */,
@@ -2120,6 +2133,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				658B14521DDDFD1400D63100 /* Reachability.swift in Sources */,
 				65DFA4A91DBBC0B0009358CE /* ResilientNetworkProcedureTests.swift in Sources */,
 				65ECB2F41DB5097500F96F46 /* NetworkDataProcedureTests.swift in Sources */,
 				0B795A8F1DC9EE6D00E03CE8 /* NetworkDownloadProcedureTests.swift in Sources */,

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -129,8 +129,9 @@
 		658A7B4F1D74E54800F897C8 /* GroupStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658A7B4E1D74E54800F897C8 /* GroupStressTests.swift */; };
 		658B144D1DDDE41A00D63100 /* NetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B144C1DDDE41A00D63100 /* NetworkReachability.swift */; };
 		658B14511DDDFD1400D63100 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14501DDDFD1400D63100 /* Reachability.swift */; };
-		658B14521DDDFD1400D63100 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14501DDDFD1400D63100 /* Reachability.swift */; };
 		658B14541DDDFE6D00D63100 /* ReachabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14531DDDFE6D00D63100 /* ReachabilityTests.swift */; };
+		658B14561DDE007300D63100 /* TestableNetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14551DDE007300D63100 /* TestableNetworkReachability.swift */; };
+		658B14581DDE009300D63100 /* NetworkReachabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14571DDE009300D63100 /* NetworkReachabilityTests.swift */; };
 		6591B3001D74954E00C2B57F /* GroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B2FE1D74953A00C2B57F /* GroupTests.swift */; };
 		6591B3021D74980900C2B57F /* GroupTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B3011D74980900C2B57F /* GroupTestCase.swift */; };
 		6593008C1DA8E31900750212 /* TransformProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6593008B1DA8E31900750212 /* TransformProcedureTests.swift */; };
@@ -599,6 +600,8 @@
 		658B144C1DDDE41A00D63100 /* NetworkReachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachability.swift; sourceTree = "<group>"; };
 		658B14501DDDFD1400D63100 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Reachability.swift; path = Sources/Reachability.swift; sourceTree = "<group>"; };
 		658B14531DDDFE6D00D63100 /* ReachabilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReachabilityTests.swift; path = Tests/ReachabilityTests.swift; sourceTree = "<group>"; };
+		658B14551DDE007300D63100 /* TestableNetworkReachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestableNetworkReachability.swift; path = Sources/Testing/TestableNetworkReachability.swift; sourceTree = "<group>"; };
+		658B14571DDE009300D63100 /* NetworkReachabilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityTests.swift; sourceTree = "<group>"; };
 		6591B2FE1D74953A00C2B57F /* GroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTests.swift; path = Tests/GroupTests.swift; sourceTree = "<group>"; };
 		6591B3011D74980900C2B57F /* GroupTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTestCase.swift; path = Sources/Testing/GroupTestCase.swift; sourceTree = "<group>"; };
 		6593008B1DA8E31900750212 /* TransformProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TransformProcedureTests.swift; path = Tests/TransformProcedureTests.swift; sourceTree = "<group>"; };
@@ -955,6 +958,7 @@
 				655594F21D9E48A200B08990 /* RepeatTestCase.swift */,
 				653644F71D7A194800C72F07 /* StressTestCase.swift */,
 				65DFA4861DB51F60009358CE /* TestableNetwork.swift */,
+				658B14551DDE007300D63100 /* TestableNetworkReachability.swift */,
 				65403ABB1D7C6CBC00D6036B /* TestCondition.swift */,
 				659E5FF91D6E3B8D002B1D10 /* TestProcedure.swift */,
 				65403AB91D7C49C500D6036B /* XCTAsserts.swift */,
@@ -1227,6 +1231,7 @@
 				65ECB2E61DB4F16E00F96F46 /* ProcedureKitNetworkTests.swift */,
 				65DFA4A81DBBC0B0009358CE /* ResilientNetworkProcedureTests.swift */,
 				65DFA4841DB514DD009358CE /* URLTests.swift */,
+				658B14571DDE009300D63100 /* NetworkReachabilityTests.swift */,
 			);
 			name = "Network Tests";
 			path = Tests/Network;
@@ -2111,6 +2116,7 @@
 				655594F31D9E48A200B08990 /* RepeatTestCase.swift in Sources */,
 				65DFA4871DB51F60009358CE /* TestableNetwork.swift in Sources */,
 				6591B3021D74980900C2B57F /* GroupTestCase.swift in Sources */,
+				658B14561DDE007300D63100 /* TestableNetworkReachability.swift in Sources */,
 				653644F81D7A194800C72F07 /* StressTestCase.swift in Sources */,
 				65403ABC1D7C6CBC00D6036B /* TestCondition.swift in Sources */,
 			);
@@ -2133,11 +2139,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				658B14521DDDFD1400D63100 /* Reachability.swift in Sources */,
 				65DFA4A91DBBC0B0009358CE /* ResilientNetworkProcedureTests.swift in Sources */,
 				65ECB2F41DB5097500F96F46 /* NetworkDataProcedureTests.swift in Sources */,
 				0B795A8F1DC9EE6D00E03CE8 /* NetworkDownloadProcedureTests.swift in Sources */,
 				65ECB2E71DB4F16E00F96F46 /* ProcedureKitNetworkTests.swift in Sources */,
+				658B14581DDE009300D63100 /* NetworkReachabilityTests.swift in Sources */,
 				65DFA4851DB514DD009358CE /* URLTests.swift in Sources */,
 				0B15EDEC1DCA147C0060D2D7 /* NetworkUploadProcedureTests.swift in Sources */,
 			);

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -1227,11 +1227,11 @@
 			children = (
 				65ECB2F31DB5097500F96F46 /* NetworkDataProcedureTests.swift */,
 				0B795A8D1DC9EE2E00E03CE8 /* NetworkDownloadProcedureTests.swift */,
+				658B14571DDE009300D63100 /* NetworkReachabilityTests.swift */,
 				0B15EDEA1DCA13810060D2D7 /* NetworkUploadProcedureTests.swift */,
 				65ECB2E61DB4F16E00F96F46 /* ProcedureKitNetworkTests.swift */,
 				65DFA4A81DBBC0B0009358CE /* ResilientNetworkProcedureTests.swift */,
 				65DFA4841DB514DD009358CE /* URLTests.swift */,
-				658B14571DDE009300D63100 /* NetworkReachabilityTests.swift */,
 			);
 			name = "Network Tests";
 			path = Tests/Network;

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -132,6 +132,8 @@
 		658B14541DDDFE6D00D63100 /* ReachabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14531DDDFE6D00D63100 /* ReachabilityTests.swift */; };
 		658B14561DDE007300D63100 /* TestableNetworkReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14551DDE007300D63100 /* TestableNetworkReachability.swift */; };
 		658B14581DDE009300D63100 /* NetworkReachabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14571DDE009300D63100 /* NetworkReachabilityTests.swift */; };
+		658B145A1DDE1D7900D63100 /* NetworkReachable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14591DDE1D7900D63100 /* NetworkReachable.swift */; };
+		658B145C1DDE1D9B00D63100 /* NetworkReachableProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B145B1DDE1D9B00D63100 /* NetworkReachableProcedureTests.swift */; };
 		6591B3001D74954E00C2B57F /* GroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B2FE1D74953A00C2B57F /* GroupTests.swift */; };
 		6591B3021D74980900C2B57F /* GroupTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B3011D74980900C2B57F /* GroupTestCase.swift */; };
 		6593008C1DA8E31900750212 /* TransformProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6593008B1DA8E31900750212 /* TransformProcedureTests.swift */; };
@@ -602,6 +604,8 @@
 		658B14531DDDFE6D00D63100 /* ReachabilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReachabilityTests.swift; path = Tests/ReachabilityTests.swift; sourceTree = "<group>"; };
 		658B14551DDE007300D63100 /* TestableNetworkReachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TestableNetworkReachability.swift; path = Sources/Testing/TestableNetworkReachability.swift; sourceTree = "<group>"; };
 		658B14571DDE009300D63100 /* NetworkReachabilityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachabilityTests.swift; sourceTree = "<group>"; };
+		658B14591DDE1D7900D63100 /* NetworkReachable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachable.swift; sourceTree = "<group>"; };
+		658B145B1DDE1D9B00D63100 /* NetworkReachableProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkReachableProcedureTests.swift; sourceTree = "<group>"; };
 		6591B2FE1D74953A00C2B57F /* GroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTests.swift; path = Tests/GroupTests.swift; sourceTree = "<group>"; };
 		6591B3011D74980900C2B57F /* GroupTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTestCase.swift; path = Sources/Testing/GroupTestCase.swift; sourceTree = "<group>"; };
 		6593008B1DA8E31900750212 /* TransformProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TransformProcedureTests.swift; path = Tests/TransformProcedureTests.swift; sourceTree = "<group>"; };
@@ -1214,6 +1218,7 @@
 				65ECB2ED1DB4FDE000F96F46 /* NetworkData.swift */,
 				0B795A8B1DC9E52F00E03CE8 /* NetworkDownload.swift */,
 				658B144C1DDDE41A00D63100 /* NetworkReachability.swift */,
+				658B14591DDE1D7900D63100 /* NetworkReachable.swift */,
 				65DFA4A61DBB9EEA009358CE /* NetworkResilience.swift */,
 				65ECB2EF1DB4FE9900F96F46 /* NetworkSupport.swift */,
 				0B15EDE71DCA07CB0060D2D7 /* NetworkUpload.swift */,
@@ -1228,6 +1233,7 @@
 				65ECB2F31DB5097500F96F46 /* NetworkDataProcedureTests.swift */,
 				0B795A8D1DC9EE2E00E03CE8 /* NetworkDownloadProcedureTests.swift */,
 				658B14571DDE009300D63100 /* NetworkReachabilityTests.swift */,
+				658B145B1DDE1D9B00D63100 /* NetworkReachableProcedureTests.swift */,
 				0B15EDEA1DCA13810060D2D7 /* NetworkUploadProcedureTests.swift */,
 				65ECB2E61DB4F16E00F96F46 /* ProcedureKitNetworkTests.swift */,
 				65DFA4A81DBBC0B0009358CE /* ResilientNetworkProcedureTests.swift */,
@@ -2131,6 +2137,7 @@
 				658B144D1DDDE41A00D63100 /* NetworkReachability.swift in Sources */,
 				0B15EDE91DCA0AFE0060D2D7 /* NetworkUpload.swift in Sources */,
 				65DFA4A71DBB9EEA009358CE /* NetworkResilience.swift in Sources */,
+				658B145A1DDE1D7900D63100 /* NetworkReachable.swift in Sources */,
 				65ECB2EE1DB4FDE000F96F46 /* NetworkData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2143,6 +2150,7 @@
 				65ECB2F41DB5097500F96F46 /* NetworkDataProcedureTests.swift in Sources */,
 				0B795A8F1DC9EE6D00E03CE8 /* NetworkDownloadProcedureTests.swift in Sources */,
 				65ECB2E71DB4F16E00F96F46 /* ProcedureKitNetworkTests.swift in Sources */,
+				658B145C1DDE1D9B00D63100 /* NetworkReachableProcedureTests.swift in Sources */,
 				658B14581DDE009300D63100 /* NetworkReachabilityTests.swift in Sources */,
 				65DFA4851DB514DD009358CE /* URLTests.swift in Sources */,
 				0B15EDEC1DCA147C0060D2D7 /* NetworkUploadProcedureTests.swift in Sources */,

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -443,9 +443,9 @@ public extension GroupProcedure {
     }
 
     public func append(fatalErrors errors: [Error]) {
-        groupErrors.write({ (ward: inout GroupErrors) in
+        groupErrors.write { (ward: inout GroupErrors) in
             ward.fatal.append(contentsOf: errors)
-        }, completion: { })
+        }
     }
 
     public func child(_ child: Operation, didEncounterFatalErrors errors: [Error]) {
@@ -454,9 +454,9 @@ public extension GroupProcedure {
     }
 
     public func child(_ child: Operation, didAttemptRecoveryFromErrors errors: [Error]) {
-        groupErrors.write({ (ward: inout GroupErrors) in
+        groupErrors.write { (ward: inout GroupErrors) in
             ward.attemptedRecovery[child] = errors
-        }, completion: { })
+        }
     }
 
     fileprivate var attemptedRecovery: GroupErrors.ByOperation {
@@ -466,19 +466,19 @@ public extension GroupProcedure {
     public func childDidRecoverFromErrors(_ child: Operation) {
         if let _ = attemptedRecovery[child] {
             log.notice(message: "successfully recovered from errors in \(child)")
-            groupErrors.write({ (ward: inout GroupErrors) in
+            groupErrors.write { (ward: inout GroupErrors) in
                 ward.attemptedRecovery.removeValue(forKey: child)
-            }, completion: { })
+            }
         }
     }
 
     public func childDidNotRecoverFromErrors(_ child: Operation) {
         log.notice(message: "failed to recover from errors in \(child)")
-        groupErrors.write({ (ward: inout GroupErrors) in
+        groupErrors.write { (ward: inout GroupErrors) in
             if let errors = ward.attemptedRecovery.removeValue(forKey: child) {
                 ward.fatal.append(contentsOf: errors)
             }
-        }, completion: { })
+        }
     }
 }
 

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -443,9 +443,9 @@ public extension GroupProcedure {
     }
 
     public func append(fatalErrors errors: [Error]) {
-        groupErrors.write { (ward: inout GroupErrors) in
+        groupErrors.write({ (ward: inout GroupErrors) in
             ward.fatal.append(contentsOf: errors)
-        }
+        }, completion: { })
     }
 
     public func child(_ child: Operation, didEncounterFatalErrors errors: [Error]) {
@@ -454,9 +454,9 @@ public extension GroupProcedure {
     }
 
     public func child(_ child: Operation, didAttemptRecoveryFromErrors errors: [Error]) {
-        groupErrors.write { (ward: inout GroupErrors) in
+        groupErrors.write({ (ward: inout GroupErrors) in
             ward.attemptedRecovery[child] = errors
-        }
+        }, completion: { })
     }
 
     fileprivate var attemptedRecovery: GroupErrors.ByOperation {
@@ -466,19 +466,19 @@ public extension GroupProcedure {
     public func childDidRecoverFromErrors(_ child: Operation) {
         if let _ = attemptedRecovery[child] {
             log.notice(message: "successfully recovered from errors in \(child)")
-            groupErrors.write { (ward: inout GroupErrors) in
+            groupErrors.write({ (ward: inout GroupErrors) in
                 ward.attemptedRecovery.removeValue(forKey: child)
-            }
+            }, completion: { })
         }
     }
 
     public func childDidNotRecoverFromErrors(_ child: Operation) {
         log.notice(message: "failed to recover from errors in \(child)")
-        groupErrors.write { (ward: inout GroupErrors) in
+        groupErrors.write({ (ward: inout GroupErrors) in
             if let errors = ward.attemptedRecovery.removeValue(forKey: child) {
                 ward.fatal.append(contentsOf: errors)
             }
-        }
+        }, completion: { })
     }
 }
 

--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -324,23 +324,23 @@ internal struct LoggerContext: LoggerProtocol {
     }
 }
 
-internal struct _Logger<M: LogManagerProtocol>: LoggerProtocol {
+public struct _Logger<M: LogManagerProtocol>: LoggerProtocol {
 
     typealias Manager = M
 
-    var severity: LogSeverity
+    public var severity: LogSeverity
 
-    var enabled: Bool
+    public var enabled: Bool
 
-    var logger: LoggerBlockType
+    public var logger: LoggerBlockType
 
-    var operationName: String? = nil
+    public var operationName: String? = nil
 
-    init(severity: LogSeverity = Manager.severity, enabled: Bool = Manager.enabled, logger: @escaping LoggerBlockType = Manager.logger) {
+    public init(severity: LogSeverity = Manager.severity, enabled: Bool = Manager.enabled, logger: @escaping LoggerBlockType = Manager.logger) {
         self.severity = severity
         self.enabled = enabled
         self.logger = logger
     }
 }
 
-internal typealias Logger = _Logger<LogManager>
+public typealias Logger = _Logger<LogManager>

--- a/Sources/Network/NetworkData.swift
+++ b/Sources/Network/NetworkData.swift
@@ -9,7 +9,7 @@
  URLSession based APIs. It only supports the completion block style API, therefore
  do not use this procedure if you wish to use delegate based APIs on URLSession.
 */
-open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, ResultInjection {
+open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, ResultInjection, NetworkOperation {
 
     public var requirement: PendingValue<URLRequest> = .pending
     public var result: PendingValue<HTTPResult<Data>> = .pending
@@ -18,6 +18,10 @@ open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, Resu
     public let completion: (HTTPResult<Data>) -> Void
 
     internal var task: Session.DataTask? = nil
+
+    public var networkError: ProcedureKitNetworkError? {
+        return errors.flatMap { $0 as? ProcedureKitNetworkError }.first
+    }
 
     public init(session: Session, request: URLRequest? = nil, completionHandler: @escaping (HTTPResult<Data>) -> Void = { _ in }) {
         self.session = session
@@ -39,7 +43,7 @@ open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, Resu
             guard let strongSelf = self else { return }
 
             if let error = error {
-                strongSelf.finish(withError: error)
+                strongSelf.finish(withError: ProcedureKitNetworkError(error as NSError))
                 return
             }
 

--- a/Sources/Network/NetworkDownload.swift
+++ b/Sources/Network/NetworkDownload.swift
@@ -9,7 +9,7 @@
  URLSession based APIs. It only supports the completion block style API, therefore
  do not use this procedure if you wish to use delegate based APIs on URLSession.
  */
-open class NetworkDownloadProcedure<Session: URLSessionTaskFactory>: Procedure, ResultInjection {
+open class NetworkDownloadProcedure<Session: URLSessionTaskFactory>: Procedure, ResultInjection, NetworkOperation {
 
     public var requirement: PendingValue<URLRequest> = .pending
     public var result: PendingValue<HTTPResult<URL>> = .pending
@@ -17,7 +17,11 @@ open class NetworkDownloadProcedure<Session: URLSessionTaskFactory>: Procedure, 
     public private(set) var session: Session
     public let completion: (HTTPResult<URL>) -> Void
 
-     internal var task: Session.DownloadTask? = nil
+    internal var task: Session.DownloadTask? = nil
+
+    public var networkError: ProcedureKitNetworkError? {
+        return errors.flatMap { $0 as? ProcedureKitNetworkError }.first
+    }
 
     public init(session: Session, request: URLRequest? = nil, completionHandler: @escaping (HTTPResult<URL>) -> Void = {_ in }) {
 
@@ -41,7 +45,7 @@ open class NetworkDownloadProcedure<Session: URLSessionTaskFactory>: Procedure, 
             guard let strongSelf = self else { return }
 
             if let error = error {
-                strongSelf.finish(withError: error)
+                strongSelf.finish(withError: ProcedureKitNetworkError(error as NSError))
                 return
             }
 

--- a/Sources/Network/NetworkReachability.swift
+++ b/Sources/Network/NetworkReachability.swift
@@ -1,0 +1,164 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import SystemConfiguration
+
+// MARK: - Internal concrete types
+
+extension Reachability {
+
+    final class Manager {
+        typealias Status = NetworkStatus
+
+        let queue = DispatchQueue(label: "run.kit.ProcedureKit.Reachability")
+        var network: NetworkReachability
+        fileprivate var protectedObservers = Protector(Array<Observer>())
+
+        var observers: [Observer] {
+            return protectedObservers.access
+        }
+
+        var count: Int {
+            return observers.count
+        }
+
+        init(_ network: NetworkReachability) {
+            self.network = network
+            self.network.delegate = self
+        }
+    }
+}
+
+extension Reachability.Manager: NetworkReachabilityDelegate {
+
+    func didChangeReachability(flags: SCNetworkReachabilityFlags) {
+        let status = Status(flags: flags)
+        let observersToCheck = observers
+
+        protectedObservers.write { (observers: inout Array<Reachability.Observer>) in
+            observers = observersToCheck.filter { observer in
+                let shouldRemove = status.isConnected(via: observer.connectivity)
+                if shouldRemove {
+                    DispatchQueue.main.async(execute: observer.didConnectBlock)
+                }
+                return shouldRemove
+            }
+        }
+
+        if count == 0 {
+            network.stopNotifier()
+        }
+    }
+}
+
+extension Reachability.Manager: SystemReachability {
+
+    func whenConnected(via connectivity: Reachability.Connectivity, block: @escaping () -> Void) {
+        protectedObservers.write({ (observers: inout Array<Reachability.Observer>) in
+            let observer = Reachability.Observer(connectivity: connectivity, didConnectBlock: block)
+            observers.append(observer)
+        }, completion: { [ weak self] in
+            guard let strongSelf = self else { return }
+            do {
+                try strongSelf.network.startNotifier(onQueue: strongSelf.queue)
+            }
+            catch {
+                print("Caught error: \(error) starting reachability notifier.")
+            }
+        })
+    }
+}
+
+// MARK: - Device Reachability
+
+class DeviceReachability: NetworkReachability {
+
+    static func makeDefaultRouteReachability() throws -> SCNetworkReachability {
+        var zeroAddress = sockaddr()
+        zeroAddress.sa_len = UInt8(MemoryLayout<sockaddr>.size)
+        zeroAddress.sa_family = sa_family_t(AF_INET)
+
+        guard let reachability: SCNetworkReachability = withUnsafePointer(to: &zeroAddress, {
+            SCNetworkReachabilityCreateWithAddress(nil, UnsafePointer($0))
+        }) else { throw ReachabilityError.failedToCreateDefaultRouteReachability }
+
+        return reachability
+    }
+
+    fileprivate let defaultRouteReachability: SCNetworkReachability
+    fileprivate var threadSafeProtector = Protector(false)
+    weak var delegate: NetworkReachabilityDelegate?
+
+    var notifierIsRunning: Bool {
+        get { return threadSafeProtector.access }
+        set {
+            threadSafeProtector.write { (isRunning: inout Bool) in
+                isRunning = newValue
+            }
+        }
+    }
+
+    init() throws {
+        defaultRouteReachability = try DeviceReachability.makeDefaultRouteReachability()
+    }
+
+    func getFlags(forReachability reachability: SCNetworkReachability) -> SCNetworkReachabilityFlags {
+        var flags = SCNetworkReachabilityFlags()
+        guard withUnsafeMutablePointer(to: &flags, {
+            SCNetworkReachabilityGetFlags(reachability, UnsafeMutablePointer($0))
+        }) else { return SCNetworkReachabilityFlags() }
+
+        return flags
+    }
+
+    func didChangeReachability(flags: SCNetworkReachabilityFlags) {
+        delegate?.didChangeReachability(flags: flags)
+    }
+
+    func check(reachability: SCNetworkReachability, on queue: DispatchQueue) {
+        queue.async { [weak self] in
+            guard let strongSelf = self else { return }
+            let flags = strongSelf.getFlags(forReachability: reachability)
+            strongSelf.didChangeReachability(flags: flags)
+        }
+    }
+
+    func startNotifier(onQueue queue: DispatchQueue) throws {
+        precondition(delegate != nil, "Reachability delegate not set.")
+        guard !notifierIsRunning else { return }
+
+        notifierIsRunning = true
+
+        var context = SCNetworkReachabilityContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
+        context.info = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+
+        guard SCNetworkReachabilitySetCallback(defaultRouteReachability, __device_reachability_callback, &context) else {
+            stopNotifier()
+            throw ReachabilityError.failedToSetNotifierCallback
+        }
+
+        guard SCNetworkReachabilitySetDispatchQueue(defaultRouteReachability, queue) else {
+            stopNotifier()
+            throw ReachabilityError.failedToSetNotifierDispatchQueue
+        }
+
+        check(reachability: defaultRouteReachability, on: queue)
+    }
+
+    func stopNotifier() {
+        SCNetworkReachabilitySetCallback(defaultRouteReachability, nil, nil)
+        SCNetworkReachabilitySetDispatchQueue(defaultRouteReachability, nil)
+        notifierIsRunning = false
+    }
+}
+
+private func __device_reachability_callback(reachability: SCNetworkReachability, flags: SCNetworkReachabilityFlags, info: UnsafeMutableRawPointer?) {
+    guard let info = info else { return }
+    let deviceReachability = Unmanaged<DeviceReachability>.fromOpaque(info).takeUnretainedValue()
+    DispatchQueue.main.async {
+        deviceReachability.didChangeReachability(flags: flags)
+    }
+}

--- a/Sources/Network/NetworkReachability.swift
+++ b/Sources/Network/NetworkReachability.swift
@@ -119,6 +119,10 @@ class DeviceReachability: NetworkReachability {
         log = logger
     }
 
+    deinit {
+        stopNotifier()
+    }
+
     func getFlags(forReachability reachability: SCNetworkReachability) -> SCNetworkReachabilityFlags {
         var flags = SCNetworkReachabilityFlags()
         guard withUnsafeMutablePointer(to: &flags, {

--- a/Sources/Network/NetworkReachability.swift
+++ b/Sources/Network/NetworkReachability.swift
@@ -33,6 +33,8 @@ extension Reachability {
 extension Reachability.Manager: NetworkReachabilityDelegate {
 
     func didChangeReachability(flags: SCNetworkReachabilityFlags) {
+        guard observers.count > 0 else { return }
+
         let status = Status(flags: flags)
         let observersToCheck = observers
 

--- a/Sources/Network/NetworkReachability.swift
+++ b/Sources/Network/NetworkReachability.swift
@@ -13,6 +13,8 @@ extension Reachability {
     final class Manager {
         typealias Status = NetworkStatus
 
+        static let shared = Reachability.Manager(DeviceReachability())
+
         let queue = DispatchQueue(label: "run.kit.ProcedureKit.Network.Reachability")
         var network: NetworkReachability
         fileprivate var protectedObservers = Protector(Array<Observer>())
@@ -110,8 +112,8 @@ class DeviceReachability: NetworkReachability {
         }
     }
 
-    init(log logger: LoggerProtocol = Logger()) throws {
-        defaultRouteReachability = try DeviceReachability.makeDefaultRouteReachability()
+    init(log logger: LoggerProtocol = Logger()) {
+        defaultRouteReachability = try! DeviceReachability.makeDefaultRouteReachability() // swiftlint:disable:this force_try
         log = logger
     }
 

--- a/Sources/Network/NetworkReachable.swift
+++ b/Sources/Network/NetworkReachable.swift
@@ -1,0 +1,62 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import SystemConfiguration
+
+class NetworkReachabilityWaitProcedure: Procedure {
+
+    let reachability: SystemReachability
+    let connectivity: Reachability.Connectivity
+
+    init(reachability: SystemReachability, via connectivity: Reachability.Connectivity = .any) {
+        self.reachability = reachability
+        self.connectivity = connectivity
+        super.init()
+    }
+
+    override func execute() {
+        reachability.whenConnected(via: connectivity) { [weak self] in
+            self?.finish()
+        }
+    }
+}
+
+class NetworkReachableRecovery<T: Operation> {
+
+    let connectivity: Reachability.Connectivity
+    var reachability: SystemReachability = Reachability.Manager.shared
+
+    init(connectivity: Reachability.Connectivity) {
+        self.connectivity = connectivity
+    }
+
+    func recover(withInfo info: RetryFailureInfo<T>, payload: RepeatProcedurePayload<T>) -> RepeatProcedurePayload<T>? {
+
+        let waiter = NetworkReachabilityWaitProcedure(reachability: reachability, via: connectivity)
+        payload.operation.add(dependency: waiter)
+        info.addOperations(waiter)
+        return payload
+    }
+}
+
+open class NetworkReachableProcedure<T: Operation>: RetryProcedure<T> {
+
+    let recovery: NetworkReachableRecovery<T>
+
+    internal var reachability: SystemReachability {
+        get { return recovery.reachability }
+        set { recovery.reachability = newValue }
+    }
+
+    public init<OperationIterator>(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, connectivity: Reachability.Connectivity = .any, iterator base: OperationIterator) where OperationIterator: IteratorProtocol, OperationIterator.Element == T {
+        recovery = NetworkReachableRecovery<T>(connectivity: connectivity)
+        super.init(dispatchQueue: dispatchQueue, max: max, wait: .immediate, iterator: base, retry: recovery.recover(withInfo:payload:))
+    }
+
+    public convenience init(dispatchQueue: DispatchQueue = DispatchQueue.default, max: Int? = nil, connectivity: Reachability.Connectivity = .any, body: @escaping () -> T?) {
+        self.init(dispatchQueue: dispatchQueue, max: max, connectivity: connectivity, iterator: AnyIterator(body))
+    }
+}

--- a/Sources/Network/NetworkReachable.swift
+++ b/Sources/Network/NetworkReachable.swift
@@ -18,9 +18,7 @@ class NetworkReachabilityWaitProcedure: Procedure {
     }
 
     override func execute() {
-        reachability.whenConnected(via: connectivity) { [weak self] in
-            self?.finish()
-        }
+        reachability.whenConnected(via: connectivity) { [weak self] in self?.finish() }
     }
 }
 

--- a/Sources/Network/NetworkReachable.swift
+++ b/Sources/Network/NetworkReachable.swift
@@ -18,7 +18,7 @@ class NetworkReachabilityWaitProcedure: Procedure {
     }
 
     override func execute() {
-        reachability.whenConnected(via: connectivity) { [weak self] in self?.finish() }
+        reachability.whenReachable(via: connectivity) { [weak self] in self?.finish() }
     }
 }
 

--- a/Sources/Network/NetworkSupport.swift
+++ b/Sources/Network/NetworkSupport.swift
@@ -70,3 +70,34 @@ public struct HTTPRequirement<Payload: Equatable>: Equatable {
     public var request: URLRequest
     public var payload: Payload?
 }
+
+public struct ProcedureKitNetworkError: Error {
+    public let underlyingError: NSError
+
+    public var isTransientError: Bool {
+        switch underlyingError.code {
+        case NSURLErrorNetworkConnectionLost:
+            return true
+        default:
+            return false
+        }
+    }
+
+    public var waitForReachabilityChangeBeforeRetrying: Bool {
+        switch underlyingError.code {
+        case NSURLErrorNotConnectedToInternet, NSURLErrorInternationalRoamingOff, NSURLErrorCallIsActive, NSURLErrorDataNotAllowed:
+            return true
+        default:
+            return false
+        }
+    }
+
+    public init(_ error: NSError) {
+        underlyingError = error
+    }
+}
+
+public protocol NetworkOperation {
+
+    var networkError: ProcedureKitNetworkError? { get }
+}

--- a/Sources/Network/NetworkUpload.swift
+++ b/Sources/Network/NetworkUpload.swift
@@ -9,7 +9,7 @@
  URLSession based APIs. It only supports the completion block style API, therefore
  do not use this procedure if you wish to use delegate based APIs on URLSession.
  */
-open class NetworkUploadProcedure<Session: URLSessionTaskFactory>: Procedure, ResultInjection {
+open class NetworkUploadProcedure<Session: URLSessionTaskFactory>: Procedure, ResultInjection, NetworkOperation {
 
     public var requirement: PendingValue<HTTPRequirement<Data>>
     public var result: PendingValue<HTTPResult<Data>> = .pending
@@ -18,6 +18,10 @@ open class NetworkUploadProcedure<Session: URLSessionTaskFactory>: Procedure, Re
     public let completion: (HTTPResult<Data>) -> Void
 
     internal var task: Session.UploadTask? = nil
+
+    public var networkError: ProcedureKitNetworkError? {
+        return errors.flatMap { $0 as? ProcedureKitNetworkError }.first
+    }
 
     public init(session: Session, request: URLRequest? = nil, data: Data? = nil, completionHandler: @escaping (HTTPResult<Data>) -> Void = { _ in }) {
 
@@ -43,7 +47,7 @@ open class NetworkUploadProcedure<Session: URLSessionTaskFactory>: Procedure, Re
 
 
             if let error = error {
-                strongSelf.finish(withError: error)
+                strongSelf.finish(withError: ProcedureKitNetworkError(error as NSError))
                 return
             }
 

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -669,7 +669,11 @@ extension Procedure {
 
         func createEvaluateConditionsProcedure() -> EvaluateConditions {
             // Set the procedure on each condition
-            conditions.forEach { $0.procedure = self }
+            conditions.forEach {
+                $0.procedure = self
+                $0.log.enabled = self.log.enabled
+                $0.log.severity = self.log.severity
+            }
 
             let evaluator = EvaluateConditions(conditions: conditions)
             evaluator.name = "\(operationName) Evaluate Conditions"

--- a/Sources/Reachability.swift
+++ b/Sources/Reachability.swift
@@ -47,6 +47,8 @@ public protocol NetworkReachability {
 
     weak var delegate: NetworkReachabilityDelegate? { get set }
 
+    var log: LoggerProtocol { get }
+
     func startNotifier(onQueue queue: DispatchQueue) throws
 
     func stopNotifier()

--- a/Sources/Reachability.swift
+++ b/Sources/Reachability.swift
@@ -1,0 +1,176 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import SystemConfiguration
+
+// MARK: - Public APIs
+
+public struct Reachability {
+
+    public enum Connectivity {
+        case any, wwan, wifi
+    }
+
+    public enum NetworkStatus {
+        case notReachable
+        case reachable(Connectivity)
+    }
+
+    public typealias ObserverBlock = (NetworkStatus) -> Void
+
+    public struct Observer {
+        public let connectivity: Connectivity
+        public let didConnectBlock: () -> Void
+
+        public init(connectivity: Connectivity, didConnectBlock: @escaping () -> Void) {
+            self.connectivity = connectivity
+            self.didConnectBlock = didConnectBlock
+        }
+    }
+}
+
+public enum ReachabilityError: Error {
+    case failedToCreateDefaultRouteReachability
+    case failedToSetNotifierCallback
+    case failedToSetNotifierDispatchQueue
+}
+
+public protocol NetworkReachabilityDelegate: class {
+
+    func didChangeReachability(flags: SCNetworkReachabilityFlags)
+}
+
+public protocol NetworkReachability {
+
+    weak var delegate: NetworkReachabilityDelegate? { get set }
+
+    func startNotifier(onQueue queue: DispatchQueue) throws
+
+    func stopNotifier()
+
+    //    func reachabilityFlags(forHost: String) -> SCNetworkReachabilityFlags?
+}
+
+public protocol SystemReachability {
+
+    func whenConnected(via: Reachability.Connectivity, block: @escaping () -> Void)
+}
+
+
+// MARK: Conformance
+
+extension Reachability.NetworkStatus: Equatable {
+
+    public static func == (lhs: Reachability.NetworkStatus, rhs: Reachability.NetworkStatus) -> Bool {
+        switch (lhs, rhs) {
+        case (.notReachable, .notReachable):
+            return true
+        case let (.reachable(lhsConnectivity), .reachable(rhsConnectivity)):
+            return lhsConnectivity == rhsConnectivity
+        default:
+            return false
+        }
+    }
+}
+
+
+public extension Reachability.NetworkStatus {
+
+    init(flags: SCNetworkReachabilityFlags) {
+        switch flags {
+        case _ where flags.isReachableViaWiFi:
+            self = .reachable(.wifi)
+        case _ where flags.isReachableViaWWAN:
+            #if os(iOS)
+                self = .reachable(.wwan)
+            #else
+                self = .reachable(.any)
+            #endif
+        default:
+            self = .notReachable
+        }
+    }
+
+    func isConnected(via connectivity: Reachability.Connectivity) -> Bool {
+        switch (self, connectivity) {
+        case (.notReachable, _), (.reachable(.wwan), .wifi):
+            return false
+        default:
+            return true
+        }
+    }
+}
+
+public extension SCNetworkReachabilityFlags {
+
+    var isReachable: Bool {
+        return contains(.reachable)
+    }
+
+    var isConnectionRequired: Bool {
+        return contains(.connectionRequired)
+    }
+
+    var isInterventionRequired: Bool {
+        return contains(.interventionRequired)
+    }
+
+    var isConnectionOnTraffic: Bool {
+        return contains(.connectionOnTraffic)
+    }
+
+    var isConnectionOnDemand: Bool {
+        return contains(.connectionOnDemand)
+    }
+
+    var isTransientConnection: Bool {
+        return contains(.transientConnection)
+    }
+
+    var isALocalAddress: Bool {
+        return contains(.isLocalAddress)
+    }
+
+    var isDirectConnection: Bool {
+        return contains(.isDirect)
+    }
+
+    var isConnectionOnTrafficOrDemand: Bool {
+        return isConnectionOnTraffic || isConnectionOnDemand
+    }
+
+    var isConnectionRequiredOrTransient: Bool {
+        return isConnectionRequired || isTransientConnection
+    }
+
+    var isConnected: Bool {
+        return isReachable && !isConnectionRequired
+    }
+
+    var isOnWWAN: Bool {
+        #if os(iOS)
+            return contains(.isWWAN)
+        #else
+            return false
+        #endif
+    }
+
+    var isReachableViaWWAN: Bool {
+        #if os(iOS)
+            return isConnected && isOnWWAN
+        #else
+            return isReachable
+        #endif
+    }
+
+    var isReachableViaWiFi: Bool {
+        #if os(iOS)
+            return isConnected && !isOnWWAN
+        #else
+            return isConnected
+        #endif
+    }
+}

--- a/Sources/Reachability.swift
+++ b/Sources/Reachability.swift
@@ -53,12 +53,14 @@ public protocol NetworkReachability {
 
     func stopNotifier()
 
-    //    func reachabilityFlags(forHost: String) -> SCNetworkReachabilityFlags?
+    //func reachabilityFlags(of: URL) -> SCNetworkReachabilityFlags?
 }
 
 public protocol SystemReachability {
 
-    func whenConnected(via: Reachability.Connectivity, block: @escaping () -> Void)
+    func whenReachable(via: Reachability.Connectivity, block: @escaping () -> Void)
+
+    func reachability(of: URL, block: @escaping (Reachability.NetworkStatus) -> Void)
 }
 
 

--- a/Sources/Support.swift
+++ b/Sources/Support.swift
@@ -61,6 +61,10 @@ public class Protector<T> {
         self.ward = ward
     }
 
+    public var access: T {
+        return read { $0 }
+    }
+
     public func read<U>(_ block: @escaping (T) -> U) -> U {
         return lock.read { [unowned self] in block(self.ward) }
     }
@@ -88,7 +92,6 @@ public extension Protector where T: RangeReplaceableCollection {
         }
     }
 }
-
 
 internal extension NSLock {
 

--- a/Sources/Support.swift
+++ b/Sources/Support.swift
@@ -27,16 +27,19 @@ protocol ReadWriteLock {
     mutating func write(_ block: @escaping () -> Void, completion: (() -> Void)?)
 }
 
+extension ReadWriteLock {
+
+    mutating func write(_ block: @escaping () -> Void) {
+        write(block, completion: nil)
+    }
+}
+
 struct Lock: ReadWriteLock {
 
     let queue = DispatchQueue.concurrent(label: "run.kit.procedure.ProcedureKit.Lock", qos: .userInitiated)
 
     mutating func read<T>(_ block: () throws -> T) rethrows -> T {
         return try queue.sync(execute: block)
-    }
-
-    mutating func write(_ block: @escaping () -> Void) {
-        queue.sync(execute: block)
     }
 
     mutating func write(_ block: @escaping () -> Void, completion: (() -> Void)?) {

--- a/Sources/Support.swift
+++ b/Sources/Support.swift
@@ -27,19 +27,16 @@ protocol ReadWriteLock {
     mutating func write(_ block: @escaping () -> Void, completion: (() -> Void)?)
 }
 
-extension ReadWriteLock {
-
-    mutating func write(_ block: @escaping () -> Void) {
-        write(block, completion: nil)
-    }
-}
-
 struct Lock: ReadWriteLock {
 
     let queue = DispatchQueue.concurrent(label: "run.kit.procedure.ProcedureKit.Lock", qos: .userInitiated)
 
     mutating func read<T>(_ block: () throws -> T) rethrows -> T {
         return try queue.sync(execute: block)
+    }
+
+    mutating func write(_ block: @escaping () -> Void) {
+        queue.sync(execute: block)
     }
 
     mutating func write(_ block: @escaping () -> Void, completion: (() -> Void)?) {

--- a/Sources/Testing/ProcedureKitTestCase.swift
+++ b/Sources/Testing/ProcedureKitTestCase.swift
@@ -88,6 +88,7 @@ open class ProcedureKitTestCase: XCTestCase {
 
     func makeFinishingProcedure(for procedure: Procedure, withExpectationDescription expectationDescription: String = #function) -> Procedure {
         let finishing = BlockProcedure { }
+        finishing.log.enabled = false
         finishing.add(dependency: procedure)
         // Adds a will add operation observer, which adds the produced operation as a dependency
         // of the finishing procedure. This way, we don't actually finish, until the

--- a/Sources/Testing/TestableNetworkReachability.swift
+++ b/Sources/Testing/TestableNetworkReachability.swift
@@ -10,7 +10,11 @@ import SystemConfiguration
 public class TestableNetworkReachability {
     typealias Reachability = String
 
-    public var flags: SCNetworkReachabilityFlags? = .reachable
+    public var flags: SCNetworkReachabilityFlags = .reachable {
+        didSet {
+            delegate?.didChangeReachability(flags: flags)
+        }
+    }
     public var didStartNotifier = false
     public var didStopNotifier = false
 
@@ -25,9 +29,7 @@ extension TestableNetworkReachability: NetworkReachability {
     public func startNotifier(onQueue queue: DispatchQueue) throws {
         log.notice(message: "Started Reachability Notifier")
         didStartNotifier = true
-        if let flags = flags {
-            delegate?.didChangeReachability(flags: flags)
-        }
+        delegate?.didChangeReachability(flags: flags)
     }
 
     public func stopNotifier() {

--- a/Sources/Testing/TestableNetworkReachability.swift
+++ b/Sources/Testing/TestableNetworkReachability.swift
@@ -1,0 +1,8 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+import SystemConfiguration

--- a/Sources/Testing/TestableNetworkReachability.swift
+++ b/Sources/Testing/TestableNetworkReachability.swift
@@ -6,3 +6,32 @@
 
 import XCTest
 import SystemConfiguration
+
+public class TestableNetworkReachability {
+    typealias Reachability = String
+
+    public var flags: SCNetworkReachabilityFlags? = .reachable
+    public var didStartNotifier = false
+    public var didStopNotifier = false
+
+    public var log: LoggerProtocol = Logger()
+    public weak var delegate: NetworkReachabilityDelegate? = nil
+
+    public init() { }
+}
+
+extension TestableNetworkReachability: NetworkReachability {
+
+    public func startNotifier(onQueue queue: DispatchQueue) throws {
+        log.notice(message: "Started Reachability Notifier")
+        didStartNotifier = true
+        if let flags = flags {
+            delegate?.didChangeReachability(flags: flags)
+        }
+    }
+
+    public func stopNotifier() {
+        log.notice(message: "Stopped Reachability Notifier")
+        didStopNotifier = true
+    }
+}

--- a/Tests/Network/NetworkDataProcedureTests.swift
+++ b/Tests/Network/NetworkDataProcedureTests.swift
@@ -24,6 +24,14 @@ class NetworkDataProcedureTests: ProcedureKitTestCase {
         download = NetworkDataProcedure(session: session, request: request)
     }
 
+    override func tearDown() {
+        url = nil
+        request = nil
+        session = nil
+        download = nil
+        super.tearDown()
+    }
+
     func test__session_receives_request() {
         wait(for: download)
         XCTAssertProcedureFinishedWithoutErrors(download)
@@ -68,10 +76,10 @@ class NetworkDataProcedureTests: ProcedureKitTestCase {
     }
 
     func test__session_error__finishes_with_error() {
-        session.returnedError = TestError()
+        session.returnedError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
         wait(for: download)
         XCTAssertProcedureFinishedWithErrors(download, count: 1)
-        XCTAssertEqual(download.errors.first as? TestError, session.returnedError as? TestError)
+        XCTAssertNotNil(download.networkError)
     }
 
     func test__completion_handler_receives_data_and_response() {

--- a/Tests/Network/NetworkDownloadProcedureTests.swift
+++ b/Tests/Network/NetworkDownloadProcedureTests.swift
@@ -23,6 +23,14 @@ class NetworkDownloadProcedureTests: ProcedureKitTestCase {
         download = NetworkDownloadProcedure(session: session, request: request)
     }
 
+    override func tearDown() {
+        url = nil
+        request = nil
+        session = nil
+        download = nil
+        super.tearDown()
+    }
+
     func test__session_receive_request() {
         wait(for: download)
         XCTAssertProcedureFinishedWithoutErrors(download)
@@ -67,10 +75,10 @@ class NetworkDownloadProcedureTests: ProcedureKitTestCase {
     }
 
     func test__session_error__finishes_with_error() {
-        session.returnedError = TestError()
+        session.returnedError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
         wait(for: download)
         XCTAssertProcedureFinishedWithErrors(download, count: 1)
-        XCTAssertEqual(download.errors.first as? TestError, session.returnedError as? TestError)
+        XCTAssertNotNil(download.networkError)
     }
 
     func test__completion_handler_receives_data_and_response() {

--- a/Tests/Network/NetworkReachabilityTests.swift
+++ b/Tests/Network/NetworkReachabilityTests.swift
@@ -35,7 +35,7 @@ class ReachabilityManagerTests: ProcedureKitTestCase {
         var didRunBlock = false
         let exp = expectation(description: "Test: \(#function)")
 
-        manager.whenConnected(via: .any) {
+        manager.whenReachable(via: .any) {
             didRunBlock = true
             exp.fulfill()
         }
@@ -49,14 +49,14 @@ class ReachabilityManagerTests: ProcedureKitTestCase {
 class DeviceReachabilityTests: XCTestCase, NetworkReachabilityDelegate {
 
     var queue: DispatchQueue!
-    var device: DeviceReachability!
+    var device: Reachability.Device!
     var testExpectation: XCTestExpectation? = nil
     var delegateDidReceiveFlags: SCNetworkReachabilityFlags? = nil
 
     override func setUp() {
         super.setUp()
         queue = DispatchQueue(label: "run.kit.ProcedureKit.Network.Reachability.Testing")
-        device = DeviceReachability()
+        device = Reachability.Device()
         device.delegate = self
     }
 

--- a/Tests/Network/NetworkReachabilityTests.swift
+++ b/Tests/Network/NetworkReachabilityTests.swift
@@ -58,10 +58,7 @@ class DeviceReachabilityTests: XCTestCase, NetworkReachabilityDelegate {
     override func setUp() {
         super.setUp()
         queue = DispatchQueue(label: "run.kit.ProcedureKit.Network.Reachability.Testing")
-        do {
-            device = try DeviceReachability()
-        }
-        catch { XCTFail("DeviceReachability threw error: \(error)") }
+        device = DeviceReachability()
         device.delegate = self
     }
 

--- a/Tests/Network/NetworkReachabilityTests.swift
+++ b/Tests/Network/NetworkReachabilityTests.swift
@@ -9,3 +9,95 @@ import SystemConfiguration
 import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitNetwork
+
+class ReachabilityManagerTests: ProcedureKitTestCase {
+
+    var network: TestableNetworkReachability!
+    var manager: Reachability.Manager!
+
+    override func setUp() {
+        super.setUp()
+        network = TestableNetworkReachability()
+        manager = Reachability.Manager(network)
+        LogManager.severity = .notice
+    }
+
+    override func tearDown() {
+        network = nil
+        manager = nil
+        LogManager.severity = .warning
+        super.tearDown()
+    }
+
+    func test__delegate_is_set() {
+        XCTAssertNotNil(network.delegate)
+    }
+
+    func test__when_connected_block_is_run() {
+        var didRunBlock = false
+        let exp = expectation(description: "Test: \(#function)")
+
+        manager.whenConnected(via: .any) {
+            didRunBlock = true
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+        XCTAssertTrue(didRunBlock)
+        XCTAssertTrue(network.didStopNotifier)
+    }
+}
+
+class DeviceReachabilityTests: XCTestCase, NetworkReachabilityDelegate {
+
+    var queue: DispatchQueue!
+    var device: DeviceReachability!
+    var testExpectation: XCTestExpectation? = nil
+    var delegateDidReceiveFlags: SCNetworkReachabilityFlags? = nil
+
+    override func setUp() {
+        super.setUp()
+        queue = DispatchQueue(label: "run.kit.ProcedureKit.Network.Reachability.Testing")
+        do {
+            device = try DeviceReachability()
+        }
+        catch { XCTFail("DeviceReachability threw error: \(error)") }
+        device.delegate = self
+    }
+
+    override func tearDown() {
+        queue = nil
+        device = nil
+        testExpectation = nil
+        delegateDidReceiveFlags = nil
+        super.tearDown()
+    }
+
+    func test__notifierIsRunning_is_true_when_running() {
+        device.notifierIsRunning = true
+        XCTAssertTrue(device.notifierIsRunning)
+    }
+
+    func test__notifierIsRunning_is_false_when_not_running() {
+        device.notifierIsRunning = false
+        XCTAssertFalse(device.notifierIsRunning)
+    }
+
+    func test__did_change_reachability_informs_delegate() {
+        device.didChangeReachability(flags: .reachable)
+        XCTAssertEqual(delegateDidReceiveFlags ?? .connectionRequired, .reachable)
+    }
+
+    func didChangeReachability(flags: SCNetworkReachabilityFlags) {
+        delegateDidReceiveFlags = flags
+        testExpectation?.fulfill()
+    }
+
+    func test__check() {
+        testExpectation = expectation(description: "Test: \(#function)")
+        let reachability = device.defaultRouteReachability
+        device.check(reachability: reachability, on: queue)
+        waitForExpectations(timeout: 3, handler: nil)
+        XCTAssertNotNil(delegateDidReceiveFlags)
+    }
+}

--- a/Tests/Network/NetworkReachabilityTests.swift
+++ b/Tests/Network/NetworkReachabilityTests.swift
@@ -1,0 +1,11 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+import SystemConfiguration
+import ProcedureKit
+import TestingProcedureKit
+@testable import ProcedureKitNetwork

--- a/Tests/Network/NetworkReachabilityTests.swift
+++ b/Tests/Network/NetworkReachabilityTests.swift
@@ -19,13 +19,11 @@ class ReachabilityManagerTests: ProcedureKitTestCase {
         super.setUp()
         network = TestableNetworkReachability()
         manager = Reachability.Manager(network)
-        LogManager.severity = .notice
     }
 
     override func tearDown() {
         network = nil
         manager = nil
-        LogManager.severity = .warning
         super.tearDown()
     }
 

--- a/Tests/Network/NetworkReachableProcedureTests.swift
+++ b/Tests/Network/NetworkReachableProcedureTests.swift
@@ -84,13 +84,11 @@ class NetworkReachableProcedureTests: ProcedureKitTestCase {
         data = NetworkDataProcedure(session: session, request: request)
         network = TestableNetworkReachability()
         manager = Reachability.Manager(network)
-        LogManager.severity = .notice
     }
 
     override func tearDown() {
         network = nil
         manager = nil
-        LogManager.severity = .warning
         super.tearDown()
     }
 

--- a/Tests/Network/NetworkReachableProcedureTests.swift
+++ b/Tests/Network/NetworkReachableProcedureTests.swift
@@ -1,9 +1,94 @@
 //
-//  NetworkReachableProcedureTests.swift
 //  ProcedureKit
 //
-//  Created by Daniel Thorpe on 17/11/2016.
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
-import Foundation
+import XCTest
+import SystemConfiguration
+import ProcedureKit
+import TestingProcedureKit
+@testable import ProcedureKitNetwork
+
+class NetworkReachabilityWaitProcedureTests: ProcedureKitTestCase {
+
+    var network: TestableNetworkReachability!
+    var manager: Reachability.Manager!
+
+    override func setUp() {
+        super.setUp()
+        network = TestableNetworkReachability()
+        manager = Reachability.Manager(network)
+    }
+
+    override func tearDown() {
+        network = nil
+        manager = nil
+        super.tearDown()
+    }
+
+    func test__procedure_waits_until_network_is_reachable() {
+        network.flags = .connectionRequired
+        let procedure = NetworkReachabilityWaitProcedure(reachability: manager)
+        let delay = DelayProcedure(by: 0.1)
+        let makeNetworkReachable = BlockProcedure {
+            self.network.flags = .reachable
+        }
+        makeNetworkReachable.add(dependency: delay)
+
+        wait(forAll: [delay, makeNetworkReachable, procedure])
+        XCTAssertProcedureFinishedWithoutErrors(procedure)
+    }
+
+    #if os(iOS)
+    func test__procedure_waits_until_correct_network_connectivity_is_available() {
+        network.flags = .interventionRequired
+        let procedure = NetworkReachabilityWaitProcedure(reachability: manager, via: .wifi)
+
+        let delay1 = DelayProcedure(by: 0.1)
+        let changeNetwork1 = BlockProcedure {
+            self.network.flags = [ .reachable, .isWWAN ]
+        }
+        changeNetwork1.add(dependency: delay1)
+
+        let delay2 = DelayProcedure(by: 0.2)
+        let changeNetwork2 = BlockProcedure {
+            self.network.flags = .reachable
+        }
+        changeNetwork2.add(dependency: delay2)
+
+
+        wait(forAll: [delay1, changeNetwork1, delay2, changeNetwork2, procedure])
+        XCTAssertProcedureFinishedWithoutErrors(procedure)
+    }
+    #endif
+
+}
+
+class NetworkReachableProcedureTests: ProcedureKitTestCase {
+
+    var network: TestableNetworkReachability!
+    var manager: Reachability.Manager!
+
+    override func setUp() {
+        super.setUp()
+        network = TestableNetworkReachability()
+        manager = Reachability.Manager(network)
+        LogManager.severity = .notice
+    }
+
+    override func tearDown() {
+        network = nil
+        manager = nil
+        LogManager.severity = .warning
+        super.tearDown()
+    }
+
+    func test__reachable_network_does_not_start_notifier() {
+        let procedure = NetworkReachableProcedure { TestProcedure() }
+        procedure.reachability = manager
+        wait(for: procedure)
+        XCTAssertProcedureFinishedWithoutErrors(procedure)
+        XCTAssertFalse(network.didStartNotifier)
+    }
+}

--- a/Tests/Network/NetworkReachableProcedureTests.swift
+++ b/Tests/Network/NetworkReachableProcedureTests.swift
@@ -1,0 +1,9 @@
+//
+//  NetworkReachableProcedureTests.swift
+//  ProcedureKit
+//
+//  Created by Daniel Thorpe on 17/11/2016.
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import Foundation

--- a/Tests/Network/NetworkUploadProcedureTests.swift
+++ b/Tests/Network/NetworkUploadProcedureTests.swift
@@ -27,6 +27,14 @@ class NetworkUploadProcedureTests: ProcedureKitTestCase {
         upload = NetworkUploadProcedure(session: session, request: request, data: sendingData)
     }
 
+    override func tearDown() {
+        url = nil
+        request = nil
+        session = nil
+        upload = nil
+        super.tearDown()
+    }
+
     func test__session_receives_request() {
         wait(for: upload)
         XCTAssertProcedureFinishedWithoutErrors(upload)
@@ -72,10 +80,10 @@ class NetworkUploadProcedureTests: ProcedureKitTestCase {
     }
 
     func test__session_error__finishes_with_error() {
-        session.returnedError = TestError()
+        session.returnedError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
         wait(for: upload)
         XCTAssertProcedureFinishedWithErrors(upload, count: 1)
-        XCTAssertEqual(upload.errors.first as? TestError, session.returnedError as? TestError)
+        XCTAssertNotNil(upload.networkError)
     }
 
     func test__completion_handler_receives_data_and_response() {

--- a/Tests/ReachabilityTests.swift
+++ b/Tests/ReachabilityTests.swift
@@ -1,0 +1,177 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+import SystemConfiguration
+@testable import ProcedureKit
+import TestingProcedureKit
+
+class SCNetworkReachabilityFlagsTests: XCTestCase {
+
+    var flags: SCNetworkReachabilityFlags!
+
+    override func tearDown() {
+        flags = nil
+        super.tearDown()
+    }
+
+    func test__flags_is_reachable() {
+        flags = .reachable
+        XCTAssertTrue(flags.isReachable)
+    }
+
+    func test__flags_isConnectionRequired() {
+        flags = .connectionRequired
+        XCTAssertTrue(flags.isConnectionRequired)
+    }
+
+    func test__flags_isInterventionRequired() {
+        flags = .interventionRequired
+        XCTAssertTrue(flags.isInterventionRequired)
+    }
+
+    func test__flags_isConnectionOnTraffic() {
+        flags = .connectionOnTraffic
+        XCTAssertTrue(flags.isConnectionOnTraffic)
+    }
+
+    func test__flags_isConnectionOnDemand() {
+        flags = .connectionOnDemand
+        XCTAssertTrue(flags.isConnectionOnDemand)
+    }
+
+    func test__flags_isConnectionOnTrafficOrDemand_when_onTraffic() {
+        flags = .connectionOnTraffic
+        XCTAssertTrue(flags.isConnectionOnTrafficOrDemand)
+    }
+
+    func test__flags_isConnectionOnTrafficOrDemand_when_onDemand() {
+        flags = .connectionOnDemand
+        XCTAssertTrue(flags.isConnectionOnTrafficOrDemand)
+    }
+
+    func test__flags_isTransientConnection() {
+        flags = .transientConnection
+        XCTAssertTrue(flags.isTransientConnection)
+    }
+
+    func test__flags_isLocalAddress() {
+        flags = .isLocalAddress
+        XCTAssertTrue(flags.isALocalAddress)
+    }
+
+    func test__flags_isDirect() {
+        flags = .isDirect
+        XCTAssertTrue(flags.isDirectConnection)
+    }
+
+    func test__flags_isConnectionRequiredOrTransient_whenRequired() {
+        flags = .connectionRequired
+        XCTAssertTrue(flags.isConnectionRequiredOrTransient)
+    }
+
+    func test__flags_isConnectionRequiredOrTransient_whenTransient() {
+        flags = .transientConnection
+        XCTAssertTrue(flags.isConnectionRequiredOrTransient)
+    }
+
+    func test__flags_isOnWWAN() {
+        #if os(iOS)
+            flags = .isWWAN
+            XCTAssertTrue(flags.isOnWWAN)
+        #else
+            flags = .reachable
+            XCTAssertFalse(flags.isOnWWAN)
+        #endif
+    }
+
+    func test__flags_isReachableViaWifi_true_when_Reachable() {
+        flags = .reachable
+        XCTAssertTrue(flags.isReachableViaWiFi)
+    }
+
+    func test__flags_isReachableViaWiFi_false_when_Reachable_but_ConnectionRequired() {
+        flags = [ .reachable, .connectionRequired ]
+        XCTAssertFalse(flags.isReachableViaWiFi)
+    }
+
+    func test__flags_isReachableViaWWAN() {
+        #if os(iOS)
+            flags = [ .reachable, .isWWAN ]
+            XCTAssertTrue(flags.isReachableViaWWAN)
+        #else
+            flags = .reachable
+            XCTAssertTrue(flags.isReachableViaWWAN)
+        #endif
+    }
+}
+
+
+class NetworkStatusTests: XCTestCase {
+    typealias Status = Reachability.NetworkStatus
+
+    var flags: SCNetworkReachabilityFlags!
+
+    override func tearDown() {
+        flags = nil
+        super.tearDown()
+    }
+
+    func test__equality() {
+        XCTAssertEqual(Status.reachable(.any), Status.reachable(.any))
+        XCTAssertEqual(Status.reachable(.wifi), Status.reachable(.wifi))
+        XCTAssertEqual(Status.reachable(.wwan), Status.reachable(.wwan))
+        XCTAssertEqual(Status.notReachable, Status.notReachable)
+        XCTAssertNotEqual(Status.reachable(.any), Status.reachable(.wifi))
+        XCTAssertNotEqual(Status.reachable(.wifi), Status.reachable(.wwan))
+        XCTAssertNotEqual(Status.reachable(.wwan), Status.reachable(.wifi))
+        XCTAssertNotEqual(Status.notReachable, Status.reachable(.any))
+    }
+
+    func test__init_flags__reachable_via_wifi() {
+        flags = [ .reachable ]
+        XCTAssertEqual(Status(flags: flags), Status.reachable(.wifi))
+    }
+
+    func test__init_flags__reachable_via_wwan() {
+        #if os(iOS)
+            flags = [ .reachable, .isWWAN ]
+            XCTAssertEqual(Reachability.NetworkStatus(flags: flags), Reachability.NetworkStatus.reachable(.wwan))
+        #endif
+    }
+
+    func test__init_flags__not_reachable() {
+        flags = [ .connectionRequired ]
+        XCTAssertEqual(Status(flags: flags), Status.notReachable)
+    }
+
+    func test__not_reachable_is_not_connected() {
+        let status: Status = .notReachable
+        XCTAssertFalse(status.isConnected(via: .any))
+    }
+
+    func test__reachable_via_wwan_is_not_connected_for_wifi() {
+        let status: Status = .reachable(.wwan)
+        XCTAssertFalse(status.isConnected(via: .wifi))
+    }
+
+    func test__reachable_via_wifi_is_connected_for_wwan() {
+        let status: Status = .reachable(.wifi)
+        XCTAssertTrue(status.isConnected(via: .wwan))
+    }
+}
+
+class ReachabilityObserverTests: XCTestCase {
+
+    func test__init() {
+        var didRunBlock = false
+        let observer = Reachability.Observer(connectivity: .any) { didRunBlock = true }
+        observer.didConnectBlock()
+        XCTAssertTrue(didRunBlock)
+    }
+}
+
+

--- a/Tests/ReachabilityTests.swift
+++ b/Tests/ReachabilityTests.swift
@@ -109,7 +109,6 @@ class SCNetworkReachabilityFlagsTests: XCTestCase {
     }
 }
 
-
 class NetworkStatusTests: XCTestCase {
     typealias Status = Reachability.NetworkStatus
 


### PR DESCRIPTION
- [x] Adds `Reachable` API wrappers back
- [x] Define protocols for constraints. Definitely require an error protocol, so that we can know that the procedure finishes with a network error.
- [x] Create a `RetryProcedure` subclass. Something like this:

```swift
final public class ReachableProcedure<T: ProcedureProtocol>: RetryProcedure<T> 
    where T: AssociatedErrorProtocol, T.AssociatedError: ReachableNetworkProcedureError {
    // etc
}
``` 