### PR TITLE
UIProcedure & AlertProcedure

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -138,7 +138,7 @@
 		658B145A1DDE1D7900D63100 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14591DDE1D7900D63100 /* Network.swift */; };
 		658B145C1DDE1D9B00D63100 /* NetworkProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B145B1DDE1D9B00D63100 /* NetworkProcedureTests.swift */; };
 		658B145E1DDF5C4000D63100 /* ProcedureKitErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B145D1DDF5C4000D63100 /* ProcedureKitErrorTests.swift */; };
-		658B14601DDF635500D63100 /* Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B145F1DDF635500D63100 /* Presentation.swift */; };
+		658B14601DDF635500D63100 /* UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B145F1DDF635500D63100 /* UI.swift */; };
 		658B14621DDF637000D63100 /* PresentationProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14611DDF637000D63100 /* PresentationProcedureTests.swift */; };
 		6591B3001D74954E00C2B57F /* GroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B2FE1D74953A00C2B57F /* GroupTests.swift */; };
 		6591B3021D74980900C2B57F /* GroupTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B3011D74980900C2B57F /* GroupTestCase.swift */; };
@@ -190,6 +190,7 @@
 		65B83EB71D731DE8007EFBFA /* Collection+ProcedureKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B83EB61D731DE8007EFBFA /* Collection+ProcedureKit.swift */; };
 		65B97DB51D65138F00AC3B5D /* Procedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B97DB41D65138F00AC3B5D /* Procedure.swift */; };
 		65C540401DF6028B00DCB059 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5403F1DF6028B00DCB059 /* Alert.swift */; };
+		65C540421DF62C3500DCB059 /* UIProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C540411DF62C3500DCB059 /* UIProcedureTests.swift */; };
 		65CFC5FA1D608A5500CAD875 /* ProcedureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */; };
 		65CFC60B1D608AA700CAD875 /* ProcedureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 65CFC60A1D608AA700CAD875 /* ProcedureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		65CFC61F1D60904700CAD875 /* TestingProcedureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 65CFC61E1D60904700CAD875 /* TestingProcedureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -614,7 +615,7 @@
 		658B14591DDE1D7900D63100 /* Network.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
 		658B145B1DDE1D9B00D63100 /* NetworkProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkProcedureTests.swift; sourceTree = "<group>"; };
 		658B145D1DDF5C4000D63100 /* ProcedureKitErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProcedureKitErrorTests.swift; path = Tests/ProcedureKitErrorTests.swift; sourceTree = "<group>"; };
-		658B145F1DDF635500D63100 /* Presentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Presentation.swift; path = Sources/Mobile/Presentation.swift; sourceTree = "<group>"; };
+		658B145F1DDF635500D63100 /* UI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UI.swift; path = Sources/Mobile/UI.swift; sourceTree = "<group>"; };
 		658B14611DDF637000D63100 /* PresentationProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PresentationProcedureTests.swift; path = Tests/Mobile/PresentationProcedureTests.swift; sourceTree = "<group>"; };
 		6591B2FE1D74953A00C2B57F /* GroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTests.swift; path = Tests/GroupTests.swift; sourceTree = "<group>"; };
 		6591B3011D74980900C2B57F /* GroupTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTestCase.swift; path = Sources/Testing/GroupTestCase.swift; sourceTree = "<group>"; };
@@ -664,6 +665,7 @@
 		65B83EB61D731DE8007EFBFA /* Collection+ProcedureKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Collection+ProcedureKit.swift"; path = "Sources/Collection+ProcedureKit.swift"; sourceTree = "<group>"; };
 		65B97DB41D65138F00AC3B5D /* Procedure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Procedure.swift; path = Sources/Procedure.swift; sourceTree = "<group>"; };
 		65C5403F1DF6028B00DCB059 /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Alert.swift; path = Sources/Mobile/Alert.swift; sourceTree = "<group>"; };
+		65C540411DF62C3500DCB059 /* UIProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIProcedureTests.swift; path = Tests/Mobile/UIProcedureTests.swift; sourceTree = "<group>"; };
 		65C88D761DC4EB4300C8D4EB /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Warnings.xcconfig; path = "Supporting Files/Warnings.xcconfig"; sourceTree = "<group>"; };
 		65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ProcedureKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65CFC5F91D608A5500CAD875 /* ProcedureKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProcedureKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -957,7 +959,7 @@
 			children = (
 				657431291D8DB8AD002E8FC9 /* BackgroundObserver.swift */,
 				657243941DE9C0EF00BFEB5B /* NetworkObserver+Mobile.swift */,
-				658B145F1DDF635500D63100 /* Presentation.swift */,
+				658B145F1DDF635500D63100 /* UI.swift */,
 				65C5403F1DF6028B00DCB059 /* Alert.swift */,
 			);
 			name = Mobile;
