### PR TITLE
Improve how stress tests are run in CI

### DIFF
--- a/.ci/buildkite/pipeline.template.yml
+++ b/.ci/buildkite/pipeline.template.yml
@@ -33,12 +33,12 @@ steps:
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane mac test_mac"
     agents:
       xcode: "$XCODE"      
- -
-   name: "ProcedureKit (iOS)"
-   command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_ios"
-   agents:
-     queue: "iOS-Simulator"
-     xcode: "$XCODE"
+  -
+    name: "ProcedureKit (iOS)"
+    command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_ios"
+    agents:
+      queue: "iOS-Simulator"
+      xcode: "$XCODE"
   -
     name: "Network (iOS)"
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_network_ios"

--- a/.ci/buildkite/pipeline.template.yml
+++ b/.ci/buildkite/pipeline.template.yml
@@ -6,7 +6,7 @@ steps:
     name: "Stress Test"
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane mac stress_test"
     agents:
-      iOS-Simulator: false
+      queue: "stress-tests"
       xcode: "$XCODE"    
   -
     name: "ProcedureKit"
@@ -33,35 +33,35 @@ steps:
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane mac test_mac"
     agents:
       xcode: "$XCODE"      
-#  -
-#    name: "ProcedureKit (iOS)"
-#    command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_ios"
-#    agents:
-#      iOS-Simulator: true
-#      xcode: "$XCODE"
+ -
+   name: "ProcedureKit (iOS)"
+   command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_ios"
+   agents:
+     queue: "iOS-Simulator"
+     xcode: "$XCODE"
   -
     name: "Network (iOS)"
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_network_ios"
     agents:
-      iOS-Simulator: true    
+      queue: "iOS-Simulator"
       xcode: "$XCODE"
   -
     name: "Location (iOS)"
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_location_ios"
     agents:
-      iOS-Simulator: true    
+      queue: "iOS-Simulator"
       xcode: "$XCODE"
   -
     name: "Cloud (iOS)"
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_cloud_ios"
     agents:
-      iOS-Simulator: true    
+      queue: "iOS-Simulator" 
       xcode: "$XCODE"      
   -
     name: "Mobile (iOS)"
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_mobile_ios"
     agents:
-      iOS-Simulator: true    
+      queue: "iOS-Simulator" 
       xcode: "$XCODE"      
 #  -
 #    name: "ProcedureKit: tvOS"
@@ -79,17 +79,17 @@ steps:
     name: "Network (tvOS)"
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_network_tvos"
     agents:
-      iOS-Simulator: true    
+      queue: "iOS-Simulator" 
       xcode: "$XCODE"
   -
     name: "Location (tvOS)"
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_location_tvos"
     agents:
-      iOS-Simulator: true    
+      queue: "iOS-Simulator" 
       xcode: "$XCODE"
   -
     name: "Cloud: tvOS"
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_cloud_tvos"
     agents:
-      iOS-Simulator: true    
+      queue: "iOS-Simulator" 
       xcode: "$XCODE"

--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -159,6 +159,7 @@ platform :mac do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "Stress Tests",
+      configuration: "Release",
       destination: "platform=macOS"
     )
 

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/Stress Tests.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/Stress Tests.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      enableThreadSanitizer = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
We need to 
- [x] run stress tests on the same dedicated build machine
- [x] run stress tests in release configuration
- [x] run stress tests with Thread Sanitizer disabled