### PR TITLE
ProcessProcedure improvements & thread-safety

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -1039,7 +1039,6 @@
 			isa = PBXGroup;
 			children = (
 				0BC54B7A1DCB4906006C7DE2 /* Process.swift */,
-				0BB369441DCB51E000AB91BD /* ProcessProcedureTests.swift */,
 			);
 			name = Mac;
 			sourceTree = "<group>";
@@ -1048,6 +1047,7 @@
 			isa = PBXGroup;
 			children = (
 				653CA04C1D60A6C80070B7A2 /* ProcedureKitMacTests.swift */,
+				0BB369441DCB51E000AB91BD /* ProcessProcedureTests.swift */,
 			);
 			name = "Mac Tests";
 			sourceTree = "<group>";

--- a/ProcessProcedureTests.swift
+++ b/ProcessProcedureTests.swift
@@ -46,10 +46,9 @@ class ProcessProcedureTests: ProcedureKitTestCase {
 
     func test__cancel_process_after_launched() {
         processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 2"])
-        processProcedure.addDidExecuteBlockObserver { (procedure) in
+        check(procedure: processProcedure, withTimeout: 1) { procedure in
             procedure.cancel()
         }
-        wait(for: processProcedure, withTimeout: 1)
         XCTAssertProcedureCancelledWithoutErrors(processProcedure)
     }
 
@@ -60,12 +59,10 @@ class ProcessProcedureTests: ProcedureKitTestCase {
     func test__processIdentifier_after_launched() {
         processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"])
         weak var didExecuteExpectation = expectation(description: "DidExecute: \(#function)")
-        var processIdentifier = Protector<Int32>(-1)
-        processProcedure.addDidExecuteBlockObserver { (procedure) in
+        let processIdentifier = Protector<Int32>(-1)
+        processProcedure.addDidExecuteBlockObserver { procedure in
             let retrievedProcessIdentifier = procedure.processIdentifier
-            processIdentifier.write({ (processIdentifier) in
-                processIdentifier = retrievedProcessIdentifier
-            })
+            processIdentifier.overwrite(with: retrievedProcessIdentifier)
             DispatchQueue.main.async {
                 didExecuteExpectation?.fulfill()
             }
@@ -83,7 +80,7 @@ class ProcessProcedureTests: ProcedureKitTestCase {
     func test__suspend_before_launched_returns_false() {
         weak var didSuspendExpectation = expectation(description: "Did Suspend: \(#function)")
         processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"])
-        processProcedure.suspend { (success) in
+        processProcedure.suspend { success in
             DispatchQueue.main.async {
                 XCTAssertFalse(success)
                 didSuspendExpectation?.fulfill()
@@ -96,7 +93,7 @@ class ProcessProcedureTests: ProcedureKitTestCase {
         wait(for: processProcedure)
         XCTAssertProcedureFinishedWithoutErrors(processProcedure)
         weak var didSuspendExpectation = expectation(description: "Did Suspend: \(#function)")
-        processProcedure.suspend { (success) in
+        processProcedure.suspend { success in
             DispatchQueue.main.async {
                 XCTAssertFalse(success)
                 didSuspendExpectation?.fulfill()
@@ -108,7 +105,7 @@ class ProcessProcedureTests: ProcedureKitTestCase {
     func test__resume_before_launched_returns_false() {
         weak var didResumeExpectation = expectation(description: "Did Resume: \(#function)")
         processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"])
-        processProcedure.resume { (success) in
+        processProcedure.resume { success in
             DispatchQueue.main.async {
                 XCTAssertFalse(success)
                 didResumeExpectation?.fulfill()
@@ -121,7 +118,7 @@ class ProcessProcedureTests: ProcedureKitTestCase {
         wait(for: processProcedure)
         XCTAssertProcedureFinishedWithoutErrors(processProcedure)
         weak var didResumeExpectation = expectation(description: "Did Resume: \(#function)")
-        processProcedure.resume { (success) in
+        processProcedure.resume { success in
             DispatchQueue.main.async {
                 XCTAssertFalse(success)
                 didResumeExpectation?.fulfill()
@@ -135,8 +132,8 @@ class ProcessProcedureTests: ProcedureKitTestCase {
         weak var didSuspendExpectation = expectation(description: "Did Suspend: \(#function)")
         weak var delayPassed = expectation(description: "Delay Passed: \(#function)")
         processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"])
-        processProcedure.addDidExecuteBlockObserver { (processProcedure) in
-            processProcedure.suspend { (success) in
+        processProcedure.addDidExecuteBlockObserver { procedure in
+            procedure.suspend { (success) in
                 DispatchQueue.main.async {
                     XCTAssertTrue(success)
                     didSuspendExpectation?.fulfill()

--- a/ProcessProcedureTests.swift
+++ b/ProcessProcedureTests.swift
@@ -15,17 +15,144 @@ class ProcessProcedureTests: ProcedureKitTestCase {
     var process: Process!
     var processProcedure: ProcessProcedure!
 
+    var launchPath: String!
+    var arguments: [String]!
+
     override func setUp() {
         super.setUp()
 
-        process = Process()
-        process.launchPath = "/bin/echo"
-        process.arguments = [ "Hello World" ]
-        processProcedure = ProcessProcedure(process: process)
+        launchPath = "/bin/echo"
+        arguments = [ "Hello World" ]
+        processProcedure = ProcessProcedure(launchPath: launchPath, arguments: arguments)
     }
 
     func test__start_process() {
         wait(for: processProcedure)
         XCTAssertProcedureFinishedWithoutErrors(processProcedure)
+    }
+
+    func test__cancel_process_before_launched() {
+        processProcedure.cancel()
+        wait(for: processProcedure)
+        XCTAssertProcedureCancelledWithoutErrors(processProcedure)
+    }
+
+    func test__cancel_process_after_launched() {
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 2"])
+        processProcedure.addDidExecuteBlockObserver { (procedure) in
+            procedure.cancel()
+        }
+        wait(for: processProcedure, withTimeout: 1)
+        XCTAssertProcedureCancelledWithoutErrors(processProcedure)
+    }
+
+    func test__processIdentifier_before_launched() {
+        XCTAssertEqual(processProcedure.processIdentifier, 0)
+    }
+
+    func test__processIdentifier_after_launched() {
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"])
+        weak var didExecuteExpectation = expectation(description: "DidExecute: \(#function)")
+        var processIdentifier = Protector<Int32>(-1)
+        processProcedure.addDidExecuteBlockObserver { (procedure) in
+            let retrievedProcessIdentifier = procedure.processIdentifier
+            processIdentifier.write({ (processIdentifier) in
+                processIdentifier = retrievedProcessIdentifier
+            })
+            DispatchQueue.main.async {
+                didExecuteExpectation?.fulfill()
+            }
+        }
+        wait(for: processProcedure)
+        XCTAssertGreaterThan(processIdentifier.access, 0)
+    }
+
+    func test__processIdentifier_after_finished() {
+        wait(for: processProcedure)
+        XCTAssertProcedureFinishedWithoutErrors(processProcedure)
+        XCTAssertGreaterThan(processProcedure.processIdentifier, 0)
+    }
+
+    func test__suspend_before_launched_returns_false() {
+        weak var didSuspendExpectation = expectation(description: "Did Suspend: \(#function)")
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"])
+        processProcedure.suspend { (success) in
+            DispatchQueue.main.async {
+                XCTAssertFalse(success)
+                didSuspendExpectation?.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func test__suspend_after_finished_returns_false() {
+        wait(for: processProcedure)
+        XCTAssertProcedureFinishedWithoutErrors(processProcedure)
+        weak var didSuspendExpectation = expectation(description: "Did Suspend: \(#function)")
+        processProcedure.suspend { (success) in
+            DispatchQueue.main.async {
+                XCTAssertFalse(success)
+                didSuspendExpectation?.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func test__resume_before_launched_returns_false() {
+        weak var didResumeExpectation = expectation(description: "Did Resume: \(#function)")
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"])
+        processProcedure.resume { (success) in
+            DispatchQueue.main.async {
+                XCTAssertFalse(success)
+                didResumeExpectation?.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func test__resume_after_finished_returns_false() {
+        wait(for: processProcedure)
+        XCTAssertProcedureFinishedWithoutErrors(processProcedure)
+        weak var didResumeExpectation = expectation(description: "Did Resume: \(#function)")
+        processProcedure.resume { (success) in
+            DispatchQueue.main.async {
+                XCTAssertFalse(success)
+                didResumeExpectation?.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func test__suspend_resume_while_executing() {
+        // suspend
+        weak var didSuspendExpectation = expectation(description: "Did Suspend: \(#function)")
+        weak var delayPassed = expectation(description: "Delay Passed: \(#function)")
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"])
+        processProcedure.addDidExecuteBlockObserver { (processProcedure) in
+            processProcedure.suspend { (success) in
+                DispatchQueue.main.async {
+                    XCTAssertTrue(success)
+                    didSuspendExpectation?.fulfill()
+                }
+            }
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
+                delayPassed?.fulfill()
+            }
+        }
+        run(operations: processProcedure)
+        waitForExpectations(timeout: 3, handler: nil)
+        XCTAssertFalse(processProcedure.isFinished)
+
+        // resume
+        addCompletionBlockTo(procedure: processProcedure)
+        weak var didResumeExpectation = expectation(description: "Did Resume: \(#function)")
+        processProcedure.resume { (success) in
+            DispatchQueue.main.async {
+                XCTAssertTrue(success)
+                didResumeExpectation?.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+        XCTAssertTrue(processProcedure.isFinished)
     }
 }

--- a/ProcessProcedureTests.swift
+++ b/ProcessProcedureTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 import ProcedureKit
 import TestingProcedureKit
+import Foundation
 @testable import ProcedureKitMac
 
 class ProcessProcedureTests: ProcedureKitTestCase {
@@ -27,6 +28,12 @@ class ProcessProcedureTests: ProcedureKitTestCase {
     }
 
     func test__start_process() {
+        wait(for: processProcedure)
+        XCTAssertProcedureFinishedWithoutErrors(processProcedure)
+    }
+
+    func test__start_process_with_launchpath_only() {
+        processProcedure = ProcessProcedure(launchPath: launchPath)
         wait(for: processProcedure)
         XCTAssertProcedureFinishedWithoutErrors(processProcedure)
     }
@@ -154,5 +161,71 @@ class ProcessProcedureTests: ProcedureKitTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
         XCTAssertTrue(processProcedure.isFinished)
+    }
+
+    // MARK: - Configuration Properties (Read-only)
+
+    func test__arguments() {
+        processProcedure = ProcessProcedure(launchPath: launchPath, arguments: arguments)
+        XCTAssertEqual(processProcedure.arguments ?? [], arguments)
+    }
+
+    func test__currentDirectoryPath() {
+        let currentDirectoryPath = "/bin/"
+        processProcedure = ProcessProcedure(launchPath: launchPath, currentDirectoryPath: currentDirectoryPath)
+        XCTAssertEqual(processProcedure.currentDirectoryPath, currentDirectoryPath)
+    }
+
+    func test__environment() {
+        var environment = ProcessInfo().environment
+        environment.updateValue("new", forKey: "procedurekittest")
+        processProcedure = ProcessProcedure(launchPath: launchPath, environment: environment)
+        XCTAssertEqual(processProcedure.environment ?? [:], environment)
+    }
+
+    func test__launchPath() {
+        XCTAssertEqual(processProcedure.launchPath, launchPath)
+    }
+
+    func test__standardError() {
+        let pipe = Pipe()
+        processProcedure = ProcessProcedure(launchPath: launchPath, standardError: pipe)
+        guard let readValue = processProcedure.standardError else {
+            XCTFail("standardError is nil")
+            return
+        }
+        guard let readValueAsPipe = readValue as? Pipe else {
+            XCTFail("standardError is not expected type")
+            return
+        }
+        XCTAssertEqual(readValueAsPipe, pipe)
+    }
+
+    func test__standardInput() {
+        let pipe = Pipe()
+        processProcedure = ProcessProcedure(launchPath: launchPath, standardInput: pipe)
+        guard let readValue = processProcedure.standardInput else {
+            XCTFail("standardInput is nil")
+            return
+        }
+        guard let readValueAsPipe = readValue as? Pipe else {
+            XCTFail("standardInput is not expected type")
+            return
+        }
+        XCTAssertEqual(readValueAsPipe, pipe)
+    }
+
+    func test__standardOutput() {
+        let pipe = Pipe()
+        processProcedure = ProcessProcedure(launchPath: launchPath, standardOutput: pipe)
+        guard let readValue = processProcedure.standardOutput else {
+            XCTFail("standardOutput is nil")
+            return
+        }
+        guard let readValueAsPipe = readValue as? Pipe else {
+            XCTFail("standardOutput is not expected type")
+            return
+        }
+        XCTAssertEqual(readValueAsPipe, pipe)
     }
 }

--- a/Sources/Mac/Process.swift
+++ b/Sources/Mac/Process.swift
@@ -33,7 +33,7 @@ open class ProcessProcedure: Procedure {
     }
 
     // - returns process: the Process
-    private let process: Process
+    fileprivate let process: Process
 
     /// - returns processDidExitCleanly: the closure for exiting cleanly.
     private let processDidExitCleanly: ProcessDidExitCleanly

--- a/Sources/Mac/Process.swift
+++ b/Sources/Mac/Process.swift
@@ -6,6 +6,7 @@
 
 import Foundation
 import ProcedureKit
+import Dispatch
 
 open class ProcessProcedure: Procedure {
 

--- a/Sources/Mac/Process.swift
+++ b/Sources/Mac/Process.swift
@@ -11,17 +11,12 @@ open class ProcessProcedure: Procedure {
 
     /// Error type for ProcessProcedure
     public enum Error: Swift.Error, Equatable {
-        case launchPathNotSet
         case terminationReason(Process.TerminationReason)
 
         public static func == (lhs: ProcessProcedure.Error, rhs: ProcessProcedure.Error) -> Bool {
             switch (lhs, rhs) {
-            case (.launchPathNotSet, .launchPathNotSet):
-                return true
             case let (.terminationReason(lhsReason), .terminationReason(rhsReason)):
                 return lhsReason == rhsReason
-            default:
-                return false
             }
         }
     }
@@ -38,47 +33,151 @@ open class ProcessProcedure: Procedure {
     }
 
     // - returns process: the Process
-    public let process: Process
+    private let process: Process
 
     /// - returns processDidExitCleanly: the closure for exiting cleanly.
-    public let processDidExitCleanly: ProcessDidExitCleanly
+    private let processDidExitCleanly: ProcessDidExitCleanly
 
-    /**
-     Initializes ProcessProcedure with a Process.
-     - parameter task: the Process
-     - parameter processDidExitCleanly: a ProcessDidExitCleanly closure with a default.
-     */
-    public init(process: Process, processDidExitCleanly: @escaping ProcessDidExitCleanly = ProcessProcedure.defaultProcessDidExitCleanly) {
+    /// Initialize a ProcessProcedure.
+    ///
+    /// The minimum required parameter is a path to the executable to launch (`launchPath`).
+    ///
+    /// Other parameters are optional, and are described in full in the documentation
+    /// for NSTask/Process: https://developer.apple.com/reference/foundation/process
+    ///
+    /// By default, `Process` inherits the environment and some other parameters from the current process.
+    ///
+    /// - Parameters:
+    ///   - launchPath: the path to the executable to be launched.
+    ///   - arguments: (optional) the command arguments that should be used to launch the executable.
+    ///   - currentDirectoryPath: (optional) the current directory to be used when launching the executable.
+    ///   - environment: (optional) the environment to be used when launching the executable.
+    ///   - standardError: (optional) the standard error (FileHandle or Pipe object)
+    ///   - standardInput: (optional) the standard input (FileHandle or Pipe object)
+    ///   - standardOutput: (optional) the standard output (FileHandle or Pipe object)
+    ///   - processDidExitCleanly: a ProcessDidExitCleanly closure with a default.
+    public init(launchPath: String, arguments: [String]? = nil, currentDirectoryPath: String? = nil, environment: [String : String]? = nil, standardError: Any? = nil, standardInput: Any? = nil, standardOutput: Any? = nil, processDidExitCleanly: @escaping ProcessDidExitCleanly = ProcessProcedure.defaultProcessDidExitCleanly) {
+
+        let process = Process()
+        process.launchPath = launchPath
+        if let arguments = arguments {
+            process.arguments = arguments
+        }
+        if let currentDirectoryPath = currentDirectoryPath {
+            process.currentDirectoryPath = currentDirectoryPath
+        }
+        if let environment = environment {
+            process.environment = environment
+        }
+        if let standardError = standardError {
+            process.standardError = standardError
+        }
+        if let standardInput = standardInput {
+            process.standardInput = standardInput
+        }
+        if let standardOutput = standardOutput {
+            process.standardOutput = standardOutput
+        }
+
         self.process = process
         self.processDidExitCleanly = processDidExitCleanly
         super.init()
 
-        addWillCancelBlockObserver { procedure, errors in
-            guard procedure.process.isRunning else { return }
-            procedure.process.terminate()
+        addDidCancelBlockObserver { procedure, errors in
+            DispatchQueue.main.async {
+                guard procedure.isExecuting && procedure.process.isRunning else { return }
+                procedure.process.terminate()
+            }
         }
     }
 
     open override func execute() {
-        guard let _ = process.launchPath else {
-            finish(withError: Error.launchPathNotSet)
-            return
-        }
+        // NOTE: NSTask/Process is *not* thread-safe.
+        // See: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/Multithreading/ThreadSafetySummary/ThreadSafetySummary.html#//apple_ref/doc/uid/10000057i-CH12-125664
+        //
+        // It's not a good idea to call `launch()` on a thread that may disappear before the
+        // NSTask/Process goes away. Thus, we use the main queue/thread.
 
-        let previousTerminationHandler = process.terminationHandler
+        DispatchQueue.onMain { [weak self] in
+            guard let procedure = self else { return }
 
-        process.terminationHandler = { [weak self] task in
-            guard let strongSelf = self else { return }
+            procedure.process.terminationHandler = { [weak procedure] task in
+                guard let procedure = procedure else { return }
 
-            previousTerminationHandler?(strongSelf.process)
-            if strongSelf.processDidExitCleanly(Int(strongSelf.process.terminationStatus)) {
-                strongSelf.finish()
+                if procedure.processDidExitCleanly(Int(procedure.process.terminationStatus)) {
+                    procedure.finish()
+                }
+                else {
+                    procedure.finish(withError: Error.terminationReason(procedure.process.terminationReason))
+                }
             }
-            else {
-                strongSelf.finish(withError: Error.terminationReason(strongSelf.process.terminationReason))
-            }
-        }
 
-        process.launch()
+            guard !procedure.isCancelled else { return }
+            procedure.process.launch()
+        }
+    }
+}
+
+public extension ProcessProcedure {
+
+    /// The processIdentifier for the started Process.
+    ///
+    /// This value is 0 until the ProcessProcedure executes and starts the Process.
+    ///
+    /// To retrieve the processIdentifier as soon as it is available,
+    /// access it inside a DidExecuteObserver (added to the ProcessProcedure).
+    var processIdentifier: Int32 {
+        get {
+            return DispatchQueue.onMain { process.processIdentifier }
+        }
+    }
+
+    /// Resumes execution of the ProcessProcedure's Process that had previously been suspended with
+    /// a call to suspend().
+    ///
+    /// See the documentation for Process.resume():
+    /// https://developer.apple.com/reference/foundation/process/1407819-resume
+    ///
+    /// If multiple `suspend()` messages were sent to the receiver, an equal number of `resume()`
+    /// messages must be sent before the task resumes execution.
+    ///
+    /// Calling `resume()` when the ProcessProcedure is not executing (i.e. before it executes or
+    /// after it finishes) has no effect and returns false.
+    ///
+    /// - parameter completion: A completion block that is called with the result of the resume() call
+    func resume(completion: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let procedure = self else { return }
+            guard procedure.isExecuting else {
+                completion(false)
+                return
+            }
+            let result = procedure.process.resume()
+            completion(result)
+        }
+    }
+
+    /// Suspends execution of the ProcessProcedure's Process.
+    ///
+    /// See the documentation for Process.suspend():
+    /// https://developer.apple.com/reference/foundation/process/1411590-suspend
+    ///
+    /// Multiple `suspend()` messages can be sent, but they must be balanced with an equal number of
+    /// `resume()` messages before the Process resumes execution.
+    ///
+    /// Calling `suspend()` when the ProcessProcedure is not executing (i.e. before it executes or
+    /// after it finishes) has no effect and returns false.
+    ///
+    /// - parameter completion: A completion block that is called with the result of the suspend() call
+    func suspend(completion: @escaping (Bool) -> Void) {
+        DispatchQueue.main.async { [weak self] in
+            guard let procedure = self else { return }
+            guard procedure.isExecuting else {
+                completion(false)
+                return
+            }
+            let result = procedure.process.suspend()
+            completion(result)
+        }
     }
 }

--- a/Sources/Mac/Process.swift
+++ b/Sources/Mac/Process.swift
@@ -118,6 +118,8 @@ open class ProcessProcedure: Procedure {
     }
 }
 
+// MARK: - Properties of the Process
+
 public extension ProcessProcedure {
 
     /// The processIdentifier for the started Process.
@@ -131,6 +133,51 @@ public extension ProcessProcedure {
             return DispatchQueue.onMain { process.processIdentifier }
         }
     }
+}
+
+// MARK: - Configuration Properties (Read-only)
+
+public extension ProcessProcedure {
+
+    /// (Read-only) The command arguments that should be used to launch the executable.
+    var arguments: [String]? {
+        get { return DispatchQueue.onMain { process.arguments } }
+    }
+
+    /// (Read-only) The current directory to be used when launching the executable.
+    var currentDirectoryPath: String {
+        get { return DispatchQueue.onMain { process.currentDirectoryPath } }
+    }
+
+    /// (Read-only) The environment to be used when launching the executable.
+    var environment: [String : String]? {
+        get { return DispatchQueue.onMain { process.environment } }
+    }
+
+    /// (Read-only) The path to the executable to be launched.
+    var launchPath: String {
+        get { return DispatchQueue.onMain { process.launchPath! } }
+    }
+
+    /// (Read-only) The standard error (FileHandle or Pipe object).
+    var standardError: Any? {
+        get { return DispatchQueue.onMain { process.standardError } }
+    }
+
+    /// (Read-only) The standard input (FileHandle or Pipe object).
+    var standardInput: Any? {
+        get { return DispatchQueue.onMain { process.standardInput } }
+    }
+
+    /// (Read-only) The standard output (FileHandle or Pipe object).
+    var standardOutput: Any? {
+        get { return DispatchQueue.onMain { process.standardOutput } }
+    }
+}
+
+// MARK: - Process Suspend / Resume
+
+public extension ProcessProcedure {
 
     /// Resumes execution of the ProcessProcedure's Process that had previously been suspended with
     /// a call to suspend().

--- a/Sources/Support.swift
+++ b/Sources/Support.swift
@@ -87,6 +87,11 @@ public class Protector<T> {
         return lock.write_sync({ block(&self.ward) })
     }
 
+    /// Synchronously overwrite the protected value
+    public func overwrite(with newValue: T) {
+        write { (ward: inout T) in ward = newValue }
+    }
+
     // Supports old callers that expect to pass in a completion block
     // NOTE: Like `write()`, this is synchronous.
     public func write(_ block: (inout T) -> Void, completion: (() -> Void)) {


### PR DESCRIPTION
`NSTask`/`Process` is listed as a Thread-Unsafe Class in the [Foundation Framework Thread Safety guide](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/Multithreading/ThreadSafetySummary/ThreadSafetySummary.html#//apple_ref/doc/uid/10000057i-CH12-125664).

Additionally, when an NSTask/Process is `launch()`ed on a thread that goes away before it does, [a crash can result](https://web.archive.org/web/20111213185028/http://cocoadev.com/index.pl?NSTaskTermination).

As such, some major modifications to ProcessProcedure are necessary.

- `init(…)` now takes all the possible configuration parameters for the Process, instead of a Process instance (the only required parameter is `launchPath`)
- the ProcessProcedure is now responsible for creating the Process object and managing it
- there is no public accessor for the Process object (it’s now an internal implementation detail of ProcessProcedure)
- various additional methods / properties were added to expose Process object functionality directly on the ProcessProcedure

Internally, the ProcessProcedure ensures that `launch()`, `terminate()`, and other important methods of the Process are dispatched to the main queue/thread.