### PR TITLE
Fixes code signing issue by clearing credentials.

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -3511,6 +3511,8 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
+				DEVELOPMENT_TEAM = "";
+				CODE_SIGN_IDENTITY = "";
 			};
 			name = Debug;
 		};


### PR DESCRIPTION
An iOS project using ProcedureKit as dependency (no cocoapods, Xcode 8.1 or 8.2) failed to build with this error message:

> ProcedureKit
    Dependency Analysis Error
        Ad Hoc code signing is not allowed with SDK 'iOS 10.2'

Using ProcedureKitMobile didn't change it.

Clearing `DEVELOPMENT_TEAM` and `CODE_SIGN_IDENTITY` is the minimum change that fixed it.