### PR TITLE
Improve AuthorizedFor mutual exclusivity

### DIFF
--- a/Sources/ProcedureKit/Capability.swift
+++ b/Sources/ProcedureKit/Capability.swift
@@ -215,13 +215,15 @@ public class AuthorizeCapabilityProcedure<Status: AuthorizationStatus>: GetAutho
 
     /**
      Initialize the operation with a base type which conforms to CapabilityProtocol
-     and an optional completion block. This operation is mutually exclusive with itself
+     and an optional completion block. This operation is mutually exclusive with
+     other AuthorizeCapabilityProcedures with the same base type CapabilityProtocol.
 
      - parameter capability: the Capability.
      - parameter completion: an optional Completion closure.
      */
     public override init<Base>(_ base: Base, completion block: Completion? = nil) where Base: CapabilityProtocol, Status == Base.Status {
         super.init(base, completion: block)
+        add(condition: MutuallyExclusive<AuthorizeCapabilityProcedure>(category: "AuthorizeCapabilityProcedure(\(String(describing: type(of: base))))"))
     }
 
     public override func execute() {
@@ -247,7 +249,7 @@ public class AuthorizedFor<Status: AuthorizationStatus>: Condition {
     public init<Base>(_ base: Base, category: String? = nil) where Base: CapabilityProtocol, Status == Base.Status {
         capability = AnyCapability(base)
         super.init()
-        mutuallyExclusiveCategory = category ?? String(describing: type(of: base))
+        mutuallyExclusiveCategory = category
         add(dependency: AuthorizeCapabilityProcedure(base))
     }
 

--- a/Tests/ProcedureKitTests/CapabilityTests.swift
+++ b/Tests/ProcedureKitTests/CapabilityTests.swift
@@ -60,16 +60,35 @@ class AuthorizeTests: TestableCapabilityTestCase {
         wait(for: authorize)
         XCTAssertTrue(capability.didRequestAuthorization)
     }
+
+    func test__authorize_procedure_is_mutually_exclusive() {
+        // AuthorizeCapabilityProcedure should have a condition that is:
+        //  MutuallyExclusive<AuthorizeCapabilityProcedure<TestableCapability.Status>>
+        // with a mutually exclusive category of: 
+        //  "AuthorizeCapabilityProcedure(TestableCapability)"
+
+        var foundMutuallyExclusiveCondition = false
+        for condition in authorize.conditions {
+            guard condition.isMutuallyExclusive else { continue }
+            guard condition is MutuallyExclusive<AuthorizeCapabilityProcedure<TestableCapability.Status>> else { continue }
+            guard condition.category == "AuthorizeCapabilityProcedure(TestableCapability)" else { continue }
+            foundMutuallyExclusiveCondition = true
+            break
+        }
+
+        XCTAssertTrue(foundMutuallyExclusiveCondition, "Failed to find appropriate Mutual Exclusivity condition")
+    }
 }
 
 class AuthorizedForTests: TestableCapabilityTestCase {
 
-    func test__is_mututally_exclusive() {
-        XCTAssertTrue(authorizedFor.isMutuallyExclusive)
+    func test__is_not_mututally_exclusive_by_default() {
+        // the AuthorizedFor condition itself does not confer mutual exclusivity by default
+        XCTAssertFalse(authorizedFor.isMutuallyExclusive)
     }
 
     func test__default_mututally_exclusive_category() {
-        XCTAssertEqual(authorizedFor.category, "TestableCapability")
+        XCTAssertNil(authorizedFor.mutuallyExclusiveCategory)
     }
 
     func test__custom_mututally_exclusive_category() {


### PR DESCRIPTION
Previously, an `AuthorizedFor` condition ensured that the Procedure to which it was added was mutually exclusive with any other Procedures with the same `AuthorizedFor` condition (where the base `CapabilityProtocol` was the same).

However, what is needed is for the `AuthorizeCapabilityProcedure` (produced by the `AuthorizedFor` condition, and which can trigger a prompt for the capability) to be mutually exclusive with other `AuthorizeCapabilityProcedure`s with the same base `CapabilityProtocol`.

This change ensure that two Procedures do not try to prompt for the same authorization/permission concurrently - but that _once they have acquired the authorization/permission_, the Procedures may then execute concurrently (unless some other MutuallyExclusive condition or dependency prevents it).