### PR TITLE
Add missing imports to make Xcode happier

### DIFF
--- a/Sources/Any.swift
+++ b/Sources/Any.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Dispatch
+
 class AnyProcedureBox_<Input, Output>: GroupProcedure, InputProcedure, OutputProcedure {
     var input: Pending<Input> = .pending
     var output: Pending<ProcedureResult<Output>> = .pending

--- a/Sources/AnyObserver.swift
+++ b/Sources/AnyObserver.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+
 class AnyObserverBox_<Procedure: ProcedureProtocol>: ProcedureObserver {
     func didAttach(to procedure: Procedure) { _abstractMethod() }
     func will(execute procedure: Procedure) { _abstractMethod() }

--- a/Sources/BlockObservers.swift
+++ b/Sources/BlockObservers.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+
 public struct Observer<Procedure: ProcedureProtocol> {
 
     public typealias VoidBlock = (Procedure) -> Void

--- a/Sources/Cloud/CKFetchShareMetadataOperation.swift
+++ b/Sources/Cloud/CKFetchShareMetadataOperation.swift
@@ -4,6 +4,7 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
 import CloudKit
 
 /// A generic protocol which exposes the properties used by Apple's CKFetchShareMetadataOperation.

--- a/Sources/Cloud/CKOperation.swift
+++ b/Sources/Cloud/CKOperation.swift
@@ -4,6 +4,7 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
 import CloudKit
 
 /**

--- a/Sources/Cloud/CloudKit.swift
+++ b/Sources/Cloud/CloudKit.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
 import CloudKit
 
 /**

--- a/Sources/Cloud/CloudKitError.swift
+++ b/Sources/Cloud/CloudKitError.swift
@@ -4,6 +4,7 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
 import CloudKit
 
 /// An error protocol for CloudKit errors.

--- a/Sources/Collection+ProcedureKit.swift
+++ b/Sources/Collection+ProcedureKit.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+
 extension Collection where Iterator.Element: Operation {
 
     internal var operationsAndProcedures: ([Operation], [Procedure]) {

--- a/Sources/Composed.swift
+++ b/Sources/Composed.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
+
 open class ComposedProcedure<T: Operation>: GroupProcedure {
 
     public private(set) var operation: T

--- a/Sources/Condition.swift
+++ b/Sources/Condition.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+
 public typealias ConditionResult = ProcedureResult<Bool>
 
 public protocol ConditionProtocol: ProcedureProtocol {

--- a/Sources/Delay.swift
+++ b/Sources/Delay.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
+
 public enum Delay: Comparable {
 
     public static func == (lhs: Delay, rhs: Delay) -> Bool {

--- a/Sources/DispatchQueue+ProcedureKit.swift
+++ b/Sources/DispatchQueue+ProcedureKit.swift
@@ -4,6 +4,7 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
 import Dispatch
 
 // MARK: - Queue

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -6,6 +6,9 @@
 
 // swiftlint:disable file_length
 
+import Foundation
+import Dispatch
+
 /**
  A `Procedure` subclass which enables the grouping
  of other procedures. Use `Group`s to associate

--- a/Sources/Identity.swift
+++ b/Sources/Identity.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+
 public protocol Identifiable {
     var identifier: UUID { get }
 }

--- a/Sources/Location/LocationSupport.swift
+++ b/Sources/Location/LocationSupport.swift
@@ -4,6 +4,7 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Dispatch
 import CoreLocation
 import MapKit
 

--- a/Sources/Location/ReverseGeocode.swift
+++ b/Sources/Location/ReverseGeocode.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
 import CoreLocation
 import MapKit
 

--- a/Sources/Location/ReverseGeocodeUserLocation.swift
+++ b/Sources/Location/ReverseGeocodeUserLocation.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
 import CoreLocation
 import MapKit
 

--- a/Sources/Location/UserLocation.swift
+++ b/Sources/Location/UserLocation.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
 import CoreLocation
 import MapKit
 

--- a/Sources/Logging.swift
+++ b/Sources/Logging.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
+
 /**
  Log Severity
 

--- a/Sources/Mobile/BackgroundObserver.swift
+++ b/Sources/Mobile/BackgroundObserver.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import UIKit
+
 internal protocol BackgroundTaskApplicationProtocol {
 
     var applicationState: UIApplicationState { get }

--- a/Sources/Mobile/NetworkObserver.swift
+++ b/Sources/Mobile/NetworkObserver.swift
@@ -4,6 +4,10 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
+import UIKit
+
 protocol NetworkActivityIndicatorProtocol {
     var networkActivityIndicatorVisible: Bool { get set }
 }

--- a/Sources/MutualExclusion.swift
+++ b/Sources/MutualExclusion.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
+
 /**
  A generic condition for describing operations that
  cannot be allowed to execute concurrently.

--- a/Sources/Operation+ProcedureKit.swift
+++ b/Sources/Operation+ProcedureKit.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+
 internal extension Operation {
 
     enum KeyPath: String {

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -7,6 +7,8 @@
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length
 
+import Foundation
+
 internal struct ProcedureKit {
 
     fileprivate enum FinishingFrom {

--- a/Sources/ProcedureObserver.swift
+++ b/Sources/ProcedureObserver.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+
 /**
  Types which conform to this protocol, can be attached to `Procedure` subclasses to receive
  events at state transitions.

--- a/Sources/ProcedureProcotol.swift
+++ b/Sources/ProcedureProcotol.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+
 public protocol ProcedureProtocol: class {
 
     var procedureName: String { get }

--- a/Sources/ProcedureQueue.swift
+++ b/Sources/ProcedureQueue.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+
 public protocol OperationQueueDelegate: class {
 
     /**

--- a/Sources/Reachability.swift
+++ b/Sources/Reachability.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
 import SystemConfiguration
 
 // MARK: - Public APIs

--- a/Sources/Repeat.swift
+++ b/Sources/Repeat.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
+
 public struct RepeatProcedurePayload<T: Operation> {
     public typealias ConfigureBlock = (T) -> Void
 

--- a/Sources/Retry.swift
+++ b/Sources/Retry.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
+
 public struct RetryFailureInfo<T: Operation> {
 
     /// - returns: the failed operation

--- a/Sources/Support.swift
+++ b/Sources/Support.swift
@@ -4,6 +4,7 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
 import Dispatch
 
 internal func _abstractMethod(file: StaticString = #file, line: UInt = #line) {

--- a/Sources/TimeoutObserver.swift
+++ b/Sources/TimeoutObserver.swift
@@ -4,6 +4,9 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+import Dispatch
+
 /**
  An observer which will automatically cancel (with an error)
  if it doesn't finish before a time interval is expired.


### PR DESCRIPTION
The projects compiled without issues, but Xcode seems to greatly prefer having explicit import statements at the top of each Swift file.

**Exception:**

We don't currently `import ProcedureKit` at the top of Swift files in the other pieces (ProcedureKitCloud, ProcedureKitMobile, etc) because of CocoaPods.