### PR TITLE
Memory leaks highlighted by Visual Memory Debugger (#622)

### DIFF
--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -99,6 +99,17 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
         self.init(operations: operations)
     }
 
+    deinit {
+        // To ensure that any remaining operations on the internal queue are released
+        // we must cancelAllOperations and also ensure the queue is not suspended.
+        queue.cancelAllOperations()
+        queue.isSuspended = false
+
+        // If you find that execution is stuck on the following line, one of the child
+        // Operations/Procedures is likely not handling cancellation and finishing.
+        queue.waitUntilAllOperationsAreFinished()
+    }
+
     // MARK: - Execute
 
     open override func execute() {

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -42,6 +42,7 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
     fileprivate var groupErrors = Protector(GroupErrors())
     fileprivate var groupChildren: Protector<[Operation]>
     fileprivate var groupIsFinishing = false
+    fileprivate var groupFinishLock = NSRecursiveLock()
     fileprivate var groupIsSuspended = false
     fileprivate var groupSuspendLock = NSLock()
     fileprivate var groupIsAddingOperations = DispatchGroup()
@@ -96,17 +97,6 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
 
     public convenience init(operations: Operation...) {
         self.init(operations: operations)
-    }
-
-    deinit {
-        // To ensure that any remaining operations on the internal queue are released
-        // we must cancelAllOperations and also ensure the queue is not suspended.
-        queue.cancelAllOperations()
-        queue.isSuspended = false
-
-        // If you find that execution is stuck on the following line, one of the child
-        // Operations/Procedures is likely not handling cancellation and finishing.
-        queue.waitUntilAllOperationsAreFinished()
     }
 
     // MARK: - Execute

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -313,12 +313,16 @@ open class Procedure: Operation, ProcedureProtocol {
     public final override func start() {
         // Don't call super.start
 
-        guard !isCancelled || isAutomaticFinishingDisabled else {
-            finish()
-            return
-        }
+        // Replicate NSOperation.start() autorelease behavior
+        // (Push an autoreleasepool before calling main(), pop after main() returns)
+        autoreleasepool {
+            guard !isCancelled || isAutomaticFinishingDisabled else {
+                finish()
+                return
+            }
 
-        main()
+            main()
+        }
     }
 
     /// Triggers execution of the operation's task, correctly managing errors and the cancelled state. Cannot be over-ridden

--- a/Sources/Retry.swift
+++ b/Sources/Retry.swift
@@ -127,6 +127,7 @@ open class RetryProcedure<T: Operation>: RepeatProcedure<T> {
         }
         retry.info = createFailureInfo(for: current, errors: errors)
         returnValue = addNextOperation()
+        retry.info = .none
         return returnValue
     }
 

--- a/Sources/TimeoutObserver.swift
+++ b/Sources/TimeoutObserver.swift
@@ -36,9 +36,10 @@ public struct TimeoutObserver: ProcedureObserver {
     public func will(execute procedure: Procedure) {
         switch delay.interval {
         case (let interval) where interval > 0.0:
-            DispatchQueue.main.asyncAfter(deadline: .now() + interval) { [delay = self.delay] in
-                guard !procedure.isFinished && !procedure.isCancelled else { return }
-                procedure.cancel(withError: ProcedureKitError.timedOut(with: delay))
+            DispatchQueue.main.asyncAfter(deadline: .now() + interval) { [delay = self.delay, weak procedure] in
+                guard let strongProcedure = procedure else { return }
+                guard !strongProcedure.isFinished && !strongProcedure.isCancelled else { return }
+                strongProcedure.cancel(withError: ProcedureKitError.timedOut(with: delay))
             }
         default: break
         }

--- a/Tests/RetryProcedureTests.swift
+++ b/Tests/RetryProcedureTests.swift
@@ -37,4 +37,42 @@ class RetryProcedureTests: RetryTestCase {
         XCTAssertProcedureFinishedWithoutErrors(retry)
         XCTAssertEqual(retry.count, 3)
     }
+
+    func test__retry_deinits_after_finished() {
+        // Catches reference cycles.
+
+        class RetryDeinitMonitor<T: Operation>: RetryProcedure<T> {
+            var deinitBlock: (() -> Void)?
+            override public init<OperationIterator>(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, wait: WaitStrategy, iterator base: OperationIterator, retry block: @escaping Handler) where OperationIterator: IteratorProtocol, OperationIterator.Element == T {
+                super.init(dispatchQueue: dispatchQueue, max: max, wait: wait, iterator: base, retry: block)
+            }
+            deinit {
+                deinitBlock?()
+            }
+        }
+
+        weak var didDeinitExpectation = expectation(description: "RetryProcedure Did DeInit")
+        DispatchQueue.default.async {
+            let queue = ProcedureQueue()
+            let retry = RetryDeinitMonitor<TestProcedure>(wait: .incrementing(initial: 0, increment: 0.001), iterator: self.createOperationIterator(succeedsAfterFailureCount: 2), retry: { $1 })
+            retry.deinitBlock = {
+                DispatchQueue.main.async {
+                    guard let didDeinitExpectation = didDeinitExpectation else { return }
+                    didDeinitExpectation.fulfill()
+                }
+            }
+            let semaphore = DispatchSemaphore(value: 0)
+            retry.addDidFinishBlockObserver { _, _ in
+                semaphore.signal()
+            }
+            queue.add(operation: retry)
+            semaphore.wait()
+        }
+
+        waitForExpectations(timeout: 3) { (error) in
+            if error != nil {
+                XCTFail("RetryProcedure did not deinit - something still has a reference. (Possible cycle.)")
+            }
+        }
+    }
 }


### PR DESCRIPTION
See issue #622.

Underlying problems fixed:

- [x] TimeoutObserver should capture a weak reference to the procedure in its dispatched block

- [x] RetryIterator should not maintain a strong reference to the RetryProcedure

> RetryIterator’s RetryFailureInfo (`info`) property is set right before `addNextOperation()` is called, which calls `next()` on the RetryIterator (which then uses the RetryFailureInfo).
> 
> Ultimately, the RetryFailureInfo contains strong references to the RetryProcedure (`addOperations`, `configure`...). And since the RetryProcedure owns the RetryIterator, which owns the RetryFailureInfo… We end up with a reference cycle.
> 
> As an immediate quick fix, since the RetryFailureInfo is only used in the call to `addNextOperation()`, set it back to `.none` after the call.

- [x] GroupProcedure: ensure that internal queue is emptied on `deinit`

> Previously, a GroupProcedure that was created and released but never added to a queue would leak the child operations on its internal OperationQueue.
> 
> To ensure that it is safe to release a GroupProcedure in all circumstances, add a `deinit` handler that explicitly cancels all operations on the queue, and also ensures that the queue is not suspended (so the queue will handle the clean-up).

- [x] Procedure: Use an autoreleasepool in `start()` override

> Ensures that the `execute()` function, when called (on a background thread), has an autorelease pool.