### PR TITLE
NetworkProcedure cancellation testing enhancements

### DIFF
--- a/Sources/Testing/TestableNetwork.swift
+++ b/Sources/Testing/TestableNetwork.swift
@@ -48,7 +48,7 @@ public class TestableURLSessionTask: Equatable {
         stateLock.withCriticalScope {
             _didResume = true
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: completionWorkItem)
+        DispatchQueue.global(qos: .default).asyncAfter(deadline: .now() + delay, execute: completionWorkItem)
     }
 
     public func cancel() {

--- a/Sources/Testing/TestableNetwork.swift
+++ b/Sources/Testing/TestableNetwork.swift
@@ -53,11 +53,12 @@ public class TestableURLSessionTask: Equatable {
 
     public func cancel() {
         // Behavior: cancel the delayed completion, and call the completion handler immediately
+        // (Unless already finished)
+        guard shouldFinish() else { return }
         stateLock.withCriticalScope {
             _didCancel = true
             completionWorkItem.cancel()
         }
-        guard shouldFinish() else { return }
         completion(self)
     }
 


### PR DESCRIPTION
- Enhance `TestableURLSessionTask` and `TestableURLSessionTaskFactory` cancellation support
The behavior now better replicates NSURLSession/NSURLSessionTask behavior on cancellation, including providing the proper error to the completionHandler (and calling the completionHandler early if cancelled).

- More cancellation tests for `NetworkDataProcedure`

- More cancellation tests for `NetworkDownloadProcedure`

- More cancellation tests for `NetworkUploadProcedure`