### PR TITLE
`Final` cleanup

### DIFF
--- a/Sources/Condition.swift
+++ b/Sources/Condition.swift
@@ -84,7 +84,7 @@ open class Condition: Procedure, ConditionProtocol, OutputProcedure {
         completion(result)
     }
 
-    internal func finish(withConditionResult conditionResult: ConditionResult) {
+    final internal func finish(withConditionResult conditionResult: ConditionResult) {
         output = .ready(conditionResult)
         finish(withError: conditionResult.error)
     }

--- a/Sources/Condition.swift
+++ b/Sources/Condition.swift
@@ -66,9 +66,12 @@ open class Condition: Procedure, ConditionProtocol, OutputProcedure {
         }
     }
 
+    /// The ConditionResult.
+    /// Will be Pending.ready(ConditionResult) once the Condition has been evaluated.
     public var output: Pending<ConditionResult> = .pending
 
-    open override func execute() {
+    /// Triggers evaluation of the Condition, unless the procedure no longer exists. Cannot be over-ridden
+    final public override func execute() {
         guard let procedure = procedure else {
             log.verbose(message: "Condition finishing before evaluation because procedure is nil.")
             finish()
@@ -77,6 +80,8 @@ open class Condition: Procedure, ConditionProtocol, OutputProcedure {
         evaluate(procedure: procedure, completion: finish)
     }
 
+    /// Must be overriden in Condition subclasses.
+    /// Must always call `completion` with the result.
     open func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {
         let reason = "Condition must be subclassed, and \(#function) overridden."
         let result: ConditionResult = .failure(ProcedureKitError.programmingError(reason: reason))

--- a/Sources/Group.swift
+++ b/Sources/Group.swift
@@ -49,7 +49,7 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
     fileprivate var groupCanFinish: CanFinishGroup!
 
     /// - returns: the operations which have been added to the queue
-    public var children: [Operation] {
+    final public var children: [Operation] {
         get { return groupChildren.read { $0 } }
     }
 
@@ -325,7 +325,7 @@ public extension GroupProcedure {
      For more, see the NSOperation and NSOperationQueue documentation for `qualityOfService`.
      */
     @available(OSX 10.10, iOS 8.0, tvOS 8.0, watchOS 2.0, *)
-    final override var qualityOfService: QualityOfService {
+    final public override var qualityOfService: QualityOfService {
         get { return queue.qualityOfService }
         set {
             super.qualityOfService = newValue
@@ -334,7 +334,7 @@ public extension GroupProcedure {
     }
 
     /// Override of Procedure.userIntent
-    public override var userIntent: UserIntent {
+    final public override var userIntent: UserIntent {
         didSet {
             let (operations, procedures) = children.operationsAndProcedures
             operations.forEach { $0.setQualityOfService(fromUserIntent: userIntent) }
@@ -351,7 +351,7 @@ public extension GroupProcedure {
      Add a single child Operation instance to the group
      - parameter child: an Operation instance
     */
-    func add(child: Operation) {
+    final func add(child: Operation) {
         add(children: child)
     }
 
@@ -359,7 +359,7 @@ public extension GroupProcedure {
      Add children Operation instances to the group
      - parameter children: a variable number of Operation instances
      */
-    func add(children: Operation...) {
+    final func add(children: Operation...) {
         add(children: children)
     }
 
@@ -367,7 +367,7 @@ public extension GroupProcedure {
      Add a sequence of Operation instances to the group
      - parameter children: a sequence of Operation instances
      */
-    func add<Children: Collection>(children: Children) where Children.Iterator.Element: Operation {
+    final func add<Children: Collection>(children: Children) where Children.Iterator.Element: Operation {
         add(additional: children, toOperationsArray: true)
     }
 
@@ -380,7 +380,7 @@ public extension GroupProcedure {
         }
     }
 
-    fileprivate func add<Additional: Collection>(additional: Additional, toOperationsArray shouldAddToProperty: Bool) where Additional.Iterator.Element: Operation {
+    final fileprivate func add<Additional: Collection>(additional: Additional, toOperationsArray shouldAddToProperty: Bool) where Additional.Iterator.Element: Operation {
         // Exit early if there are no children in the collection
         guard !additional.isEmpty else { return }
 
@@ -446,22 +446,22 @@ public extension GroupProcedure {
         }
     }
 
-    public func append(fatalError error: Error) {
+    final public func append(fatalError error: Error) {
         append(fatalErrors: [error])
     }
 
-    public func child(_ child: Operation, didEncounterFatalError error: Error) {
+    final public func child(_ child: Operation, didEncounterFatalError error: Error) {
         log.warning(message: "\(child.operationName) did encounter fatal error: \(error).")
         append(fatalError: error)
     }
 
-    public func append(fatalErrors errors: [Error]) {
+    final public func append(fatalErrors errors: [Error]) {
         groupErrors.write { (ward: inout GroupErrors) in
             ward.fatal.append(contentsOf: errors)
         }
     }
 
-    public func child(_ child: Operation, didEncounterFatalErrors errors: [Error]) {
+    final public func child(_ child: Operation, didEncounterFatalErrors errors: [Error]) {
         log.warning(message: "\(child.operationName) did encounter \(errors.count) fatal errors.")
         append(fatalErrors: errors)
     }
@@ -476,7 +476,7 @@ public extension GroupProcedure {
         return groupErrors.read { $0.attemptedRecovery }
     }
 
-    public func childDidRecoverFromErrors(_ child: Operation) {
+    final public func childDidRecoverFromErrors(_ child: Operation) {
         if let _ = attemptedRecovery[child] {
             log.notice(message: "successfully recovered from errors in \(child)")
             groupErrors.write { (ward: inout GroupErrors) in
@@ -485,7 +485,7 @@ public extension GroupProcedure {
         }
     }
 
-    public func childDidNotRecoverFromErrors(_ child: Operation) {
+    final public func childDidNotRecoverFromErrors(_ child: Operation) {
         log.notice(message: "failed to recover from errors in \(child)")
         groupErrors.write { (ward: inout GroupErrors) in
             if let errors = ward.attemptedRecovery.removeValue(forKey: child) {
@@ -499,7 +499,7 @@ public extension GroupProcedure {
 
 fileprivate extension GroupProcedure {
 
-    fileprivate class CanFinishGroup: Operation {
+    fileprivate final class CanFinishGroup: Operation {
 
         private weak var group: GroupProcedure?
         private var _isFinished = false

--- a/Sources/MutualExclusion.swift
+++ b/Sources/MutualExclusion.swift
@@ -26,7 +26,7 @@ public final class MutuallyExclusive<T>: Condition {
     }
 }
 
-public class ExclusivityManager {
+final public class ExclusivityManager {
 
     static let sharedInstance = ExclusivityManager()
 

--- a/Sources/Procedure.swift
+++ b/Sources/Procedure.swift
@@ -200,7 +200,7 @@ open class Procedure: Operation, ProcedureProtocol {
      ```
 
      */
-    public var log: LoggerProtocol {
+    final public var log: LoggerProtocol {
         get {
             let operationName = self.operationName
             return protectedProperties.read { LoggerContext(parent: $0.log, operationName: operationName) }
@@ -214,7 +214,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
     // MARK: Observers
 
-    var observers: [AnyObserver<Procedure>] {
+    final var observers: [AnyObserver<Procedure>] {
         get { return protectedProperties.read { $0.observers } }
     }
 
@@ -304,7 +304,7 @@ open class Procedure: Operation, ProcedureProtocol {
     }
 
 
-    public func willEnqueue(on queue: ProcedureQueue) {
+    public final func willEnqueue(on queue: ProcedureQueue) {
         state = .pending
         self.queue = queue
     }
@@ -442,7 +442,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
     open func procedureDidCancel(withErrors: [Error]) { }
 
-    public func cancel(withErrors errors: [Error]) {
+    public final func cancel(withErrors errors: [Error]) {
         _cancel(withAdditionalErrors: errors)
     }
 
@@ -523,7 +523,7 @@ open class Procedure: Operation, ProcedureProtocol {
         _finish(withErrors: errors, from: .finish)
     }
 
-    private func shouldFinish(from source: ProcedureKit.FinishingFrom) -> Bool {
+    private final func shouldFinish(from source: ProcedureKit.FinishingFrom) -> Bool {
         return _stateLock.withCriticalScope {
             // Do not finish is already finishing or finished
             guard state <= .finishing else { return false }
@@ -607,7 +607,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
 public extension Procedure {
 
-    public func add<Dependency: ProcedureProtocol>(dependency: Dependency) {
+    public final func add<Dependency: ProcedureProtocol>(dependency: Dependency) {
         guard let op = dependency as? Operation else {
             assertionFailure("Adding dependencies which do not subclass Foundation.Operation is not supported.")
             return
@@ -620,7 +620,7 @@ public extension Procedure {
 
 extension Procedure {
 
-    class EvaluateConditions: GroupProcedure, InputProcedure, OutputProcedure {
+    final class EvaluateConditions: GroupProcedure, InputProcedure, OutputProcedure {
 
         var input: Pending<[Condition]> = .pending
         var output: Pending<ConditionResult> = .pending
@@ -784,7 +784,7 @@ extension Procedure {
 
      - parameter condition: a `Condition` which must be satisfied for the procedure to be executed.
      */
-    public func add(condition: Condition) {
+    public final func add(condition: Condition) {
         assert(state < .executing, "Cannot modify conditions after operation has begun executing, current state: \(state).")
         protectedProperties.write {
             $0.conditions.insert(condition)

--- a/Sources/ProcedureQueue.swift
+++ b/Sources/ProcedureQueue.swift
@@ -271,7 +271,7 @@ public extension OperationQueue {
      Add operations to the queue as an array
      - parameters ops: a array of `NSOperation` instances.
      */
-    func add<S>(operations: S) where S: Sequence, S.Iterator.Element: Operation {
+    final func add<S>(operations: S) where S: Sequence, S.Iterator.Element: Operation {
         addOperations(Array(operations), waitUntilFinished: false)
     }
 
@@ -279,7 +279,7 @@ public extension OperationQueue {
      Add operations to the queue as a variadic parameter
      - parameters ops: a variadic array of `NSOperation` instances.
      */
-    func add(operations: Operation...) {
+    final func add(operations: Operation...) {
         add(operations: operations)
     }
 }

--- a/Sources/Repeat.swift
+++ b/Sources/Repeat.swift
@@ -135,7 +135,7 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
     ///
     /// - returns: whether or not there was a next payload added.
     @discardableResult
-    public func addNextOperation(_ shouldAddNext: @autoclosure () -> Bool = true) -> Bool {
+    final public func addNextOperation(_ shouldAddNext: @autoclosure () -> Bool = true) -> Bool {
         assert(!isFinished, "Cannot add next operation after the procedure has finished.")
         guard !isCancelled else { return false }
 
@@ -174,7 +174,7 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
     /// further before it is added.
     ///
     /// - returns: an optional Paylod
-    public func next() -> Payload? {
+    final public func next() -> Payload? {
         return _repeatStateLock.withCriticalScope { _next() }
     }
 
@@ -186,7 +186,7 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
     /// so it is possible to overwrite previous configurations.
     ///
     /// - parameter block: a block which receives an instance of T
-    public func append(configureBlock block: @escaping Payload.ConfigureBlock) {
+    final public func append(configureBlock block: @escaping Payload.ConfigureBlock) {
         _repeatStateLock.withCriticalScope {
             let config = _configure
             _configure = { operation in
@@ -196,7 +196,7 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
         }
     }
 
-    public func appendConfigureBlock(block: @escaping Payload.ConfigureBlock) {
+    final public func appendConfigureBlock(block: @escaping Payload.ConfigureBlock) {
         append(configureBlock: block)
     }
 
@@ -206,13 +206,13 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
     /// this API, before configuring
     ///
     /// - parameter block: a block which receives an instance of T
-    public func replace(configureBlock block: @escaping Payload.ConfigureBlock) {
+    final public func replace(configureBlock block: @escaping Payload.ConfigureBlock) {
         _repeatStateLock.withCriticalScope {
             _replace(configureBlock: block)
         }
     }
 
-    public func replaceConfigureBlock(block: @escaping Payload.ConfigureBlock) {
+    final public func replaceConfigureBlock(block: @escaping Payload.ConfigureBlock) {
         replace(configureBlock: block)
     }
 


### PR DESCRIPTION
Mark non-open properties/methods as `final` unless they are explicitly audited/purposed for overriding to ensure that later attempts to override (even internally) do not silently succeed without reviewing side-effects/implications.