@@ -989,6 +991,7 @@
 				658B14611DDF637000D63100 /* PresentationProcedureTests.swift */,
 				653C9FE61D6099850070B7A2 /* ProcedureKitMobileTests.swift */,
 				6574312E1D8DE848002E8FC9 /* TestableUIApplication.swift */,
+				65C540411DF62C3500DCB059 /* UIProcedureTests.swift */,
 			);
 			name = "Mobile Tests";
 			sourceTree = "<group>";
@@ -1895,7 +1898,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				657243951DE9C0EF00BFEB5B /* NetworkObserver+Mobile.swift in Sources */,
-				658B14601DDF635500D63100 /* Presentation.swift in Sources */,
+				658B14601DDF635500D63100 /* UI.swift in Sources */,
 				65C540401DF6028B00DCB059 /* Alert.swift in Sources */,
 				6574312B1D8DDF0D002E8FC9 /* BackgroundObserver.swift in Sources */,
 			);
@@ -1907,6 +1910,7 @@
 			files = (
 				653C9FEA1D6099F40070B7A2 /* ProcedureKitMobileTests.swift in Sources */,
 				6574312F1D8DE848002E8FC9 /* TestableUIApplication.swift in Sources */,
+				65C540421DF62C3500DCB059 /* UIProcedureTests.swift in Sources */,
 				658B14621DDF637000D63100 /* PresentationProcedureTests.swift in Sources */,
 				6574312D1D8DE712002E8FC9 /* BackgroundObserverTests.swift in Sources */,
 			);

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		65B3D6461DAC40370074CA9D /* ReverseGeocodeUserLocationProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B3D6451DAC40370074CA9D /* ReverseGeocodeUserLocationProcedureTests.swift */; };
 		65B83EB71D731DE8007EFBFA /* Collection+ProcedureKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B83EB61D731DE8007EFBFA /* Collection+ProcedureKit.swift */; };
 		65B97DB51D65138F00AC3B5D /* Procedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B97DB41D65138F00AC3B5D /* Procedure.swift */; };
+		65C540401DF6028B00DCB059 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5403F1DF6028B00DCB059 /* Alert.swift */; };
 		65CFC5FA1D608A5500CAD875 /* ProcedureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */; };
 		65CFC60B1D608AA700CAD875 /* ProcedureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 65CFC60A1D608AA700CAD875 /* ProcedureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		65CFC61F1D60904700CAD875 /* TestingProcedureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 65CFC61E1D60904700CAD875 /* TestingProcedureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -662,6 +663,7 @@
 		65B3D6451DAC40370074CA9D /* ReverseGeocodeUserLocationProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReverseGeocodeUserLocationProcedureTests.swift; sourceTree = "<group>"; };
 		65B83EB61D731DE8007EFBFA /* Collection+ProcedureKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Collection+ProcedureKit.swift"; path = "Sources/Collection+ProcedureKit.swift"; sourceTree = "<group>"; };
 		65B97DB41D65138F00AC3B5D /* Procedure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Procedure.swift; path = Sources/Procedure.swift; sourceTree = "<group>"; };
+		65C5403F1DF6028B00DCB059 /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Alert.swift; path = Sources/Mobile/Alert.swift; sourceTree = "<group>"; };
 		65C88D761DC4EB4300C8D4EB /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Warnings.xcconfig; path = "Supporting Files/Warnings.xcconfig"; sourceTree = "<group>"; };
 		65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ProcedureKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65CFC5F91D608A5500CAD875 /* ProcedureKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProcedureKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -956,6 +958,7 @@
 				657431291D8DB8AD002E8FC9 /* BackgroundObserver.swift */,
 				657243941DE9C0EF00BFEB5B /* NetworkObserver+Mobile.swift */,
 				658B145F1DDF635500D63100 /* Presentation.swift */,
+				65C5403F1DF6028B00DCB059 /* Alert.swift */,
 			);
 			name = Mobile;
 			sourceTree = "<group>";
@@ -1893,6 +1896,7 @@
 			files = (
 				657243951DE9C0EF00BFEB5B /* NetworkObserver+Mobile.swift in Sources */,
 				658B14601DDF635500D63100 /* Presentation.swift in Sources */,
+				65C540401DF6028B00DCB059 /* Alert.swift in Sources */,
 				6574312B1D8DDF0D002E8FC9 /* BackgroundObserver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		65B97DB51D65138F00AC3B5D /* Procedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B97DB41D65138F00AC3B5D /* Procedure.swift */; };
 		65C540401DF6028B00DCB059 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C5403F1DF6028B00DCB059 /* Alert.swift */; };
 		65C540421DF62C3500DCB059 /* UIProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C540411DF62C3500DCB059 /* UIProcedureTests.swift */; };
