### PR TITLE
Network*Procedure tweaks

### DIFF
--- a/Sources/Network/NetworkData.swift
+++ b/Sources/Network/NetworkData.swift
@@ -50,7 +50,7 @@ open class NetworkDataProcedure<Session: URLSessionTaskFactory>: Procedure, Inpu
         super.init()
         self.input = request.flatMap { .ready($0) } ?? .pending
 
-        addWillCancelBlockObserver { procedure, _ in
+        addDidCancelBlockObserver { procedure, _ in
             procedure.stateLock.withCriticalScope {
                 procedure.task?.cancel()
             }

--- a/Sources/Network/NetworkDownload.swift
+++ b/Sources/Network/NetworkDownload.swift
@@ -50,7 +50,7 @@ open class NetworkDownloadProcedure<Session: URLSessionTaskFactory>: Procedure, 
         super.init()
         self.input = request.flatMap { .ready($0) } ?? .pending
 
-        addWillCancelBlockObserver { procedure, _ in
+        addDidCancelBlockObserver { procedure, _ in
             procedure.stateLock.withCriticalScope {
                 procedure.task?.cancel()
             }

--- a/Sources/Network/NetworkUpload.swift
+++ b/Sources/Network/NetworkUpload.swift
@@ -50,7 +50,7 @@ open class NetworkUploadProcedure<Session: URLSessionTaskFactory>: Procedure, In
         super.init()
         self.input = request.flatMap { .ready(HTTPPayloadRequest(payload: data, request: $0)) } ?? .pending
 
-        addWillCancelBlockObserver { procedure, _ in
+        addDidCancelBlockObserver { procedure, _ in
             procedure.stateLock.withCriticalScope {
                 procedure.task?.cancel()
             }


### PR DESCRIPTION
The internal cancel observer should be a DidCancelObserver. (Also required to fully resolve the cancellation race condition.)