### PR TITLE
Network*Procedure tweaks

### DIFF
--- a/Sources/Network/NetworkData.swift
+++ b/Sources/Network/NetworkData.swift
@@ -64,6 +64,7 @@ open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, Inpu
         }
 
         stateLock.withCriticalScope {
+            guard !isCancelled else { return }
             task = session.dataTask(with: request) { [weak self] data, response, error in
                 guard let strongSelf = self else { return }
 

--- a/Sources/Network/NetworkData.swift
+++ b/Sources/Network/NetworkData.swift
@@ -35,7 +35,7 @@ open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, Inpu
     public let completion: CompletionBlock
 
     private let stateLock = NSLock()
-    internal var task: Session.DataTask? = nil
+    internal private(set) var task: Session.DataTask? = nil
     private var _input: Pending<URLRequest> = .pending
     private var _output: Pending<NetworkResult> = .pending
 

--- a/Sources/Network/NetworkDownload.swift
+++ b/Sources/Network/NetworkDownload.swift
@@ -64,6 +64,7 @@ open class NetworkDownloadProcedure<Session: URLSessionTaskFactory>: Procedure, 
         }
 
         stateLock.withCriticalScope {
+            guard !isCancelled else { return }
             task = session.downloadTask(with: request) { [weak self] location, response, error in
                 guard let strongSelf = self else { return }
 

--- a/Sources/Network/NetworkDownload.swift
+++ b/Sources/Network/NetworkDownload.swift
@@ -35,7 +35,7 @@ open class NetworkDownloadProcedure<Session: URLSessionTaskFactory>: Procedure, 
     public let completion: CompletionBlock
 
     private let stateLock = NSLock()
-    internal var task: Session.DownloadTask? = nil
+    internal private(set) var task: Session.DownloadTask? = nil
     private var _input: Pending<URLRequest> = .pending
     private var _output: Pending<NetworkResult> = .pending
 

--- a/Sources/Network/NetworkUpload.swift
+++ b/Sources/Network/NetworkUpload.swift
@@ -35,7 +35,7 @@ open class NetworkUploadProcedure<Session: URLSessionTaskFactory>: Procedure, In
     public let completion: CompletionBlock
 
     private let stateLock = NSLock()
-    internal var task: Session.UploadTask? = nil
+    internal private(set) var task: Session.UploadTask? = nil
     private var _input: Pending<HTTPPayloadRequest<Data>> = .pending
     private var _output: Pending<NetworkResult> = .pending
 

--- a/Sources/Network/NetworkUpload.swift
+++ b/Sources/Network/NetworkUpload.swift
@@ -64,6 +64,7 @@ open class NetworkUploadProcedure<Session: URLSessionTaskFactory>: Procedure, In
         }
 
         stateLock.withCriticalScope {
+            guard !isCancelled else { return }
             task = session.uploadTask(with: requirement.request, from: requirement.payload) { [weak self] data, response, error in
                 guard let strongSelf = self else { return }
 


### PR DESCRIPTION
- [x] Resolve cancellation race condition in Network*Procedure

> Must check `!isCancelled` inside the `stateLock`, or it is possible for a `NetworkDataProcedure` / `NetworkDownloadProcedure` / `NetworkUploadProcedure` that is cancelled after the `execute()` function is called, but before the acquisition of the `stateLock` inside it, to continue to create a network task.

- [x] Mark `task` as `private(set)`

> Per Slack discussion.