+		65C540441DF6340900DCB059 /* AlertProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C540431DF6340900DCB059 /* AlertProcedureTests.swift */; };
 		65CFC5FA1D608A5500CAD875 /* ProcedureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */; };
 		65CFC60B1D608AA700CAD875 /* ProcedureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 65CFC60A1D608AA700CAD875 /* ProcedureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		65CFC61F1D60904700CAD875 /* TestingProcedureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 65CFC61E1D60904700CAD875 /* TestingProcedureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -666,6 +667,7 @@
 		65B97DB41D65138F00AC3B5D /* Procedure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Procedure.swift; path = Sources/Procedure.swift; sourceTree = "<group>"; };
 		65C5403F1DF6028B00DCB059 /* Alert.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Alert.swift; path = Sources/Mobile/Alert.swift; sourceTree = "<group>"; };
 		65C540411DF62C3500DCB059 /* UIProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIProcedureTests.swift; path = Tests/Mobile/UIProcedureTests.swift; sourceTree = "<group>"; };
+		65C540431DF6340900DCB059 /* AlertProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AlertProcedureTests.swift; path = Tests/Mobile/AlertProcedureTests.swift; sourceTree = "<group>"; };
 		65C88D761DC4EB4300C8D4EB /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Warnings.xcconfig; path = "Supporting Files/Warnings.xcconfig"; sourceTree = "<group>"; };
 		65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ProcedureKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65CFC5F91D608A5500CAD875 /* ProcedureKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProcedureKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -992,6 +994,7 @@
 				653C9FE61D6099850070B7A2 /* ProcedureKitMobileTests.swift */,
 				6574312E1D8DE848002E8FC9 /* TestableUIApplication.swift */,
 				65C540411DF62C3500DCB059 /* UIProcedureTests.swift */,
+				65C540431DF6340900DCB059 /* AlertProcedureTests.swift */,
 			);
 			name = "Mobile Tests";
 			sourceTree = "<group>";
@@ -1908,6 +1911,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				65C540441DF6340900DCB059 /* AlertProcedureTests.swift in Sources */,
 				653C9FEA1D6099F40070B7A2 /* ProcedureKitMobileTests.swift in Sources */,
 				6574312F1D8DE848002E8FC9 /* TestableUIApplication.swift in Sources */,
 				65C540421DF62C3500DCB059 /* UIProcedureTests.swift in Sources */,

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -138,6 +138,8 @@
 		658B145A1DDE1D7900D63100 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14591DDE1D7900D63100 /* Network.swift */; };
 		658B145C1DDE1D9B00D63100 /* NetworkProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B145B1DDE1D9B00D63100 /* NetworkProcedureTests.swift */; };
 		658B145E1DDF5C4000D63100 /* ProcedureKitErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B145D1DDF5C4000D63100 /* ProcedureKitErrorTests.swift */; };
+		658B14601DDF635500D63100 /* Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B145F1DDF635500D63100 /* Presentation.swift */; };
+		658B14621DDF637000D63100 /* PresentationProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658B14611DDF637000D63100 /* PresentationProcedureTests.swift */; };
 		6591B3001D74954E00C2B57F /* GroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B2FE1D74953A00C2B57F /* GroupTests.swift */; };
 		6591B3021D74980900C2B57F /* GroupTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6591B3011D74980900C2B57F /* GroupTestCase.swift */; };
 		6593008C1DA8E31900750212 /* TransformProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6593008B1DA8E31900750212 /* TransformProcedureTests.swift */; };
@@ -611,6 +613,8 @@
 		658B14591DDE1D7900D63100 /* Network.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Network.swift; sourceTree = "<group>"; };
 		658B145B1DDE1D9B00D63100 /* NetworkProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkProcedureTests.swift; sourceTree = "<group>"; };
 		658B145D1DDF5C4000D63100 /* ProcedureKitErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProcedureKitErrorTests.swift; path = Tests/ProcedureKitErrorTests.swift; sourceTree = "<group>"; };
+		658B145F1DDF635500D63100 /* Presentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Presentation.swift; path = Sources/Mobile/Presentation.swift; sourceTree = "<group>"; };
+		658B14611DDF637000D63100 /* PresentationProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PresentationProcedureTests.swift; path = Tests/Mobile/PresentationProcedureTests.swift; sourceTree = "<group>"; };
 		6591B2FE1D74953A00C2B57F /* GroupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTests.swift; path = Tests/GroupTests.swift; sourceTree = "<group>"; };
 		6591B3011D74980900C2B57F /* GroupTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GroupTestCase.swift; path = Sources/Testing/GroupTestCase.swift; sourceTree = "<group>"; };
 		6593008B1DA8E31900750212 /* TransformProcedureTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TransformProcedureTests.swift; path = Tests/TransformProcedureTests.swift; sourceTree = "<group>"; };
@@ -951,6 +955,7 @@
 			children = (
 				657431291D8DB8AD002E8FC9 /* BackgroundObserver.swift */,
 				657243941DE9C0EF00BFEB5B /* NetworkObserver+Mobile.swift */,
