### PR TITLE
Resolve ProcedureKitCloud compilation issues with Xcode 8.2 beta 2

### DIFF
--- a/Sources/Cloud/CKAcceptSharesOperation.swift
+++ b/Sources/Cloud/CKAcceptSharesOperation.swift
@@ -9,8 +9,11 @@ import CloudKit
 /// A generic protocol which exposes the properties used by Apple's CKAcceptSharesOperation.
 public protocol CKAcceptSharesOperationProtocol: CKOperationProtocol {
 
+    /// The type of the shareMetadatas property
+    associatedtype ShareMetadatasPropertyType
+
     /// - returns: the share metadatas
-    var shareMetadatas: [ShareMetadata] { get set }
+    var shareMetadatas: ShareMetadatasPropertyType { get set }
 
     /// - returns: the block used to return accepted shares
     var perShareCompletionBlock: ((ShareMetadata, Share?, Swift.Error?) -> Void)? { get set }
@@ -28,7 +31,7 @@ extension CKAcceptSharesOperation: CKAcceptSharesOperationProtocol, AssociatedEr
 
 extension CKProcedure where T: CKAcceptSharesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
 
-    public var shareMetadatas: [T.ShareMetadata] {
+    public var shareMetadatas: T.ShareMetadatasPropertyType {
         get { return operation.shareMetadatas }
         set { operation.shareMetadatas = newValue }
     }
@@ -59,7 +62,7 @@ extension CloudKitProcedure where T: CKAcceptSharesOperationProtocol, T: Associa
     public typealias AcceptSharesCompletionBlock = () -> Void
 
     /// - returns: the share metadatas
-    public var shareMetadatas: [T.ShareMetadata] {
+    public var shareMetadatas: T.ShareMetadatasPropertyType {
         get { return current.shareMetadatas }
         set {
             current.shareMetadatas = newValue

--- a/Sources/Cloud/CKFetchRecordChangesOperation.swift
+++ b/Sources/Cloud/CKFetchRecordChangesOperation.swift
@@ -9,8 +9,11 @@ import CloudKit
 /// A generic protocol which exposes the properties used by Apple's CKFetchRecordChangesOperation.
 public protocol CKFetchRecordChangesOperationProtocol: CKDatabaseOperationProtocol, CKFetchOperation, CKDesiredKeys {
 
+    /// The type of the recordZoneID property
+    associatedtype RecordZoneIDPropertyType
+
     /// - returns: the record zone ID whcih will fetch changes
-    var recordZoneID: RecordZoneID { get set }
+    var recordZoneID: RecordZoneIDPropertyType { get set }
 
     /// - returns: a block for when a record is changed
     var recordChangedBlock: ((Record) -> Void)? { get set }
@@ -41,7 +44,7 @@ extension CKFetchRecordChangesOperation: CKFetchRecordChangesOperationProtocol, 
 
 extension CKProcedure where T: CKFetchRecordChangesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
 
-    public var recordZoneID: T.RecordZoneID {
+    public var recordZoneID: T.RecordZoneIDPropertyType {
         get { return operation.recordZoneID }
         set { operation.recordZoneID = newValue }
     }
@@ -80,7 +83,7 @@ extension CloudKitProcedure where T: CKFetchRecordChangesOperationProtocol, T: A
     public typealias FetchRecordChangesCompletionBlock = (T.ServerChangeToken?, Data?) -> Void
 
     /// - returns: the record zone ID
-    public var recordZoneID: T.RecordZoneID {
+    public var recordZoneID: T.RecordZoneIDPropertyType {
         get { return current.recordZoneID }
         set {
             current.recordZoneID = newValue

--- a/Sources/Cloud/CKFetchRecordZoneChangesOperation.swift
+++ b/Sources/Cloud/CKFetchRecordZoneChangesOperation.swift
@@ -12,8 +12,11 @@ public protocol CKFetchRecordZoneChangesOperationProtocol: CKDatabaseOperationPr
     /// The type of the CloudKit FetchRecordZoneChangesOptions
     associatedtype FetchRecordZoneChangesOptions
 
+    /// The type of the recordZoneIDs property
+    associatedtype RecordZoneIDsPropertyType
+
     /// - returns: the record zone IDs which will fetch changes
-    var recordZoneIDs: [RecordZoneID] { get set }
+    var recordZoneIDs: RecordZoneIDsPropertyType { get set }
 
     /// - returns: the per-record-zone options
     var optionsByRecordZoneID: [RecordZoneID : FetchRecordZoneChangesOptions]? { get set }
@@ -47,7 +50,7 @@ extension CKFetchRecordZoneChangesOperation: CKFetchRecordZoneChangesOperationPr
 extension CKProcedure where T: CKFetchRecordZoneChangesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
 
     /// - returns: the record zone IDs which will fetch changes
-    public var recordZoneIDs: [T.RecordZoneID] {
+    public var recordZoneIDs: T.RecordZoneIDsPropertyType {
         get { return operation.recordZoneIDs }
         set { operation.recordZoneIDs = newValue }
     }
@@ -113,7 +116,7 @@ extension CloudKitProcedure where T: CKFetchRecordZoneChangesOperationProtocol, 
     public typealias FetchRecordZoneChangesCompletionBlock = () -> Void
 
     /// - returns: the record zone IDs which will fetch changes
-    public var recordZoneIDs: [T.RecordZoneID] {
+    public var recordZoneIDs: T.RecordZoneIDsPropertyType {
         get { return current.recordZoneIDs }
         set {
             current.recordZoneIDs = newValue

--- a/Sources/Cloud/CKFetchShareMetadataOperation.swift
+++ b/Sources/Cloud/CKFetchShareMetadataOperation.swift
@@ -10,8 +10,11 @@ import CloudKit
 /// A generic protocol which exposes the properties used by Apple's CKFetchShareMetadataOperation.
 public protocol CKFetchShareMetadataOperationProtocol: CKOperationProtocol {
 
+    /// The type of the shareURLs property
+    associatedtype ShareURLsPropertyType
+
     /// - returns: the share URLs
-    var shareURLs: [URL] { get set }
+    var shareURLs: ShareURLsPropertyType { get set }
 
     /// - returns: whether to fetch the share root record
     var shouldFetchRootRecord: Bool { get set }
@@ -35,7 +38,7 @@ extension CKFetchShareMetadataOperation: CKFetchShareMetadataOperationProtocol, 
 
 extension CKProcedure where T: CKFetchShareMetadataOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
 
-    public var shareURLs: [URL] {
+    public var shareURLs: T.ShareURLsPropertyType {
         get { return operation.shareURLs }
         set { operation.shareURLs = newValue }
     }
@@ -76,7 +79,7 @@ extension CloudKitProcedure where T: CKFetchShareMetadataOperationProtocol, T: A
     public typealias FetchShareMetadataCompletionBlock = () -> Void
 
     /// - returns: the share URLs
-    public var shareURLs: [URL] {
+    public var shareURLs: T.ShareURLsPropertyType {
         get { return current.shareURLs }
         set {
             current.shareURLs = newValue

--- a/Sources/Cloud/CKFetchShareParticipantsOperation.swift
+++ b/Sources/Cloud/CKFetchShareParticipantsOperation.swift
@@ -9,8 +9,11 @@ import CloudKit
 /// A generic protocol which exposes the properties used by Apple's CKFetchShareParticipantsOperation.
 public protocol CKFetchShareParticipantsOperationProtocol: CKOperationProtocol {
 
+    /// The type of the userIdentityLookupInfos property
+    associatedtype UserIdentityLookupInfosPropertyType
+
     /// - returns: the user identity lookup infos
-    var userIdentityLookupInfos: [UserIdentityLookupInfo] { get set }
+    var userIdentityLookupInfos: UserIdentityLookupInfosPropertyType { get set }
 
     /// - returns: the share participant fetched block
     var shareParticipantFetchedBlock: ((ShareParticipant) -> Void)? { get set }
@@ -28,7 +31,7 @@ extension CKFetchShareParticipantsOperation: CKFetchShareParticipantsOperationPr
 
 extension CKProcedure where T: CKFetchShareParticipantsOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
 
-    public var userIdentityLookupInfos: [T.UserIdentityLookupInfo] {
+    public var userIdentityLookupInfos: T.UserIdentityLookupInfosPropertyType {
         get { return operation.userIdentityLookupInfos }
         set { operation.userIdentityLookupInfos = newValue }
     }
@@ -59,7 +62,7 @@ extension CloudKitProcedure where T: CKFetchShareParticipantsOperationProtocol, 
     public typealias FetchShareParticipantsCompletionBlock = (Void) -> Void
 
     /// - returns: the user identity lookup infos
-    public var userIdentityLookupInfos: [T.UserIdentityLookupInfo] {
+    public var userIdentityLookupInfos: T.UserIdentityLookupInfosPropertyType {
         get { return current.userIdentityLookupInfos }
         set {
             current.userIdentityLookupInfos = newValue

--- a/Sources/Cloud/CKMarkNotificationsReadOperation.swift
+++ b/Sources/Cloud/CKMarkNotificationsReadOperation.swift
@@ -9,8 +9,11 @@ import CloudKit
 /// A generic protocol which exposes the properties used by Apple's CKMarkNotificationsReadOperation.
 public protocol CKMarkNotificationsReadOperationProtocol: CKOperationProtocol {
 
+    /// The type of the notificationIDs property
+    associatedtype NotificationIDsPropertyType
+
     /// - returns: the notification IDs
-    var notificationIDs: [NotificationID] { get set }
+    var notificationIDs: NotificationIDsPropertyType { get set }
 
     /// - returns: the completion block used when marking notifications
     var markNotificationsReadCompletionBlock: (([NotificationID]?, Error?) -> Void)? { get set }
@@ -30,7 +33,7 @@ extension CKMarkNotificationsReadOperation: CKMarkNotificationsReadOperationProt
 
 extension CKProcedure where T: CKMarkNotificationsReadOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
 
-    public var notificationIDs: [T.NotificationID] {
+    public var notificationIDs: T.NotificationIDsPropertyType {
         get { return operation.notificationIDs }
         set { operation.notificationIDs = newValue }
     }
@@ -53,7 +56,7 @@ extension CloudKitProcedure where T: CKMarkNotificationsReadOperationProtocol, T
     public typealias MarkNotificationsReadCompletionBlock = ([T.NotificationID]?) -> Void
 
     /// - returns: the notification IDs
-    public var notificationIDs: [T.NotificationID] {
+    public var notificationIDs: T.NotificationIDsPropertyType {
         get { return current.notificationIDs }
         set {
             current.notificationIDs = newValue

--- a/Sources/Cloud/CKModifyRecordsOperation.swift
+++ b/Sources/Cloud/CKModifyRecordsOperation.swift
@@ -9,6 +9,9 @@ import CloudKit
 /// A generic protocol which exposes the properties used by Apple's CKModifyRecordsOperation.
 public protocol CKModifyRecordsOperationProtocol: CKDatabaseOperationProtocol {
 
+    /// The type of the perRecordCompletionBlock property
+    associatedtype PerRecordCompletionBlockType
+
     /// - returns: the records to save
     var recordsToSave: [Record]? { get set }
 
@@ -28,7 +31,7 @@ public protocol CKModifyRecordsOperationProtocol: CKDatabaseOperationProtocol {
     var perRecordProgressBlock: ((Record, Double) -> Void)? { get set }
 
     /// - returns: a per record completion block
-    var perRecordCompletionBlock: ((Record?, Error?) -> Void)? { get set }
+    var perRecordCompletionBlock: PerRecordCompletionBlockType { get set }
 
     /// - returns: the modify records completion block
     var modifyRecordsCompletionBlock: (([Record]?, [RecordID]?, Error?) -> Void)? { get set }
@@ -79,7 +82,7 @@ extension CKProcedure where T: CKModifyRecordsOperationProtocol, T: AssociatedEr
         set { operation.perRecordProgressBlock = newValue }
     }
 
-    public var perRecordCompletionBlock: CloudKitProcedure<T>.ModifyRecordsPerRecordCompletionBlock? {
+    public var perRecordCompletionBlock: CloudKitProcedure<T>.ModifyRecordsPerRecordCompletionBlock {
         get { return operation.perRecordCompletionBlock }
         set { operation.perRecordCompletionBlock = newValue }
     }
@@ -106,7 +109,7 @@ extension CloudKitProcedure where T: CKModifyRecordsOperationProtocol, T: Associ
     public typealias ModifyRecordsPerRecordProgressBlock = (T.Record, Double) -> Void
 
     /// A typealias for the block types used by CloudKitOperation<CKModifyRecordsOperation>
-    public typealias ModifyRecordsPerRecordCompletionBlock = (T.Record?, Error?) -> Void
+    public typealias ModifyRecordsPerRecordCompletionBlock = T.PerRecordCompletionBlockType
 
     /// A typealias for the block types used by CloudKitOperation<CKModifyRecordsOperation>
     public typealias ModifyRecordsCompletionBlock = ([T.Record]?, [T.RecordID]?) -> Void
@@ -166,7 +169,7 @@ extension CloudKitProcedure where T: CKModifyRecordsOperationProtocol, T: Associ
     }
 
     /// - returns: a block for per record completion
-    public var perRecordCompletionBlock: ModifyRecordsPerRecordCompletionBlock? {
+    public var perRecordCompletionBlock: ModifyRecordsPerRecordCompletionBlock {
         get { return current.perRecordCompletionBlock }
         set {
             current.perRecordCompletionBlock = newValue

--- a/Sources/Cloud/CKOperation.swift
+++ b/Sources/Cloud/CKOperation.swift
@@ -67,6 +67,9 @@ public protocol CKOperationProtocol: class {
     /// The type of the CloudKit ShareParticipant
     associatedtype ShareParticipant
 
+    /// The type of the longLivedOperationWasPersistedBlock property
+    associatedtype LongLivedOperationWasPersistedBlockType
+
     /// - returns the CloudKit Container
     var container: Container? { get set }
 
@@ -83,7 +86,7 @@ public protocol CKOperationProtocol: class {
 
     /// - returns the block to execute when the server starts storing callbacks for this long-lived CKOperation
     @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
-    var longLivedOperationWasPersistedBlock: () -> Void { get set }
+    var longLivedOperationWasPersistedBlock: LongLivedOperationWasPersistedBlockType { get set }
 
     /// If non-zero, overrides the timeout interval for any network requests issued by this operation.
     /// See NSURLSessionConfiguration.timeoutIntervalForRequest
@@ -192,7 +195,7 @@ extension CKProcedure where T: CKOperationProtocol {
     }
 
     @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
-    public var longLivedOperationWasPersistedBlock: () -> Void {
+    public var longLivedOperationWasPersistedBlock: T.LongLivedOperationWasPersistedBlockType {
         get { return operation.longLivedOperationWasPersistedBlock }
         set { operation.longLivedOperationWasPersistedBlock = newValue }
     }
@@ -248,7 +251,7 @@ extension CloudKitProcedure where T: CKOperationProtocol {
 
     /// - returns the block to execute when the server starts storing callbacks for this long-lived CKOperation
     @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
-    public var longLivedOperationWasPersistedBlock: () -> Void {
+    public var longLivedOperationWasPersistedBlock: T.LongLivedOperationWasPersistedBlockType {
         get { return current.longLivedOperationWasPersistedBlock }
         set {
             current.longLivedOperationWasPersistedBlock = newValue


### PR DESCRIPTION
Xcode 8.2 beta 2 (8C30a) changed several of the CKOperation (and subclasses') property/block types slightly. Make these `associatedtype`s so they work on both Xcode 8.2 beta 2 and earlier versions of Xcode 8.