### PR TITLE
Add "batch modify" support to CloudKitProcedure

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		657243911DE9C0BE00BFEB5B /* NetworkObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657243901DE9C0BE00BFEB5B /* NetworkObserver.swift */; };
 		657243931DE9C0CB00BFEB5B /* NetworkObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657243921DE9C0CB00BFEB5B /* NetworkObserverTests.swift */; };
 		657243951DE9C0EF00BFEB5B /* NetworkObserver+Mobile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657243941DE9C0EF00BFEB5B /* NetworkObserver+Mobile.swift */; };
+		657243971DEA425000BFEB5B /* CloudKitBatchProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657243961DEA425000BFEB5B /* CloudKitBatchProcessing.swift */; };
 		657431281D8D9765002E8FC9 /* Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657431271D8D9765002E8FC9 /* Identity.swift */; };
 		6574312B1D8DDF0D002E8FC9 /* BackgroundObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657431291D8DB8AD002E8FC9 /* BackgroundObserver.swift */; };
 		6574312D1D8DE712002E8FC9 /* BackgroundObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6574312C1D8DE712002E8FC9 /* BackgroundObserverTests.swift */; };
@@ -593,6 +594,7 @@
 		657243901DE9C0BE00BFEB5B /* NetworkObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NetworkObserver.swift; path = Sources/NetworkObserver.swift; sourceTree = "<group>"; };
 		657243921DE9C0CB00BFEB5B /* NetworkObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NetworkObserverTests.swift; path = Tests/NetworkObserverTests.swift; sourceTree = "<group>"; };
 		657243941DE9C0EF00BFEB5B /* NetworkObserver+Mobile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NetworkObserver+Mobile.swift"; path = "Sources/Mobile/NetworkObserver+Mobile.swift"; sourceTree = "<group>"; };
+		657243961DEA425000BFEB5B /* CloudKitBatchProcessing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CloudKitBatchProcessing.swift; path = Sources/Cloud/CloudKitBatchProcessing.swift; sourceTree = SOURCE_ROOT; };
 		657431271D8D9765002E8FC9 /* Identity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Identity.swift; path = Sources/Identity.swift; sourceTree = "<group>"; };
 		657431291D8DB8AD002E8FC9 /* BackgroundObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BackgroundObserver.swift; path = Sources/Mobile/BackgroundObserver.swift; sourceTree = "<group>"; };
 		6574312C1D8DE712002E8FC9 /* BackgroundObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BackgroundObserverTests.swift; path = Tests/Mobile/BackgroundObserverTests.swift; sourceTree = "<group>"; };
@@ -1041,10 +1043,11 @@
 			isa = PBXGroup;
 			children = (
 				6532DD891DBCECF800B030F5 /* Extensions */,
+				6532DD8A1DBCEDE800B030F5 /* CloudKit.swift */,
+				657243961DEA425000BFEB5B /* CloudKitBatchProcessing.swift */,
 				65931A5D1DB193B30067B0A4 /* CloudKitCapability.swift */,
 				6532DD5B1DBCE5F500B030F5 /* CloudKitError.swift */,
 				65931A5F1DB2640C0067B0A4 /* CloudKitSupport.swift */,
-				6532DD8A1DBCEDE800B030F5 /* CloudKit.swift */,
 			);
 			name = Cloud;
 			path = ProcedureKitCloud;
@@ -1951,6 +1954,7 @@
 				6532DD821DBCECC500B030F5 /* CKModifyRecordZonesOperation.swift in Sources */,
 				6532DD5E1DBCEA9800B030F5 /* CKOperation.swift in Sources */,
 				6532DD841DBCECD300B030F5 /* CKModifyRecordsOperation.swift in Sources */,
