### PR TITLE
Procedure & Support thread-safety fixes

### DIFF
--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -142,7 +142,7 @@ public class LogManager: LogManagerProtocol {
 
     var logger: LoggerBlockType {
         get { return loggerLock.read { _logger } }
-        set { loggerLock.write { self._logger = newValue } }
+        set { loggerLock.write_sync { self._logger = newValue } }
     }
 
     init() {

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -258,10 +258,10 @@ open class Procedure: Operation, ProcedureProtocol {
      The default behavior of Operation is to automatically call finish()
      when:
      (a) it's cancelled, whether that occurs:
-     - prior to the Operation starting
-     (in which case, Operation will skip calling execute())
-     - on another thread at the same time that the operation is
-     executing
+        - prior to the Operation starting
+          (in which case, Operation will skip calling execute())
+        - on another thread at the same time that the operation is
+          executing
      (b) when willExecuteObservers log errors
 
      To ensure that an Operation subclass does not finish until the
@@ -277,9 +277,9 @@ open class Procedure: Operation, ProcedureProtocol {
 
      ```swift
      guard !cancelled else {
-     // do any necessary clean-up
-     finish()    // always call finish if automatic finishing is disabled
-     return
+        // do any necessary clean-up
+        finish()    // always call finish if automatic finishing is disabled
+        return
      }
      ```
 

--- a/Sources/Support.swift
+++ b/Sources/Support.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Dispatch
+
 internal func _abstractMethod(file: StaticString = #file, line: UInt = #line) {
     fatalError("Method must be overriden", file: file, line: line)
 }

--- a/Sources/Support.swift
+++ b/Sources/Support.swift
@@ -75,12 +75,8 @@ public class Protector<T> {
         return read { $0 }
     }
 
-    public func read<U>(_ block: @escaping (T) -> U) -> U {
-        return lock.read { [unowned self] in block(self.ward) }
-    }
-
-    public func write(_ block: @escaping (inout T) -> Void) {
-        lock.write({ block(&self.ward) })
+    public func read<U>(_ block: (T) -> U) -> U {
+        return lock.read { block(self.ward) }
     }
 
     /// Synchronously modify the protected value

--- a/Sources/Support.swift
+++ b/Sources/Support.swift
@@ -85,6 +85,13 @@ public class Protector<T> {
     @discardableResult public func write<U>(_ block: (inout T) -> U) -> U {
         return lock.write_sync({ block(&self.ward) })
     }
+
+    // Supports old callers that expect to pass in a completion block
+    // NOTE: Like `write()`, this is synchronous.
+    public func write(_ block: (inout T) -> Void, completion: (() -> Void)) {
+        lock.write_sync({ block(&self.ward) })
+        completion()
+    }
 }
 
 public extension Protector where T: RangeReplaceableCollection {


### PR DESCRIPTION
Fixes issues identified by an audit and Thread Sanitizer.

`add(directDependency:)`
`remove(directDependency:)`
`add(condition:)`
are now thread-safe.

In addition, accessing the various properties are now thread-safe.

And a data race that was not prevented by the existing use of locks surrounding `_error` is resolved.