+				658B145F1DDF635500D63100 /* Presentation.swift */,
 			);
 			name = Mobile;
 			sourceTree = "<group>";
@@ -978,6 +983,7 @@
 			isa = PBXGroup;
 			children = (
 				6574312C1D8DE712002E8FC9 /* BackgroundObserverTests.swift */,
+				658B14611DDF637000D63100 /* PresentationProcedureTests.swift */,
 				653C9FE61D6099850070B7A2 /* ProcedureKitMobileTests.swift */,
 				6574312E1D8DE848002E8FC9 /* TestableUIApplication.swift */,
 			);
@@ -1886,6 +1892,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				657243951DE9C0EF00BFEB5B /* NetworkObserver+Mobile.swift in Sources */,
+				658B14601DDF635500D63100 /* Presentation.swift in Sources */,
 				6574312B1D8DDF0D002E8FC9 /* BackgroundObserver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1896,6 +1903,7 @@
 			files = (
 				653C9FEA1D6099F40070B7A2 /* ProcedureKitMobileTests.swift in Sources */,
 				6574312F1D8DE848002E8FC9 /* TestableUIApplication.swift in Sources */,
+				658B14621DDF637000D63100 /* PresentationProcedureTests.swift in Sources */,
 				6574312D1D8DE712002E8FC9 /* BackgroundObserverTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Mobile/Alert.swift
+++ b/Sources/Mobile/Alert.swift
@@ -1,0 +1,16 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public class AlertProcedure<Presenting: PresentingViewController>: UIProcedure<Presenting> {
+
+    public init(presentAlertFrom presenting: Presenting, withPreferredStyle preferredAlertStyle: UIAlertControllerStyle = .alert, waitForDismissal: Bool = false) {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: preferredAlertStyle)
+        super.init(present: alert, from: presenting, withStyle: .present, inNavigationController: false, sender: nil, waitForDismissal: waitForDismissal)
+    }
+}

--- a/Sources/Mobile/Alert.swift
+++ b/Sources/Mobile/Alert.swift
@@ -7,10 +7,140 @@
 import Foundation
 import UIKit
 
-public class AlertProcedure<Presenting: PresentingViewController>: UIProcedure<Presenting> {
+public class AlertProcedure: UIProcedure {
 
-    public init(presentAlertFrom presenting: Presenting, withPreferredStyle preferredAlertStyle: UIAlertControllerStyle = .alert, waitForDismissal: Bool = false) {
+    /// - returns: the presented `UIAlertController`.
+    public var alert: UIAlertController {
+        return presented as! UIAlertController // swiftlint:disable:this force_cast
+    }
+
+    /**
+     The style of the alert controller. (read-only)
+
+     The value of this property is set to the value you specified in the [alertControllerWithTitle:message:preferredStyle:](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIAlertController_class/#//apple_ref/occ/clm/UIAlertController/alertControllerWithTitle:message:preferredStyle:) method. This value determines how the alert is displayed onscreen.
+
+     - returns: the preferred style of the alert
+     */
+    public var preferredStyle: UIAlertControllerStyle {
+        return alert.preferredStyle
+    }
+
+    /**
+     The title of the alert.
+
+     The title string is displayed prominently in the alert or action sheet. You should use this string to get the user’s attention and communicate the reason for displaying the alert.
+
+     - returns: the optional title String?
+     */
+    public var title: String? {
+        get { return alert.title }
+        set {
+            alert.title = newValue
+            name = newValue
+        }
+    }
+
+    /**
+     Descriptive text that provides more details about the reason for the alert.
+
+     The message string is displayed below the title string and is less prominent. Use this string to provide additional context about the reason for the alert or about the actions that the user might take.
+
+     - returns: the optional message String?
+     */
+    public var message: String? {
+        get { return alert.message }
+        set { alert.message = newValue }
+    }
+
+    /**
+     The actions that the user can take in response to the alert or action sheet. (read-only)
+
+     The actions are in the order in which you added them to the alert controller. This order also corresponds to the order in which they are displayed in the alert or action sheet. The second action in the array is displayed below the first, the third is displayed below the second, and so on.
+
+     - returns: the array of UIAlertAction actions.
+     */
+    public var actions: [UIAlertAction] {
+        return alert.actions
+    }
+
+    /**
+     The preferred action for the user to take from an alert.
+
+     The preferred action is relevant for the [UIAlertControllerStyleAlert](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIAlertController_class/#//apple_ref/c/tdef/UIAlertControllerStyle) style only; it is not used by action sheets. When you specify a preferred action, the alert controller highlights the text of that action to give it emphasis. (If the alert also contains a cancel button, the preferred action receives the highlighting instead of the cancel button.) If the iOS device is connected to a physical keyboard, pressing the Return key triggers the preferred action.
+
+     The action object you assign to this property must have already been added to the alert controller’s list of actions. Assigning an object to this property before adding it with the [addAction:](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIAlertController_class/#//apple_ref/occ/instm/UIAlertController/addAction:) method is a programmer error.
+
+     The default value of this property is `nil`.
+
+     - returns: the optional preferredAction, UIAlertAction
+     */
+    @available (iOS 9.0, *)
+    public var preferredAction: UIAlertAction? {
+        get { return alert.preferredAction }
+        set { alert.preferredAction = newValue }
+    }
+
+    /**
+     The array of text fields displayed by the alert. (read-only)
+
+     Use this property to access the text fields displayed by the alert. The text fields are in the order in which you added them to the alert controller. This order also corresponds to the order in which they are displayed in the alert.
+
+     - returns: the optional array of UITextField instances
+     */
+    public var textFields: [UITextField]? {
+        return alert.textFields
+    }
+
+    /**
+     Creates an `AlertProcedure`. It must be constructed with the view
+     controller which the alert will be presented from.
+
+     - parameter from: a generic type conforming to `PresentingViewController`,
+     such as an `UIViewController`
+     */
+    public init(presentAlertFrom presenting: PresentingViewController, withPreferredStyle preferredAlertStyle: UIAlertControllerStyle = .alert, waitForDismissal: Bool = false) {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: preferredAlertStyle)
-        super.init(present: alert, from: presenting, withStyle: .present, inNavigationController: false, sender: nil, waitForDismissal: waitForDismissal)
+        super.init(present: alert, from: presenting, withStyle: .present, inNavigationController: false, sender: nil)
+        add(condition: MutuallyExclusive<UIAlertController>())
+    }
+
+    /**
+     Adds an action button with a title, style and handler.
+
+     Do not add actions directly to the `UIAlertController`, as
+     this will prevent the `AlertOperation` from correctly finishing.
+
+     - parameter actionWithTitle: an optional String?.
+     - parameter style: a `UIAlertActionStyle` which defaults to `.default`.
+     - parameter handler: a block which receives the operation, and returns Void.
+     */
+    @discardableResult public func add(actionWithTitle title: String?, style: UIAlertActionStyle = .default, handler: @escaping (AlertProcedure, UIAlertAction) -> Void = { _, _ in }) -> UIAlertAction {
+        let action = UIAlertAction(title: title, style: style) { [weak self] action in
+            guard let strongSelf = self else { return }
+            handler(strongSelf, action)
+            strongSelf.finish()
+        }
+        alert.addAction(action)
+        return action
+    }
+
+    /**
+     Adds a text field to an alert.
+
+     Calling this method adds an editable text field to the alert. You can call this method more than once to add additional text fields. The text fields are stacked in the resulting alert.
+
+     You can add a text field only if the [preferredStyle](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIAlertController_class/#//apple_ref/occ/instp/UIAlertController/preferredStyle) property is set to [UIAlertControllerStyleAlert](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIAlertController_class/#//apple_ref/c/tdef/UIAlertControllerStyle).
+
+     - parameter configurationHandler: A block for configuring the text field prior to displaying the alert. This block has no return value and takes a single parameter corresponding to the text field object. Use that parameter to change the text field properties.
+     */
+    public func addTextField(configurationHandler: ((UITextField) -> Void)?) {
+        alert.addTextField(configurationHandler: configurationHandler)
+    }
+
+    public override func execute() {
+        if alert.actions.isEmpty {
+            add(actionWithTitle: NSLocalizedString("Okay", comment: "Okay"))
+        }
+        super.execute()
     }
 }