+				657243971DEA425000BFEB5B /* CloudKitBatchProcessing.swift in Sources */,
 				6532DD801DBCECB700B030F5 /* CKFetchSubscriptionsOperation.swift in Sources */,
 				6532DD881DBCECED00B030F5 /* CKQueryOperation.swift in Sources */,
 				65931A601DB2640C0067B0A4 /* CloudKitSupport.swift in Sources */,

--- a/Sources/Cloud/CKMarkNotificationsReadOperation.swift
+++ b/Sources/Cloud/CKMarkNotificationsReadOperation.swift
@@ -16,16 +16,27 @@ public protocol CKMarkNotificationsReadOperationProtocol: CKOperationProtocol {
     var markNotificationsReadCompletionBlock: (([NotificationID]?, Error?) -> Void)? { get set }
 }
 
-public struct MarkNotificationsReadError<NotificationID>: CloudKitError {
+public struct MarkNotificationsReadError<NotificationID>: CloudKitBatchProcessError {
 
     public let underlyingError: Error
     public let marked: [NotificationID]?
+
+    public var processed: [NotificationID]? {
+        return marked
+    }
 }
 
-extension CKMarkNotificationsReadOperation: CKMarkNotificationsReadOperationProtocol, AssociatedErrorProtocol {
+extension CKMarkNotificationsReadOperation: CKMarkNotificationsReadOperationProtocol, AssociatedErrorProtocol, CloudKitBatchProcessOperation {
 
-    // The associated error type
+    public typealias Process = NotificationID
+
+    /// The associated error type
     public typealias AssociatedError = MarkNotificationsReadError<NotificationID>
+
+    public var toProcess: [NotificationID]? {
+        get { return notificationIDs }
+        set { notificationIDs = newValue ?? [] }
+    }
 }
 
 extension CKProcedure where T: CKMarkNotificationsReadOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {

--- a/Sources/Cloud/CKOperation.swift
+++ b/Sources/Cloud/CKOperation.swift
@@ -278,3 +278,54 @@ extension CloudKitProcedure where T: CKOperationProtocol {
         }
     }
 }
+
+internal extension CKProcedure where T: CloudKitBatchProcessOperation {
+
+    var toProcess: [T.Process]? {
+        get { return operation.toProcess }
+        set { operation.toProcess = newValue }
+    }
+}
+
+public extension CloudKitProcedure where T: CloudKitBatchProcessOperation {
+
+    var toProcess: [T.Process]? {
+        get { return current.toProcess }
+        set {
+            current.toProcess = newValue
+            appendConfigureBlock { $0.toProcess = newValue }
+        }
+    }
+}
+
+internal extension CKProcedure where T: CloudKitBatchModifyOperation {
+
+    var toSave: [T.Save]? {
+        get { return operation.toSave }
+        set { operation.toSave = newValue }
+    }
+
+    var toDelete: [T.Delete]? {
+        get { return operation.toDelete }
+        set { operation.toDelete = newValue }
+    }
+}
+
+public extension CloudKitProcedure where T: CloudKitBatchModifyOperation {
+
+    var toSave: [T.Save]? {
+        get { return current.toSave }
+        set {
+            current.toSave = newValue
+            appendConfigureBlock { $0.toSave = newValue }
+        }
+    }
+
+    var toDelete: [T.Delete]? {
+        get { return current.toDelete }
+        set {
+            current.toDelete = newValue
+            appendConfigureBlock { $0.toDelete = newValue }
+        }
+    }
+}

--- a/Sources/Cloud/CloudKitBatchProcessing.swift
+++ b/Sources/Cloud/CloudKitBatchProcessing.swift
@@ -1,0 +1,48 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import Foundation
+import Dispatch
+import CloudKit
+
+// MARK: - Batch Processing
+
+/// An error protocol for batch processing operations
+public protocol CloudKitBatchProcessError: CloudKitError {
+    associatedtype Process
+
+    var processed: [Process]? { get }
+}
+
+// MARK: - Batch Processing
+
+/// A protocol for batch processing operations
+public protocol CloudKitBatchProcessOperation: CKOperationProtocol {
+    associatedtype Process
+    associatedtype AssociatedError: CloudKitBatchProcessError
+
+    var toProcess: [Process]? { get set }
+}
+
+// MARK: - Batch Modification
+
+/// An error protocol for batch modifying operations
+public protocol CloudKitBatchModifyError: CloudKitError {
+    associatedtype Save
+    associatedtype Delete
+
+    var saved: [Save]? { get }
+    var deleted: [Delete]? { get }
+}
+
+public protocol CloudKitBatchModifyOperation: CKOperationProtocol {
+    associatedtype Save
+    associatedtype Delete
+    associatedtype AssociatedError: CloudKitBatchModifyError
+
+    var toSave: [Save]? { get set }
+    var toDelete: [Delete]? { get set }
+}

--- a/Sources/Cloud/CloudKitError.swift
+++ b/Sources/Cloud/CloudKitError.swift
@@ -40,3 +40,156 @@ public extension CloudKitError {
 public struct PKCKError: CloudKitError {
     public let underlyingError: Error
 }
+
+// MARK: - Batch error handling
+
+internal extension Array where Element: Equatable {
+
+    func bisect() -> (left: [Element], right: [Element]) {
+        let half = count / 2
+        return (Array(prefix(upTo: half)), Array(suffix(from: half)))
+    }
+}
+
+public extension CloudKitBatchModifyOperation where Save: Equatable, Save == AssociatedError.Save, Delete: Equatable, Delete == AssociatedError.Delete {
+
+    typealias ToModify = (toSave: [Save]?, toDelete: [Delete]?)
+    typealias ToModifyResponse = (left: ToModify, right: ToModify)
+
+    internal func bisect(error: AssociatedError) -> ToModifyResponse {
+        var left: ToModify = (nil, nil)
+        var right: ToModify = (nil, nil)
+
+        let remainingToSave = toSave?.filter { !(error.saved?.contains($0) ?? false ) }
+        let remainingToDelete = toDelete?.filter { !(error.deleted?.contains($0) ?? false ) }
+
+        if let bisectedToSave = remainingToSave.map({ $0.bisect() }) {
+            left.toSave = bisectedToSave.left
+            right.toSave = bisectedToSave.right
+        }
+
+        if let bisectedToDelete = remainingToDelete.map({ $0.bisect() }) {
+            left.toDelete = bisectedToDelete.left
+            right.toDelete = bisectedToDelete.right
+        }
+
+        return (left, right)
+    }
+}
+
+public extension CloudKitProcedure where T: CloudKitBatchModifyOperation, T.Save: Equatable, T.Save == T.AssociatedError.Save, T.Delete: Equatable, T.Delete == T.AssociatedError.Delete {
+
+    typealias ToModifyResponse = T.ToModifyResponse
+
+    func setErrorHandlerForLimitExceeded(_ handler: @escaping (T.AssociatedError, LoggerProtocol, ToModifyResponse) -> ToModifyResponse? = { $2 }) {
+        set(errorHandlerForCode: .limitExceeded) { [weak self] operation, error, log, suggested in
+
+            guard let strongSelf = self else { return nil }
+
+            log.warning(message: "Received CloudKit Limit Exceeded error: \(error)")
+
+            // Execute the handler
+            guard let response = handler(error, log, operation.bisect(error: error)) else { return nil }
+
+            // Create a new procedure for the left hand bisect of the remaining data
+            let lhs = CloudKitProcedure { T() }
+
+            // Setup basic configuration such as container & database
+            lhs.append(configureBlock: suggested.configure)
+
+            // Set the error handlers
+            lhs.set(errorHandlers: strongSelf.errorHandlers)
+
+            // Set the modifications to perform
+            lhs.toSave = response.left.toSave
+            lhs.toDelete = response.left.toDelete
+
+            // Setup the configuration block for the right hand side
+            // which is the original procedure which will be re-tried
+            let configure = { (rhs: CKProcedure<T>) in
+
+                // Set the suggested configuration
+                suggested.configure(rhs)
+
+                // Set the modifications to perform
+                rhs.toSave = response.right.toSave
+                rhs.toDelete = response.right.toDelete
+
+                // Set the left half as a dependency
+                rhs.add(dependency: lhs)
+            }
+
+            // Add the left hand side procedure to the group
+            strongSelf.add(child: lhs)
+
+            return (suggested.delay, configure)
+        }
+    }
+}
+
+public extension CloudKitBatchProcessOperation where Process: Equatable, Process == AssociatedError.Process {
+
+    typealias ToProcessResponse = (left: [Process]?, right: [Process]?)
+
+    func bisect(error: AssociatedError) -> ToProcessResponse {
+        var left: [Process]? = nil
+        var right: [Process]? = nil
+
+        let remainingToProcess = toProcess?.filter { !(error.processed?.contains($0) ?? false) }
+
+        if let bisectedToProcess = remainingToProcess.map({ $0.bisect() }) {
+            left = bisectedToProcess.left
+            right = bisectedToProcess.right
+        }
+
+        return (left, right)
+    }
+}
+
+public extension CloudKitProcedure where T: CloudKitBatchProcessOperation, T.Process: Equatable, T.Process == T.AssociatedError.Process {
+
+    typealias ToProcessResponse = T.ToProcessResponse
+
+    func setErrorHandlerForLimitExceeded(_ handler: @escaping (T.AssociatedError, LoggerProtocol, ToProcessResponse) -> ToProcessResponse? = { $2 }) {
+        set(errorHandlerForCode: .limitExceeded) { [weak self] operation, error, log, suggested in
+
+            guard let strongSelf = self else { return nil }
+
+            log.warning(message: "Received CloudKit Limit Exceeded error: \(error)")
+
+            // Execute the handler
+            guard let response = handler(error, log, operation.bisect(error: error)) else { return nil }
+
+            // Create a new procedure for the left hand bisect of the remaining data
+            let lhs = CloudKitProcedure { T() }
+
+            // Setup basic configuration such as container & database
+            lhs.append(configureBlock: suggested.configure)
+
+            // Set the error handlers
+            lhs.set(errorHandlers: strongSelf.errorHandlers)
+
+            // Set the modifications to perform
+            lhs.toProcess = response.left
+
+            // Setup the configuration block for the right hand side
+            // which is the original procedure which will be re-tried
+            let configure = { (rhs: CKProcedure<T>) in
+
+                // Set the suggested configuration
+                suggested.configure(rhs)
+
+                // Set the modifications to perform
+                rhs.toProcess = response.right
+
+                // Set the left half as a dependency
+                rhs.add(dependency: lhs)
+            }
+
+            // Add the left hand side procedure to the group
+            strongSelf.add(child: lhs)
+
+            return (suggested.delay, configure)
+        }
+    }
+}

--- a/Sources/Cloud/CloudKitError.swift
+++ b/Sources/Cloud/CloudKitError.swift
@@ -35,24 +35,6 @@ public extension CloudKitError {
     }
 }
 
-// MARK: - Batch Errors
-
-/// An error protocol for batch modifying operations
-public protocol CloudKitBatchModifyError: CloudKitError {
-    associatedtype Save
-    associatedtype Delete
-
-    var saved: [Save]? { get }
-    var deleted: [Delete]? { get }
-}
-
-/// An error protocol for batch processing operations
-public protocol CloudKitBatchProcessError: CloudKitError {
-    associatedtype Process
-
-    var processed: [Process]? { get }
-}
-
 // MARK: - Concrete types
 
 public struct PKCKError: CloudKitError {


### PR DESCRIPTION
Some CloudKit operations work in batches, like modify records, or modify record zones. And it is possible for us to provide some rudimentary error handling when the number of items exceeds the limit.