### PR TITLE
Add steps to CI for TryProcedureKit integration

### DIFF
--- a/.ci/buildkite/pipeline.template.yml
+++ b/.ci/buildkite/pipeline.template.yml
@@ -93,3 +93,17 @@ steps:
     agents:
       queue: "iOS-Simulator" 
       xcode: "$XCODE"
+
+  - wait
+  
+  -
+    name: "Test CocoaPods Integration"
+    trigger: "TryProcedureKit"
+    build:
+      message: "Testing ProcedureKit Integration via Cocoapods"
+      commit: "HEAD"
+      branch: "cocoapods/macOS"
+      env:
+        PROCEDUREKIT_HASH: $BUILDKITE_COMMIT
+
+

--- a/.ci/buildkite/pipeline.template.yml
+++ b/.ci/buildkite/pipeline.template.yml
@@ -88,7 +88,7 @@ steps:
       queue: "iOS-Simulator" 
       xcode: "$XCODE"
   -
-    name: "Cloud: tvOS"
+    name: "Cloud (tvOS)"
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane ios test_cloud_tvos"
     agents:
       queue: "iOS-Simulator" 

--- a/.ci/buildkite/pipeline.template.yml
+++ b/.ci/buildkite/pipeline.template.yml
@@ -104,6 +104,6 @@ steps:
       commit: "HEAD"
       branch: "cocoapods/macOS"
       env:
-        PROCEDUREKIT_HASH: $BUILDKITE_COMMIT
+        PROCEDUREKIT_HASH: "$COMMIT"
 
 

--- a/.ci/buildkite/pipeline.template.yml
+++ b/.ci/buildkite/pipeline.template.yml
@@ -102,7 +102,7 @@ steps:
     build:
       message: "Testing ProcedureKit Integration via Cocoapods"
       commit: "HEAD"
-      branch: "cocoapods/macOS"
+      branch: "cocoapods"
       env:
         PROCEDUREKIT_HASH: "$COMMIT"
 

--- a/.ci/buildkite/pipeline.template.yml
+++ b/.ci/buildkite/pipeline.template.yml
@@ -98,7 +98,7 @@ steps:
   
   -
     name: "Test CocoaPods Integration"
-    trigger: "TryProcedureKit"
+    trigger: "tryprocedurekit"
     build:
       message: "Testing ProcedureKit Integration via Cocoapods"
       commit: "HEAD"


### PR DESCRIPTION
- [x] Given that all unit tests have passed, 
- [x] New step
- [x] Create/Trigger a build on _TryProcedureKit_ pipeline
- [x] Set `PROCEDUREKIT_HASH` to `BUILDKITE_COMMIT`