### PR TITLE
Requesting image from PHImageManager inside an Operation

### DIFF
--- a/Tests/RepeatProcedureTests.swift
+++ b/Tests/RepeatProcedureTests.swift
@@ -101,6 +101,37 @@ class RepeatProcedureTests: RepeatTestCase {
     }
 }
 
+class RepeatableTestProcedure: TestProcedure, Repeatable {
+
+    let limit: Int
+
+    init(limit: Int = 5) {
+        self.limit = limit
+        super.init()
+    }
+
+    func shouldRepeat(count: Int) -> Bool {
+        return count < limit
+    }
+}
+
+class RepeatableRepeatProcedureTests: ProcedureKitTestCase {
+
+    func test__init_with_repeatable_procedure() {
+        let repeatProcedure = RepeatProcedure { RepeatableTestProcedure() }
+        wait(for: repeatProcedure)
+        XCTAssertProcedureFinishedWithoutErrors(repeatProcedure)
+        XCTAssertEqual(repeatProcedure.count, 5)
+    }
+
+    func test__init_with_max_repeatable_procedure() {
+        let repeatProcedure = RepeatProcedure(max: 4) { RepeatableTestProcedure() }
+        wait(for: repeatProcedure)
+        XCTAssertProcedureFinishedWithoutErrors(repeatProcedure)
+        XCTAssertEqual(repeatProcedure.count, 4)
+    }
+}
+
 class IteratorTests: XCTestCase {
 
     func test__finite__limits_are_not_exceeeded() {


### PR DESCRIPTION
Hi, I encounter some deadlocks and I would like to check some things with you. (it's not an issue in procedureKit)

- It's ok to put operationGroup in operationGroup ? (I believe it is, but just to be sure..)

- The following code is showing where it's deadlocking : I add a lot of CalculationOperation (100) and the scoringOperation is itself launched multiple times in another groupOperation higher up.

Things to be noted : the block in calculationOperation is synchronous and executed on the caller thread. I have everytimes something like 10 calculationOperation who are finishing correctly before nothing moved anymore (xcode inspector show me lots of threads in lock state).

Thank you in advance for your help.

```swift
import Foundation
import Operations

class  CalculationOperation : Operation{
    
    private(set) var result: Double?
    
    let size:(Int, Int)
    
    init(localAsset:PHAsset, size:(Int, Int)) {
        
        self.localAsset = localAsset
        self.size = size
        super.init()
        name = "CalculationOperation"
        
    }
    
    override func execute() {
        
        // first check if the operation is cancelled, just in case
        guard !cancelled else { return }
     
        
        let options = PHImageRequestOptions()
	
	// I want to stay in this thread
        options.synchronous = true

        options.deliveryMode = .HighQualityFormat
        options.networkAccessAllowed = true
        options.resizeMode = .Exact
        
        let manager = PHImageManager.defaultManager()
        
        manager.requestImageForAsset(self.localAsset,
                                     targetSize: CGSize(width: size.0, height: size.1),
                                     contentMode: .AspectFill,
                                     options: options) { (img, infos) in
                                        
                                        // Thanks to synchronous = true, this block is called on the same thread that
                                        // called requestImageForAsset (ie : our operation thread)
                                                                                                
                                        self.result = somecalculation(img)
                                        self.finish()
                              
        }
    }

    func somecalculation(img:UIImage) -> Double{

           return Double(img.scale)
    }
}

class ScoringOperation: GroupOperation {
    
    private let imageSize = (200,200)
    
    init(files:[String]){
        
        super.init(operations: [])
        
        name = "ScoringOperation"
        
        let finishingOperation = finishingOperation()
 
        let assets = PHAsset.fetchAssetsWithLocalIdentifiers(files, options: nil)
        
        assets.enumerateObjectsUsingBlock { (obj, index, stop) in
            
            if let a = obj as? PHAsset{
                
                let op = CalculationOperation(localAsset: a, size: self.imageSize)
                finishingOperation.injectResultFromDependency(op, block: { (operation, dependency, errors) in
                    operation.addAsset(dependency.localAsset, score: dependency.result!)
                })
                
                self.addOperation(op)
            }
        }
        
        self.addOperations([finishingOperation])
        
    }    
}
```