--- a/Sources/Mobile/Alert.swift
+++ b/Sources/Mobile/Alert.swift
@@ -98,9 +98,9 @@ public class AlertProcedure: UIProcedure {
      - parameter from: a generic type conforming to `PresentingViewController`,
      such as an `UIViewController`
      */
-    public init(presentAlertFrom presenting: PresentingViewController, withPreferredStyle preferredAlertStyle: UIAlertControllerStyle = .alert, waitForDismissal: Bool = false) {
+    public init(presentAlertFrom presenting: PresentingViewController, withPreferredStyle preferredAlertStyle: UIAlertControllerStyle = .alert, waitForDismissal: Bool = true) {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: preferredAlertStyle)
-        super.init(present: alert, from: presenting, withStyle: .present, inNavigationController: false, sender: nil)
+        super.init(present: alert, from: presenting, withStyle: .present, inNavigationController: false, sender: nil, finishAfterPresenting: !waitForDismissal)
         add(condition: MutuallyExclusive<UIAlertController>())
     }
 
@@ -118,7 +118,9 @@ public class AlertProcedure: UIProcedure {
         let action = UIAlertAction(title: title, style: style) { [weak self] action in
             guard let strongSelf = self else { return }
             handler(strongSelf, action)
-            strongSelf.finish()
+            if strongSelf.shouldWaitUntilDismissal {
+                strongSelf.finish()
+            }
         }
         alert.addAction(action)
         return action

--- a/Sources/Mobile/Presentation.swift
+++ b/Sources/Mobile/Presentation.swift
@@ -1,0 +1,5 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//

--- a/Sources/Mobile/Presentation.swift
+++ b/Sources/Mobile/Presentation.swift
@@ -17,7 +17,7 @@ public protocol PresentingViewController: class {
 }
 
 public protocol DismissingViewController: class {
-    var didDismiss: () -> Void { get set }
+    var didDismissViewControllerBlock: () -> Void { get set }
 }
 
 public enum PresentationStyle {
@@ -48,7 +48,7 @@ open class UIProcedure<Presenting>: Procedure where Presenting: PresentingViewCo
         self.init(present: present, from: from, withStyle: style, inNavigationController: inNavigationController, sender: sender)
         if waitForDismissal {
             shouldFinishAfterPresentating = false
-            present.didDismiss = { [weak self] in
+            present.didDismissViewControllerBlock = { [weak self] in
                 guard let strongSelf = self, !strongSelf.shouldFinishAfterPresentating && strongSelf.isExecuting else { return }
                 strongSelf.finish()
             }
@@ -56,7 +56,6 @@ open class UIProcedure<Presenting>: Procedure where Presenting: PresentingViewCo
     }
 
     open override func execute() {
-
         DispatchQueue.main.async { [weak self] in
             guard let strongSelf = self else { return }
 
@@ -78,13 +77,10 @@ open class UIProcedure<Presenting>: Procedure where Presenting: PresentingViewCo
                 strongSelf.presenting.showDetailViewController(strongSelf.presented, sender: strongSelf.sender)
             }
 
-            guard strongSelf.shouldFinishAfterPresentating else {
+            if strongSelf.shouldFinishAfterPresentating {
                 strongSelf.finish()
                 return
             }
-
-            // Deal with waiting for dismissal here
-
         }
     }
 }

--- a/Sources/Mobile/Presentation.swift
+++ b/Sources/Mobile/Presentation.swift
@@ -44,8 +44,14 @@ open class UIProcedure<Presenting>: Procedure where Presenting: PresentingViewCo
         super.init()
     }
 
-    public convenience init<T: UIViewController>(present: T, from: Presenting, withStyle style: PresentationStyle, inNavigationController: Bool = true, sender: Any? = nil, waitForDismissal: Bool) where T: DismissingViewController {
-        self.init(present: present, from: from, withStyle: style, inNavigationController: inNavigationController, sender: sender)
+    public init<T: UIViewController>(present: T, from: Presenting, withStyle style: PresentationStyle, inNavigationController: Bool = true, sender: Any? = nil, waitForDismissal: Bool) where T: DismissingViewController {
+        self.presented = present
+        self.presenting = from
+        self.style = style
+        self.wrapInNavigationController = inNavigationController
+        self.sender = sender
+        self.shouldFinishAfterPresentating = true
+        super.init()
         if waitForDismissal {
             shouldFinishAfterPresentating = false
             present.didDismissViewControllerBlock = { [weak self] in

--- a/Sources/Mobile/Presentation.swift
+++ b/Sources/Mobile/Presentation.swift
@@ -3,3 +3,83 @@
 //
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
+
+import Foundation
+import UIKit
+
+public protocol PresentingViewController: class {
+
+    func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?)
+
+    func show(_ viewControllerToShow: UIViewController, sender: Any?)
+
+    func showDetailViewController(_ viewControllerToShow: UIViewController, sender: Any?)
+}
+
+public protocol PresentationProcedure {
+    associatedtype Presented: UIViewController
+    associatedtype Presenting: PresentingViewController
+}
+
+public enum PresentationStyle {
+    case show, showDetail, present
+}
+
+open class UIProcedure<T, V>: Procedure, PresentationProcedure, InputProcedure where T: UIViewController, V: PresentingViewController {
+    public typealias Presented = T
+    public typealias Presenting = V
+
+    public var input: Pending<Presented> = .pending
+    public let presenting: Presenting
+    public let style: PresentationStyle
+    public let wrapInNavigationController: Bool
+    public let sender: Any?
+    public let waitForDismissal: Bool
+
+    public init(present: T? = nil, from: V, withStyle style: PresentationStyle, inNavigationController: Bool = true, sender: Any? = nil, waitForDismissal: Bool = false) {
+        self.input = Pending(present)
+        self.presenting = from
+        self.style = style
+        self.wrapInNavigationController = inNavigationController
+        self.sender = sender
+        self.waitForDismissal = waitForDismissal
+        super.init()
+    }
+
+    open override func execute() {
+        guard let viewController = input.value else {
+            finish(withError: ProcedureKitError.requirementNotSatisfied())
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let strongSelf = self else { return }
+
+            switch strongSelf.style {
+            case .present:
+                let viewControllerToPresent: UIViewController
+                if viewController is UIAlertController || !strongSelf.wrapInNavigationController {
+                    viewControllerToPresent = viewController
+                }
+                else {
+                    viewControllerToPresent = UINavigationController(rootViewController: viewController)
+                }
+                strongSelf.presenting.present(viewControllerToPresent, animated: true, completion: nil)
+
+            case .show:
+                strongSelf.presenting.show(viewController, sender: strongSelf.sender)
+
+            case .showDetail:
+                strongSelf.presenting.showDetailViewController(viewController, sender: strongSelf.sender)
+            }
+
+            guard strongSelf.waitForDismissal else {
+                strongSelf.finish()
+                return
+            }
+
+            // Deal with waiting for dismissal here
+
+        }
+    }
+}

--- a/Sources/ProcedureResult.swift
+++ b/Sources/ProcedureResult.swift
@@ -19,6 +19,10 @@ public enum Pending<T> {
         guard case let .ready(value) = self else { return nil }
         return value
     }
+
+    public init(_ value: T?) {
+        self = value.pending
+    }
 }
 
 extension Pending where T: Equatable {
@@ -31,6 +35,18 @@ extension Pending where T: Equatable {
             return lhsValue == rhsValue
         default:
             return false
+        }
+    }
+}
+
+public extension Optional {
+
+    var pending: Pending<Wrapped> {
+        switch self {
+        case .none:
+            return .pending
+        case let .some(value):
+            return .ready(value)
         }
     }
 }

--- a/Tests/Mobile/AlertProcedureTests.swift
+++ b/Tests/Mobile/AlertProcedureTests.swift
@@ -1,0 +1,88 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+import ProcedureKit
+import TestingProcedureKit
+@testable import ProcedureKitMobile
+
+class AlertProcedureTests: ProcedureKitTestCase {
+
+    var title: String!
+    var message: String!
+    var presenting: TestablePresentingController!
+    var alert: AlertProcedure!
+
+    override func setUp() {
+        super.setUp()
+        title = "This is the alert title"
+        message = "This is the alert message"
+        presenting = TestablePresentingController()
+        alert = AlertProcedure(presentAlertFrom: presenting)
+    }
+
+    override func tearDown() {
+        title = nil
+        message = nil
+        presenting = nil
+        alert = nil
+        super.tearDown()
+    }
+
+    func test__alert_style_set_default() {
+        XCTAssertEqual(alert.preferredStyle, UIAlertControllerStyle.alert)
+    }
+
+    func test__alert_style_actionSheet() {
+        let style: UIAlertControllerStyle = .actionSheet
+        alert = AlertProcedure(presentAlertFrom: presenting, withPreferredStyle: style)
+        XCTAssertEqual(alert.preferredStyle, style)
+    }
+
+    func test__alert_title() {
+        alert.title = title
+        XCTAssertEqual(alert.title, title)
+    }
+
+    func test__alert_message() {
+        alert.message = message
+        XCTAssertEqual(alert.message, message)
+    }
+
+    func test__alert_add_textfield() {
+        alert.addTextField(configurationHandler: nil)
+        XCTAssertNotNil(alert.textFields)
+    }
+
+    func test__alert_actions() {
+        alert.add(actionWithTitle: "OK")
+        XCTAssertEqual(alert.actions.count, 1)
+    }
+
+    func test__alert_preferred_action() {
+        let action = alert.add(actionWithTitle: "OK", style: .default)
+        alert.add(actionWithTitle: "Cancel", style: .cancel)
+        alert.preferredAction = action
+        XCTAssertNotNil(alert.preferredAction)
+    }
+
+    func test__alert_presents_alert_controller() {
+        alert = AlertProcedure(presentAlertFrom: presenting, waitForDismissal: false)
+        alert.title = title
+        alert.message = message
+        presenting.check = { [unowned self] received in
+            guard let alertController = received as? UIAlertController else {
+                XCTFail("Did not receive an alert controller")
+                return
+            }
+            XCTAssertEqual(alertController.title, self.title)
+            XCTAssertEqual(alertController.message, self.message)
+        }
+
+        wait(for: alert)
+        XCTAssertProcedureFinishedWithoutErrors(alert)
+    }
+}

--- a/Tests/Mobile/PresentationProcedureTests.swift
+++ b/Tests/Mobile/PresentationProcedureTests.swift
@@ -1,0 +1,19 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+import ProcedureKit
+import TestingProcedureKit
+@testable import ProcedureKitMobile
+
+public protocol PresentingViewController {
+
+}
+
+public protocol PresentationProcedure {
+    associatedtype Presented: UIViewController
+    associatedtype Presenting: PresentingViewController
+}

--- a/Tests/Mobile/PresentationProcedureTests.swift
+++ b/Tests/Mobile/PresentationProcedureTests.swift
@@ -9,11 +9,3 @@ import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitMobile
 
-public protocol PresentingViewController {
-
-}
-
-public protocol PresentationProcedure {
-    associatedtype Presented: UIViewController
-    associatedtype Presenting: PresentingViewController
-}

--- a/Tests/Mobile/UIProcedureTests.swift
+++ b/Tests/Mobile/UIProcedureTests.swift
@@ -1,0 +1,112 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+import ProcedureKit
+import TestingProcedureKit
+@testable import ProcedureKitMobile
+
+class TestablePresentingController: NSObject, PresentingViewController {
+    typealias CheckBlockType = (UIViewController) -> Void
+
+    var check: CheckBlockType? = nil
+    var expectation: XCTestExpectation? = nil
+
+    func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)?) {
+        check?(viewControllerToPresent)
+        completion?()
+        expectation?.fulfill()
+    }
+
+    func show(_ viewControllerToShow: UIViewController, sender: Any?) {
+        check?(viewControllerToShow)
+        expectation?.fulfill()
+    }
+
+    func showDetailViewController(_ viewControllerToShow: UIViewController, sender: Any?) {
+        check?(viewControllerToShow)
+        expectation?.fulfill()
+    }
+}
+
+class TestableDismissingViewController: UIViewController, DismissingViewController {
+    var didDismissViewControllerBlock: () -> Void = { }
+
+    func dismissTheViewController() {
+        didDismissViewControllerBlock()
+    }
+}
+
+class UIProcedureTests: ProcedureKitTestCase {
+
+    var presenting: TestablePresentingController!
+    var presented: TestableDismissingViewController!
+
+    override func setUp() {
+        super.setUp()
+        presenting = TestablePresentingController()
+        presented = TestableDismissingViewController()
+    }
+
+    override func tearDown() {
+        presenting = nil
+        presented = nil
+        super.tearDown()
+    }
+
+    func checkReceivedViewController(inNavigationController: Bool) -> (UIViewController) -> Void {
+        return {  [unowned self] received in
+            if inNavigationController {
+                guard let nav = received as? UINavigationController else {
+                    XCTFail("Expected received view controller to be a UINavigationController")
+                    return
+                }
+                XCTAssertEqual(nav.topViewController, self.presented)
+            }
+            else {
+                XCTAssertEqual(received, self.presented)
+            }
+        }
+    }
+
+    func test__present_style() {
+        presenting.check = checkReceivedViewController(inNavigationController: true)
+        let ui = UIProcedure(present: presented, from: presenting, withStyle: .present, sender: nil)
+        wait(for: ui)
+        XCTAssertProcedureFinishedWithoutErrors(ui)
+    }
+
+    func test__present_style_without_navigation_controller() {
+        presenting.check = checkReceivedViewController(inNavigationController: false)
+        let ui = UIProcedure(present: presented, from: presenting, withStyle: .present, inNavigationController: false, sender: nil)
+        wait(for: ui)
+        XCTAssertProcedureFinishedWithoutErrors(ui)
+    }
+
+    func test__show_style() {
+        presenting.check = checkReceivedViewController(inNavigationController: false)
+        let ui = UIProcedure(present: presented, from: presenting, withStyle: .show, sender: nil)
+        wait(for: ui)
+        XCTAssertProcedureFinishedWithoutErrors(ui)
+    }
+
+    func test__show_detail_style() {
+        presenting.check = checkReceivedViewController(inNavigationController: false)
+        let ui = UIProcedure(present: presented, from: presenting, withStyle: .showDetail, sender: nil)
+        wait(for: ui)
+        XCTAssertProcedureFinishedWithoutErrors(ui)
+    }
+
+    func test__present_dismissing_view_controller() {
+        presenting.check = checkReceivedViewController(inNavigationController: true)
+        let ui = UIProcedure(present: presented, from: presenting, withStyle: .present, sender: nil, waitForDismissal: true)
+        let delay = DelayProcedure(by: 0.1)
+        let dismiss = BlockProcedure { [unowned self] in self.presented.dismissTheViewController() }
+        dismiss.add(dependency: delay)
+        wait(for: ui, delay, dismiss)
+        XCTAssertProcedureFinishedWithoutErrors(ui)
+    }
+}


### PR DESCRIPTION
Supports `UIProcedure` and `AlertProcedure` in _ProcedureKitMobile_.

Usage is a bit like this:

```swift
let alert = AlertProcedure(presentAlertFrom: self)
alert.add(actionWithTitle: "Sweet") { alert, action in
    alert.log.info(message: "Running the handler!")
}
alert.title = "Hello World"
alert.message = "This is a message in an alert"
queue.add(operation: alert)
```