### PR TITLE
Limit RetryProcedure to Procedure subclasses

### DIFF
--- a/Sources/ProcedureKit/Retry.swift
+++ b/Sources/ProcedureKit/Retry.swift
@@ -7,7 +7,7 @@
 import Foundation
 import Dispatch
 
-public struct RetryFailureInfo<T: Operation> {
+public struct RetryFailureInfo<T: Procedure> {
 
     /// - returns: the failed operation
     public let operation: T
@@ -53,7 +53,7 @@ public extension RetryFailureInfo {
 }
 
 
-internal class RetryIterator<T: Operation>: IteratorProtocol {
+internal class RetryIterator<T: Procedure>: IteratorProtocol {
     typealias Payload = RepeatProcedure<T>.Payload
     typealias Handler = RetryProcedure<T>.Handler
     typealias FailureInfo = RetryProcedure<T>.FailureInfo
@@ -75,10 +75,10 @@ internal class RetryIterator<T: Operation>: IteratorProtocol {
 }
 
 /**
- RetryProcedure is a subclass of RepeatProcedure. Like RepeatProcedure
- it is generic over T, an Operation subclass. It can be used to
- automatically retry another instance of operation T if the first
- instance finishes with errors.
+ RetryProcedure is a RepeatProcedure subclass which can be used
+ to automatically retry another instance of procedure T if the
+ first instance finishes with errors. It is generic over T, a
+ `Procedure` subclass.
 
  To support effective error recovery, in addition to a (T, Delay?)
  iterator, RetryProcedure is initialized with a block. This block
@@ -90,7 +90,7 @@ internal class RetryIterator<T: Operation>: IteratorProtocol {
 
  To exit with the error, this block can return nil.
  */
-open class RetryProcedure<T: Operation>: RepeatProcedure<T> {
+open class RetryProcedure<T: Procedure>: RepeatProcedure<T> {
     public typealias Handler = (FailureInfo, Payload) -> Payload?
     public typealias FailureInfo = RetryFailureInfo<T>
 
@@ -115,7 +115,7 @@ open class RetryProcedure<T: Operation>: RepeatProcedure<T> {
 
     open override func childWillFinishWithoutErrors(_ child: Operation) {
         // no-op
-        // To ensure that we do not retry/repeat successful operations
+        // To ensure that we do not retry/repeat successful procedures
     }
 
     open override func child(_ child: Operation, willAttemptRecoveryFromErrors errors: [Error]) -> Bool {

--- a/Sources/ProcedureKitNetwork/Network.swift
+++ b/Sources/ProcedureKitNetwork/Network.swift
@@ -97,7 +97,7 @@ class NetworkReachabilityWaitProcedure: Procedure {
     }
 }
 
-class NetworkRecovery<T: Operation> where T: NetworkOperation {
+class NetworkRecovery<T: Procedure> where T: NetworkOperation {
 
     let resilience: NetworkResilience
     let connectivity: Reachability.Connectivity

--- a/Tests/ProcedureKitTests/RetryProcedureTests.swift
+++ b/Tests/ProcedureKitTests/RetryProcedureTests.swift
@@ -41,7 +41,7 @@ class RetryProcedureTests: RetryTestCase {
     func test__retry_deinits_after_finished() {
         // Catches reference cycles.
 
-        class RetryDeinitMonitor<T: Operation>: RetryProcedure<T> {
+        class RetryDeinitMonitor<T: Procedure>: RetryProcedure<T> {
             var deinitBlock: (() -> Void)?
             override public init<OperationIterator>(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, wait: WaitStrategy, iterator base: OperationIterator, retry block: @escaping Handler) where OperationIterator: IteratorProtocol, OperationIterator.Element == T {
                 super.init(dispatchQueue: dispatchQueue, max: max, wait: wait, iterator: base, retry: block)


### PR DESCRIPTION
A likely side-effect of the transition from Operations -> ProcedureKit was a `RetryProcedure` class that takes any `Operation` subclass.

But since `Operation` is now `Foundation.Operation` (i.e. `NSOperation`), this poses a problem: `Foundation.Operation` provides no error information, and thus Operation subclasses will never trigger the Retry behavior (they can't report errors through the GroupProcedure machinery - only Procedure subclasses can). i.e. `RetryProcedure` is only useful for `Procedure` subclasses.

This PR makes that explicit by changing:

```diff
- class RetryProcedure<T: Operation>
+ class RetryProcedure<T: Procedure>
```