### PR TITLE
TimeoutObserver improvements

### DIFF
--- a/Sources/TimeoutObserver.swift
+++ b/Sources/TimeoutObserver.swift
@@ -74,6 +74,7 @@ internal class ProcedureTimeoutRegistrar {
             procedureTimers.append(timer)
             $0[procedure] = procedureTimers
         }
+        timer.scheduleOneshot(deadline: .now() + delay.interval)
         timer.resume()
     }
 

--- a/Sources/TimeoutObserver.swift
+++ b/Sources/TimeoutObserver.swift
@@ -36,12 +36,108 @@ public struct TimeoutObserver: ProcedureObserver {
     public func will(execute procedure: Procedure) {
         switch delay.interval {
         case (let interval) where interval > 0.0:
-            DispatchQueue.main.asyncAfter(deadline: .now() + interval) { [delay = self.delay, weak procedure] in
-                guard let strongProcedure = procedure else { return }
-                guard !strongProcedure.isFinished && !strongProcedure.isCancelled else { return }
-                strongProcedure.cancel(withError: ProcedureKitError.timedOut(with: delay))
-            }
+            ProcedureTimeoutRegistrar.shared.createFinishTimeout(forProcedure: procedure, withDelay: delay)
+            break
         default: break
         }
+    }
+
+    public func did(finish procedure: Procedure, withErrors errors: [Error]) {
+        ProcedureTimeoutRegistrar.shared.registerFinished(procedure: procedure)
+    }
+}
+
+// A shared registrar of Procedure -> timeout timers.
+// Used to cancel all outstanding timers for a Procedure if:
+//      - that Procedure finishes
+//      - one of the Procedure's timers fires
+internal class ProcedureTimeoutRegistrar {
+
+    static let shared = ProcedureTimeoutRegistrar()
+
+    private let queue = DispatchQueue(label: "run.kit.procedure.ProcedureKit.ProcedureTimeouts", attributes: [.concurrent])
+    private let protectedFinishTimers = Protector<[Procedure : [DispatchTimerWrapper]]>([:])
+
+    func createFinishTimeout(forProcedure procedure: Procedure, withDelay delay: Delay) {
+        let timer = DispatchTimerWrapper(queue: queue)
+        timer.setEventHandler { [delay, weak procedure, weak registrar = self] in
+            guard let strongProcedure = procedure else { return }
+            guard !strongProcedure.isFinished && !strongProcedure.isCancelled else { return }
+            strongProcedure.cancel(withError: ProcedureKitError.timedOut(with: delay))
+            registrar?.registerTimeoutProcessed(forProcedure: strongProcedure)
+        }
+        protectedFinishTimers.write {
+            guard var procedureTimers = $0[procedure] else {
+                $0.updateValue([timer], forKey: procedure)
+                return
+            }
+            procedureTimers.append(timer)
+            $0[procedure] = procedureTimers
+        }
+        timer.resume()
+    }
+
+    // Called when a Procedure will/did Finish.
+    // Only the first call is processed, and removes all pending timers/timeouts for that Procedure.
+    func registerFinished(procedure: Procedure) {
+        registerTimeoutProcessed(forProcedure: procedure)
+    }
+
+    // Removes all DispatchTimers associated with a Procedure's registered timeouts.
+    // Is called when a Procedure finishes and when a timeout fires.
+    private func registerTimeoutProcessed(forProcedure procedure: Procedure) {
+        guard let dispatchTimers = protectedFinishTimers.write( {
+            return $0.removeValue(forKey: procedure)
+        })
+        else {
+            return
+        }
+        for timer in dispatchTimers {
+            timer.cancel()
+        }
+    }
+}
+
+// A wrapper for a DispatchSourceTimer that ensures that the timer is cancelled 
+// and not suspended prior to deinitialization.
+fileprivate class DispatchTimerWrapper {
+    fileprivate typealias EventHandler = @convention(block) () -> Swift.Void
+    private let timer: DispatchSourceTimer
+    private let lock = NSLock()
+    private var didResume = false
+
+    init(queue: DispatchQueue) {
+        timer = DispatchSource.makeTimerSource(flags: [], queue: queue)
+    }
+    deinit {
+        // ensure that the timer is cancelled and resumed before deiniting
+        // (trying to deconstruct a suspended DispatchSource will fail)
+        timer.cancel()
+        lock.withCriticalScope {
+            guard !didResume else { return }
+            timer.resume()
+        }
+    }
+
+    // MARK: - DispatchSourceTimer methods
+
+    func setEventHandler(qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], handler: @escaping EventHandler) {
+        timer.setEventHandler(qos: qos, flags: flags, handler: handler)
+    }
+    func setEventHandler(handler: DispatchWorkItem) {
+        timer.setEventHandler(handler: handler)
+    }
+    func scheduleOneshot(deadline: DispatchTime, leeway: DispatchTimeInterval = .nanoseconds(0)) {
+        timer.scheduleOneshot(deadline: deadline, leeway: leeway)
+    }
+    func resume() {
+        lock.withCriticalScope {
+            guard !didResume else { fatalError("Do not call resume() twice.") }
+            timer.resume()
+            didResume = true
+        }
+    }
+    func cancel() {
+        timer.cancel()
     }
 }

--- a/Tests/TimeoutObserverTests.swift
+++ b/Tests/TimeoutObserverTests.swift
@@ -44,4 +44,28 @@ final class TimeoutObserverTests: ProcedureKitTestCase {
         wait(for: procedure)
         XCTAssertProcedureFinishedWithoutErrors()
     }
+
+    func test__multiple_timeout_observers_on_a_single_procedure() {
+        procedure = TestProcedure(delay: 0.5)
+        procedure.add(observer: TimeoutObserver(by: 0.1))
+        procedure.add(observer: TimeoutObserver(by: 0.1))
+        procedure.add(observer: TimeoutObserver(by: 0.2))
+        procedure.add(observer: TimeoutObserver(by: 3.0))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithErrors(count: 1)
+    }
+
+    func test__add_single_timeout_observer_to_multiple_procedures() {
+        let procedure1 = TestProcedure(delay: 0.5)
+        let procedure2 = TestProcedure(delay: 0.5)
+        let procedure3 = TestProcedure(delay: 0)
+        let timeoutObserver = TimeoutObserver(by: 0.1)
+        procedure1.add(observer: timeoutObserver)
+        procedure2.add(observer: timeoutObserver)
+        procedure3.add(observer: timeoutObserver)
+        wait(for: procedure1, procedure2, procedure3)
+        XCTAssertProcedureCancelledWithErrors(procedure1, count: 1)
+        XCTAssertProcedureCancelledWithErrors(procedure2, count: 1)
+        XCTAssertProcedureFinishedWithoutErrors(procedure3)
+    }
 }


### PR DESCRIPTION
- Utilize a new ProcedureTimeoutRegistrar to handle the lifetime of timeout timers.
- When a Procedure finishes (or a timer fires), cancel all outstanding timers for that Procedure. (Thus, a TimeoutObserver with a long timeout will immediately deallocate its timers and associated timeout blocks when the Procedure finishes, instead of keeping the timers / timeout blocks in memory until the timeout passes.)
- Eliminate impact on the main thread/queue by executing the timer blocks on a private queue.