### PR TITLE
Fixed code signing issue that prevented building release builds

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -3452,6 +3452,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 65CFC60E1D608AE200CAD875 /* ProcedureKit.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
@@ -3460,6 +3461,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 65CFC60E1D608AE200CAD875 /* ProcedureKit.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
The current dev branch won't build a release build. Results in error "Ad Hoc code signing is not allowed with SDK 'iOS 10.2'" Building from Carthage works, but we're not using Carthage. We have PK set up as a dependent subproject, so our release builds fail.