### PR TITLE
NetworkProcedure testing improvements

### DIFF
--- a/Sources/Testing/TestableNetwork.swift
+++ b/Sources/Testing/TestableNetwork.swift
@@ -73,24 +73,120 @@ public class TestableURLSessionTask: Equatable {
 
 public class TestableURLSessionTaskFactory {
 
-    public var delay: TimeInterval = 0
-    public var returnedResponse: HTTPURLResponse? = HTTPURLResponse()
-    public var returnedError: Error? = nil
+    public var delay: TimeInterval {
+        get { return stateLock.withCriticalScope { _delay } }
+        set {
+            stateLock.withCriticalScope {
+                _delay = newValue
+            }
+        }
+    }
+    public var returnedResponse: HTTPURLResponse? {
+        get { return stateLock.withCriticalScope { _returnedResponse } }
+        set {
+            stateLock.withCriticalScope {
+                _returnedResponse = newValue
+            }
+        }
+    }
+    public var returnedError: Error? {
+        get { return stateLock.withCriticalScope { _returnedError } }
+        set {
+            stateLock.withCriticalScope {
+                _returnedError = newValue
+            }
+        }
+    }
 
     // Data
-    public var didReceiveDataRequest: URLRequest? = nil
-    public var didReturnDataTask: TestableURLSessionTask? = nil
-    public var returnedData: Data? = "hello world".data(using: String.Encoding.utf8)
+    public var didReceiveDataRequest: URLRequest? {
+        get { return stateLock.withCriticalScope { _didReceiveDataRequest } }
+        set {
+            stateLock.withCriticalScope {
+                _didReceiveDataRequest = newValue
+            }
+        }
+    }
+    public var didReturnDataTask: TestableURLSessionTask? {
+        get { return stateLock.withCriticalScope { _didReturnDataTask } }
+        set {
+            stateLock.withCriticalScope {
+                _didReturnDataTask = newValue
+            }
+        }
+    }
+    public var returnedData: Data? {
+        get { return stateLock.withCriticalScope { _returnedData } }
+        set {
+            stateLock.withCriticalScope {
+                _returnedData = newValue
+            }
+        }
+    }
 
     // Download
-    public var didReceiveDownloadRequest: URLRequest? = nil
-    public var didReturnDownloadTask: TestableURLSessionTask? = nil
-    public var returnedURL: URL? = URL(fileURLWithPath: "/var/tmp/hello/this/is/a/test/url")
+    public var didReceiveDownloadRequest: URLRequest? {
+        get { return stateLock.withCriticalScope { _didReceiveDownloadRequest } }
+        set {
+            stateLock.withCriticalScope {
+                _didReceiveDownloadRequest = newValue
+            }
+        }
+    }
+    public var didReturnDownloadTask: TestableURLSessionTask? {
+        get { return stateLock.withCriticalScope { _didReturnDownloadTask } }
+        set {
+            stateLock.withCriticalScope {
+                _didReturnDownloadTask = newValue
+            }
+        }
+    }
+    public var returnedURL: URL? {
+        get { return stateLock.withCriticalScope { _returnedURL } }
+        set {
+            stateLock.withCriticalScope {
+                _returnedURL = newValue
+            }
+        }
+    }
 
     // Upload
-    public var didReceiveUploadRequest: URLRequest? = nil
-    public var didReturnUploadTask: TestableURLSessionTask? = nil
+    public var didReceiveUploadRequest: URLRequest? {
+        get { return stateLock.withCriticalScope { _didReceiveUploadRequest } }
+        set {
+            stateLock.withCriticalScope {
+                _didReceiveUploadRequest = newValue
+            }
+        }
+    }
+    public var didReturnUploadTask: TestableURLSessionTask? {
+        get { return stateLock.withCriticalScope { _didReturnUploadTask } }
+        set {
+            stateLock.withCriticalScope {
+                _didReturnUploadTask = newValue
+            }
+        }
+    }
 
+    private var stateLock = NSLock()
+
+    // Private (protected) Properties
+    private var _delay: TimeInterval = 0
+    private var _returnedResponse: HTTPURLResponse? = HTTPURLResponse()
+    private var _returnedError: Error? = nil
+
+    private var _didReceiveDataRequest: URLRequest? = nil
+    private var _didReturnDataTask: TestableURLSessionTask? = nil
+    private var _returnedData: Data? = "hello world".data(using: String.Encoding.utf8)
+
+    private var _didReceiveDownloadRequest: URLRequest? = nil
+    private var _didReturnDownloadTask: TestableURLSessionTask? = nil
+    private var _returnedURL: URL? = URL(fileURLWithPath: "/var/tmp/hello/this/is/a/test/url")
+
+    private var _didReceiveUploadRequest: URLRequest? = nil
+    private var _didReturnUploadTask: TestableURLSessionTask? = nil
+
+    // Initializers
     public init() { }
 
     public func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> TestableURLSessionTask {
@@ -98,7 +194,7 @@ public class TestableURLSessionTaskFactory {
         let task = TestableURLSessionTask(delay: delay) { (task) in
             DispatchQueue.main.async {
                 guard !task.didCancel else {
-                    completionHandler(nil, nil, self.cancelledError(forRequest: request))
+                    completionHandler(nil, nil, TestableURLSessionTaskFactory.cancelledError(forRequest: request))
                     return
                 }
                 completionHandler(self.returnedData, self.returnedResponse, self.returnedError)
@@ -113,7 +209,7 @@ public class TestableURLSessionTaskFactory {
         let task = TestableURLSessionTask(delay: delay) { (task) in
             DispatchQueue.main.async {
                 guard !task.didCancel else {
-                    completionHandler(nil, nil, self.cancelledError(forRequest: request))
+                    completionHandler(nil, nil, TestableURLSessionTaskFactory.cancelledError(forRequest: request))
                     return
                 }
                 completionHandler(self.returnedURL, self.returnedResponse, self.returnedError)
@@ -129,7 +225,7 @@ public class TestableURLSessionTaskFactory {
         let task = TestableURLSessionTask(delay: delay) { (task) in
             DispatchQueue.main.async {
                 guard !task.didCancel else {
-                    completionHandler(nil, nil, self.cancelledError(forRequest: request))
+                    completionHandler(nil, nil, TestableURLSessionTaskFactory.cancelledError(forRequest: request))
                     return
                 }
                 completionHandler(self.returnedData, self.returnedResponse, self.returnedError)
@@ -139,7 +235,7 @@ public class TestableURLSessionTaskFactory {
         return task
     }
 
-    private func cancelledError(forRequest request: URLRequest) -> Error {
+    private static func cancelledError(forRequest request: URLRequest) -> Error {
         var userInfo: [AnyHashable: Any] = [NSLocalizedDescriptionKey: "cancelled"]
         if let requestURL = request.url {
             userInfo[NSURLErrorFailingURLErrorKey] = requestURL

--- a/Sources/Testing/TestableNetworkReachability.swift
+++ b/Sources/Testing/TestableNetworkReachability.swift
@@ -12,16 +12,58 @@ import ProcedureKit
 public class TestableNetworkReachability {
     typealias Reachability = String
 
-    public var flags: SCNetworkReachabilityFlags = .reachable {
+    public var flags: SCNetworkReachabilityFlags {
+        get { return stateLock.withCriticalScope { _flags } }
+        set {
+            stateLock.withCriticalScope {
+                _flags = newValue
+            }
+        }
+    }
+    public var didStartNotifier: Bool {
+        get { return stateLock.withCriticalScope { _didStartNotifier } }
+        set {
+            stateLock.withCriticalScope {
+                _didStartNotifier = newValue
+            }
+        }
+    }
+    public var didStopNotifier: Bool {
+        get { return stateLock.withCriticalScope { _didStopNotifier } }
+        set {
+            stateLock.withCriticalScope {
+                _didStopNotifier = newValue
+            }
+        }
+    }
+
+    public var log: LoggerProtocol {
+        get { return stateLock.withCriticalScope { _log } }
+        set {
+            stateLock.withCriticalScope {
+                _log = newValue
+            }
+        }
+    }
+    public weak var delegate: NetworkReachabilityDelegate? {
+        get { return stateLock.withCriticalScope { _delegate } }
+        set {
+            stateLock.withCriticalScope {
+                _delegate = newValue
+            }
+        }
+    }
+
+    private var stateLock = NSRecursiveLock()
+    private var _flags: SCNetworkReachabilityFlags = .reachable {
         didSet {
             delegate?.didChangeReachability(flags: flags)
         }
     }
-    public var didStartNotifier = false
-    public var didStopNotifier = false
-
-    public var log: LoggerProtocol = Logger()
-    public weak var delegate: NetworkReachabilityDelegate? = nil
+    private var _didStartNotifier = false
+    private var _didStopNotifier = false
+    private var _log: LoggerProtocol = Logger()
+    private var _delegate: NetworkReachabilityDelegate? = nil
 
     public init() { }
 }


### PR DESCRIPTION
Certain ProcedureKitNetwork tests occasionally fail:

```
[18:25:34]: ▸ Failing tests:
[18:25:34]: ▸ -[NetworkProcedureTests test__waits_for_reachability_change_before_retrying()]
[18:25:34]: ▸ -[NetworkReachabilityWaitProcedureTests test__procedure_waits_until_network_is_reachable()]
[18:25:34]: ▸ -[ReachabilityManagerTests test__when_connected_block_is_run()]
[18:25:34]: ▸ ** TEST FAILED **
```

Some of this may be due to a lack of thread-safety in `TestableURLSessionTaskFactory` and `TestableNetworkReachability`.