### PR TITLE
NetworkDataProcedure, NetworkDownloadProcedure, NetworkUploadProcedure thread-safety

### DIFF
--- a/Sources/Network/NetworkData.swift
+++ b/Sources/Network/NetworkData.swift
@@ -13,25 +13,47 @@ open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, Inpu
     public typealias NetworkResult = ProcedureResult<HTTPPayloadResponse<Data>>
     public typealias CompletionBlock = (NetworkResult) -> Void
 
-    public var input: Pending<URLRequest> = .pending
-    public var output: Pending<NetworkResult> = .pending
+    public var input: Pending<URLRequest> {
+        get { return stateLock.withCriticalScope { _input } }
+        set {
+            stateLock.withCriticalScope {
+                _input = newValue
+            }
+        }
+    }
 
-    public private(set) var session: Session
+    public var output: Pending<NetworkResult> {
+        get { return stateLock.withCriticalScope { _output } }
+        set {
+            stateLock.withCriticalScope {
+                _output = newValue
+            }
+        }
+    }
+
+    public let session: Session
     public let completion: CompletionBlock
 
+    private let stateLock = NSLock()
     internal var task: Session.DataTask? = nil
+    private var _input: Pending<URLRequest> = .pending
+    private var _output: Pending<NetworkResult> = .pending
 
     public var networkError: ProcedureKitNetworkError? {
         return output.error as? ProcedureKitNetworkError ?? errors.flatMap { $0 as? ProcedureKitNetworkError }.first
     }
 
     public init(session: Session, request: URLRequest? = nil, completionHandler: @escaping CompletionBlock = { _ in }) {
+
         self.session = session
-        self.input = request.flatMap { .ready($0) } ?? .pending
         self.completion = completionHandler
         super.init()
+        self.input = request.flatMap { .ready($0) } ?? .pending
+
         addWillCancelBlockObserver { procedure, _ in
-            procedure.task?.cancel()
+            procedure.stateLock.withCriticalScope {
+                procedure.task?.cancel()
+            }
         }
     }
 
@@ -41,25 +63,27 @@ open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, Inpu
             return
         }
 
-        task = session.dataTask(with: request) { [weak self] data, response, error in
-            guard let strongSelf = self else { return }
+        stateLock.withCriticalScope {
+            task = session.dataTask(with: request) { [weak self] data, response, error in
+                guard let strongSelf = self else { return }
 
-            if let error = error {
-                strongSelf.finish(withResult: .failure(ProcedureKitNetworkError(error as NSError)))
-                return
+                if let error = error {
+                    strongSelf.finish(withResult: .failure(ProcedureKitNetworkError(error as NSError)))
+                    return
+                }
+
+                guard let data = data, let response = response as? HTTPURLResponse else {
+                    strongSelf.finish(withResult: .failure(ProcedureKitError.unknown))
+                    return
+                }
+
+                let http = HTTPPayloadResponse(payload: data, response: response)
+
+                strongSelf.completion(.success(http))
+                strongSelf.finish(withResult: .success(http))
             }
 
-            guard let data = data, let response = response as? HTTPURLResponse else {
-                strongSelf.finish(withResult: .failure(ProcedureKitError.unknown))
-                return
-            }
-
-            let http = HTTPPayloadResponse(payload: data, response: response)
-
-            strongSelf.completion(.success(http))
-            strongSelf.finish(withResult: .success(http))
+            task?.resume()
         }
-
-        task?.resume()
     }
 }

--- a/Sources/Network/NetworkDownload.swift
+++ b/Sources/Network/NetworkDownload.swift
@@ -13,13 +13,31 @@ open class NetworkDownloadProcedure<Session: URLSessionTaskFactory>: Procedure, 
     public typealias NetworkResult = ProcedureResult<HTTPPayloadResponse<URL>>
     public typealias CompletionBlock = (NetworkResult) -> Void
 
-    public var input: Pending<URLRequest> = .pending
-    public var output: Pending<NetworkResult> = .pending
+    public var input: Pending<URLRequest> {
+        get { return stateLock.withCriticalScope { _input } }
+        set {
+            stateLock.withCriticalScope {
+                _input = newValue
+            }
+        }
+    }
 
-    public private(set) var session: Session
+    public var output: Pending<NetworkResult> {
+        get { return stateLock.withCriticalScope { _output } }
+        set {
+            stateLock.withCriticalScope {
+                _output = newValue
+            }
+        }
+    }
+
+    public let session: Session
     public let completion: CompletionBlock
 
+    private let stateLock = NSLock()
     internal var task: Session.DownloadTask? = nil
+    private var _input: Pending<URLRequest> = .pending
+    private var _output: Pending<NetworkResult> = .pending
 
     public var networkError: ProcedureKitNetworkError? {
         return output.error as? ProcedureKitNetworkError ?? errors.flatMap { $0 as? ProcedureKitNetworkError }.first
@@ -28,12 +46,14 @@ open class NetworkDownloadProcedure<Session: URLSessionTaskFactory>: Procedure, 
     public init(session: Session, request: URLRequest? = nil, completionHandler: @escaping CompletionBlock = { _ in }) {
 
         self.session = session
-        self.input = request.flatMap { .ready($0) } ?? .pending
         self.completion = completionHandler
-
         super.init()
+        self.input = request.flatMap { .ready($0) } ?? .pending
+
         addWillCancelBlockObserver { procedure, _ in
-            procedure.task?.cancel()
+            procedure.stateLock.withCriticalScope {
+                procedure.task?.cancel()
+            }
         }
     }
 
@@ -43,25 +63,27 @@ open class NetworkDownloadProcedure<Session: URLSessionTaskFactory>: Procedure, 
             return
         }
 
-        task = session.downloadTask(with: request) { [weak self] location, response, error in
-            guard let strongSelf = self else { return }
+        stateLock.withCriticalScope {
+            task = session.downloadTask(with: request) { [weak self] location, response, error in
+                guard let strongSelf = self else { return }
 
-            if let error = error {
-                strongSelf.finish(withResult: .failure(ProcedureKitNetworkError(error as NSError)))
-                return
+                if let error = error {
+                    strongSelf.finish(withResult: .failure(ProcedureKitNetworkError(error as NSError)))
+                    return
+                }
+
+                guard let location = location, let response = response as? HTTPURLResponse else {
+                    strongSelf.finish(withResult: .failure(ProcedureKitError.unknown))
+                    return
+                }
+
+                let http = HTTPPayloadResponse(payload: location, response: response)
+
+                strongSelf.completion(.success(http))
+                strongSelf.finish(withResult: .success(http))
             }
 
-            guard let location = location, let response = response as? HTTPURLResponse else {
-                strongSelf.finish(withResult: .failure(ProcedureKitError.unknown))
-                return
-            }
-
-            let http = HTTPPayloadResponse(payload: location, response: response)
-
-            strongSelf.completion(.success(http))
-            strongSelf.finish(withResult: .success(http))
+            task?.resume()
         }
-
-        task?.resume()
     }
 }


### PR DESCRIPTION
Thread-safety for `input` and `output`, as well as in the event of cancellation (which can occur on any thread).