### PR TITLE
Improve Conditions

### DIFF
--- a/Sources/ProcedureKit/Capability.swift
+++ b/Sources/ProcedureKit/Capability.swift
@@ -249,8 +249,10 @@ public class AuthorizedFor<Status: AuthorizationStatus>: Condition {
     public init<Base>(_ base: Base, category: String? = nil) where Base: CapabilityProtocol, Status == Base.Status {
         capability = AnyCapability(base)
         super.init()
-        mutuallyExclusiveCategory = category
-        add(dependency: AuthorizeCapabilityProcedure(base))
+        if let category = category {
+            addToAttachedProcedure(mutuallyExclusiveCategory: category)
+        }
+        produce(dependency: AuthorizeCapabilityProcedure(base))
     }
 
     public override func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {

--- a/Sources/ProcedureKit/Condition.swift
+++ b/Sources/ProcedureKit/Condition.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 
 /**
@@ -107,7 +109,7 @@ public extension ProcedureKitError {
         public var description: String {
             return "ProcedureKitError.ConditionDependenciesFailed(condition: \(condition))"
         }
-        public static func ==(lhs: ConditionDependenciesFailed, rhs: ConditionDependenciesFailed) -> Bool {
+        public static func == (lhs: ConditionDependenciesFailed, rhs: ConditionDependenciesFailed) -> Bool {
             return lhs.condition === rhs.condition
         }
     }
@@ -120,7 +122,7 @@ public extension ProcedureKitError {
         public var description: String {
             return "ProcedureKitError.ConditionDependenciesCancelled(condition: \(condition))"
         }
-        public static func ==(lhs: ConditionDependenciesCancelled, rhs: ConditionDependenciesCancelled) -> Bool {
+        public static func == (lhs: ConditionDependenciesCancelled, rhs: ConditionDependenciesCancelled) -> Bool {
             return lhs.condition === rhs.condition
         }
     }
@@ -436,11 +438,11 @@ open class Condition: ConditionProtocol, Hashable {
 
     // MARK: Hashable
 
-    public static func ==(lhs: Condition, rhs: Condition) -> Bool {
+    public static func == (lhs: Condition, rhs: Condition) -> Bool {
         return lhs === rhs
     }
 
-    public var hashValue : Int {
+    public var hashValue: Int {
         return ObjectIdentifier(self).hashValue
     }
 
@@ -733,7 +735,7 @@ open class CompoundCondition: Condition {
 }
 
 open class AndCondition: CompoundCondition {
-    public init(_ conditions: [Condition]){
+    public init(_ conditions: [Condition]) {
         super.init(andPredicateWith: conditions)
     }
     public init<S: Sequence>(_ conditions: S) where S.Iterator.Element == Condition {
@@ -745,7 +747,7 @@ open class AndCondition: CompoundCondition {
 }
 
 open class OrCondition: CompoundCondition {
-    public init(_ conditions: [Condition]){
+    public init(_ conditions: [Condition]) {
         super.init(orPredicateWith: conditions)
     }
     public init<S: Sequence>(_ conditions: S) where S.Iterator.Element == Condition {
@@ -868,11 +870,11 @@ public class IgnoredCondition<C: Condition>: ComposedCondition<C> {
 
 // MARK: - Condition Logical Operator Support
 
-public func &&(lhs: Condition, rhs: Condition) -> AndCondition {
+public func && (lhs: Condition, rhs: Condition) -> AndCondition {
     return AndCondition([lhs, rhs])
 }
 
-public func ||(lhs: Condition, rhs: Condition) -> OrCondition {
+public func || (lhs: Condition, rhs: Condition) -> OrCondition {
     return OrCondition([lhs, rhs])
 }
 
@@ -908,7 +910,7 @@ internal class ConditionEvaluationContext {
         }
         return __procedureQueue!
     }
-    private var __procedureQueue: ProcedureQueue? = nil
+    private var __procedureQueue: ProcedureQueue? = nil // swiftlint:disable:this variable_name
 
     func cancel() {
         stateLock.withCriticalScope {
@@ -1118,6 +1120,7 @@ internal extension Condition {
         case dependencyCancelled
     }
 
+    // swiftlint:disable cyclomatic_complexity
     func verifyDependencyRequirements() -> DependencyVerificationResult {
         let dependencyRequirements = self.dependencyRequirements
         guard !dependencyRequirements.isEmpty else { return .success }
@@ -1150,6 +1153,7 @@ internal extension Condition {
 
         return .success
     }
+    // swiftlint:enable cyclomatic_complexity
 }
 
 internal extension Collection where Iterator.Element == Condition {
@@ -1338,10 +1342,12 @@ internal extension Collection where Iterator.Element == ConditionResult {
 // MARK: - Unavailable
 
 public extension Condition {
-    
+
     @available(*, unavailable, renamed: "addToAttachedProcedure(mutuallyExclusiveCategory:)")
     public var mutuallyExclusiveCategory: String? {
         get { fatalError("Unavailable. Use `mutuallyExclusiveCategories` instead to query.") }
         set { fatalError("Unavailable. Use `addToAttachedProcedure(mutuallyExclusiveCategory:)` instead to set.") }
     }
 }
+
+// swiftlint:enable file_length

--- a/Sources/ProcedureKit/Condition.swift
+++ b/Sources/ProcedureKit/Condition.swift
@@ -625,22 +625,9 @@ open class CompoundCondition: Condition {
     /// i.e. The CompoundCondition will only succeed if all the supplied
     /// conditions succeed.
     ///
-    /// - Parameter conditions: an array of Conditions
-    public init(andPredicateWith conditions: [Condition]) {
-        self.conditions = conditions
-        self.kind = .andPredicate
-        super.init()
-    }
-
-    /// Initialize a CompoundCondition that evaluates to the logical "&&"
-    /// of all the supplied conditions.
-    ///
-    /// i.e. The CompoundCondition will only succeed if all the supplied
-    /// conditions succeed.
-    ///
-    /// - Parameter conditions: an Sequence of Conditions
+    /// - Parameter conditions: a Sequence of Conditions
     public init<S: Sequence>(andPredicateWith conditions: S) where S.Iterator.Element == Condition {
-        self.conditions = Array<Condition>(conditions)
+        self.conditions = conditions.filterDuplicates()
         self.kind = .andPredicate
         super.init()
     }
@@ -664,22 +651,9 @@ open class CompoundCondition: Condition {
     /// i.e. As soon as one of the supplied conditions evaluates successfully,
     /// the CompoundCondition will return success.
     ///
-    /// - Parameter conditions: an array of Conditions
-    public init(orPredicateWith conditions: [Condition]) {
-        self.conditions = conditions
-        self.kind = .orPredicate
-        super.init()
-    }
-
-    /// Initialize a CompoundCondition that evaluates to the logical "||"
-    /// of all the supplied conditions.
-    ///
-    /// i.e. As soon as one of the supplied conditions evaluates successfully,
-    /// the CompoundCondition will return success.
-    ///
     /// - Parameter conditions: a Sequence of Conditions
     public init<S: Sequence>(orPredicateWith conditions: S) where S.Iterator.Element == Condition {
-        self.conditions = Array<Condition>(conditions)
+        self.conditions = conditions.filterDuplicates()
         self.kind = .orPredicate
         super.init()
     }
@@ -1336,6 +1310,21 @@ internal extension Collection where Iterator.Element == ConditionResult {
             }
         }
         return false
+    }
+}
+
+internal extension Sequence where Iterator.Element: Hashable {
+
+    // - returns: an Array<Iterator.Element> that preserves the original sequence order, but in which only the first instance of a unique Element is preserved
+    func filterDuplicates() -> [Iterator.Element] {
+        var result: [Iterator.Element] = []
+        var added = Set<Iterator.Element>()
+        for element in self {
+            guard !added.contains(element) else { continue }
+            result.append(element)
+            added.insert(element)
+        }
+        return result
     }
 }
 

--- a/Sources/ProcedureKit/Condition.swift
+++ b/Sources/ProcedureKit/Condition.swift
@@ -6,23 +6,65 @@
 
 import Foundation
 
+/**
+ ConditionResult encompasses 3 states:
+ 1. `.success(true)`
+ 2. `.success(false)`
+ 3. `.failure(let error)`
+
+ Generally:
+ - If a Condition succeeds, return `.success(true)`.
+ - If a Condition *fails*, return `.failure(error)` with a unique error
+ defined for your Condition.
+
+ In some situations, it can be beneficial for a Procedure to not collect an
+ error if an attached condition fails. You can use `IgnoredCondition` to
+ suppress the error associated with any Condition. This is generally
+ preferred to returning `.success(false)` directly.
+ */
 public typealias ConditionResult = ProcedureResult<Bool>
 
-public protocol ConditionProtocol: ProcedureProtocol {
+public protocol ConditionProtocol: Hashable {
 
-    var mutuallyExclusiveCategory: String? { get }
+    /// Dependencies to produce and wait on.
+    ///
+    /// The framework will automatically schedule these dependencies to run
+    /// after all dependencies on the attached Procedure, and will wait for
+    /// these dependencies to finish before the Condition's
+    /// `evaluate(procedure:completion:)` function is called.
+    ///
+    /// It is programmer error to add an Operation to the `producedDependencies`
+    /// this is already scheduled for execution or executing, or that will be
+    /// scheduled for execution elsewhere.
+    var producedDependencies: Set<Operation> { get }
 
+    /// Dependencies to wait on.
+    ///
+    /// The framework will wait for these dependencies to finish
+    /// before the Condition's `evaluate(procedure:completion:)`
+    /// function is called.
+    var dependencies: Set<Operation> { get }
+
+    /// Mutually exclusive categories to apply to the attached Procedure.
+    ///
+    /// Only one Procedure with a particular mutuallyExclusiveCategory may
+    /// execute at a time.
+    var mutuallyExclusiveCategories: Set<String> { get }
+
+    /// Called before a Condition is added to a Procedure.
+    ///
+    /// - Parameter procedure: the Procedure to which the Condition is being added
+    func willAttach(to procedure: Procedure)
+
+    /// Called to evaluate the Condition on a Procedure.
+    /// Must always call `completion` with the result.
     func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void)
 }
 
 public extension ConditionProtocol {
 
     var isMutuallyExclusive: Bool {
-        return mutuallyExclusiveCategory != nil
-    }
-
-    var category: String {
-        return mutuallyExclusiveCategory ?? String(describing: type(of: self))
+        return !mutuallyExclusiveCategories.isEmpty
     }
 }
 
@@ -52,55 +94,406 @@ public extension ProcedureKitError {
     public struct FalseCondition: Error {
         internal init() { }
     }
+
+    public struct ConditionEvaluationCancelled: Error {
+        internal init() { }
+    }
+
+    public struct ConditionDependenciesFailed: Error, Equatable, CustomStringConvertible {
+        public let condition: Condition
+        internal init(condition: Condition) {
+            self.condition = condition
+        }
+        public var description: String {
+            return "ProcedureKitError.ConditionDependenciesFailed(condition: \(condition))"
+        }
+        public static func ==(lhs: ConditionDependenciesFailed, rhs: ConditionDependenciesFailed) -> Bool {
+            return lhs.condition === rhs.condition
+        }
+    }
+
+    public struct ConditionDependenciesCancelled: Error, Equatable, CustomStringConvertible {
+        public let condition: Condition
+        internal init(condition: Condition) {
+            self.condition = condition
+        }
+        public var description: String {
+            return "ProcedureKitError.ConditionDependenciesCancelled(condition: \(condition))"
+        }
+        public static func ==(lhs: ConditionDependenciesCancelled, rhs: ConditionDependenciesCancelled) -> Bool {
+            return lhs.condition === rhs.condition
+        }
+    }
 }
 
-open class Condition: Procedure, ConditionProtocol, OutputProcedure {
+/**
+ Conditions are attached to a Procedure. Before a Procedure executes, it will
+ asynchronously evaluate all of its conditions. If a condition fails, the
+ Procedure cancels with an error instead of executing.
 
-    public var mutuallyExclusiveCategory: String? = nil
+ For example:
+ ```swift
+ procedure.add(condition: BlockCondition {
+     // procedure will cancel instead of executing if this is false
+     return trueOrFalse
+ })
+ ```
 
-    internal weak var procedure: Procedure? = nil {
-        didSet {
-            if let severity = procedure?.log.severity {
-                log.severity = severity
+ Conditions are evaluated after all of the Procedure's dependencies have finished.
+
+ A Condition can also produce its own dependencies, which are executed after the
+ Procedure's dependencies have finished, but _prior_ to evaluating the Condition.
+ Thus, if a crucial detail must be set to satisfy the condition, it can be
+ performed in its own Operation / Procedure.
+
+ ProcedureKit has several built-in Conditions, like `BlockCondition` and
+ `MutuallyExclusive<T>`. It is also easy to implement your own.
+
+ ## Implementing a Custom Condition
+
+ First, subclass `Condition`. Then, override `evaluate(procedure:completion:)`.
+ Here is a simple example - a FalseCondition that always fails:
+
+ ```swift
+ public class FalseCondition: Condition {
+     public override func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {
+        completion(.failure(ProcedureKitError.FalseCondition()))
+     }
+ }
+ ```
+
+ ### Calling the Completion Block
+
+ Your `evaluate(procedure:completion:)` override *must* eventually call the
+ completion block with a `ConditionResult`. (Although it may, of course, be
+ called asynchronously.)
+
+ `ConditionResult` encompasses 3 states:
+ 1. `.success(true)`
+ 2. `.success(false)`
+ 3. `.failure(let error: Error)`
+
+ Generally:
+ - If a Condition *succeeds*, return `.success(true)`.
+ - If a Condition *fails*, return `.failure(error)` with a unique error
+ defined for your Condition.
+
+ In some situations, it can be beneficial for a Procedure to not collect an
+ error if an attached condition fails. You can use `IgnoredCondition` to
+ suppress the error associated with any Condition. This is generally
+ preferred to returning `.success(false)` directly.
+ */
+open class Condition: ConditionProtocol, Hashable {
+
+    /// Requirements to be verified of all Condition dependencies once they are finished
+    /// (and before the Condition's evaluate method is called).
+    ///
+    /// Failures are evaluated before cancellations. Thus, if [.noFailed, .noCancelled] is specified:
+    /// 1. You will receive `ProcedureKitError.ConditionDependenciesFailed` if any Conditions finished
+    /// with errors (i.e. failed).
+    /// 2. If not, you will receive `ProcedureKitError.ConditionDependenciesCancelled` if any
+    /// dependencies are cancelled.
+    ///
+    /// - noFailed: Verifies that no dependencies have finished with errors. If any dependencies have, the Condition fails with a `ProcedureKitError.ConditionDependenciesFailed` error.
+    /// - ignoreFailedIfCancelled: Does not consider a dependency to have failed if it's cancelled. (To be used with .noFailed.)
+    ///
+    /// - noCancelled: Verifies that no dependencies are cancelled. If any dependencies are cancelled, the Condition fails with a `ProcedureKitError.ConditionDependenciesCancelled` error.
+    ///
+    /// - noFailedOrCancelled: [.noFailed, .noCancelled] (Verifies that no dependencies are failed nor cancelled.)
+    /// - none: Do not automatically verify any properties of the dependencies once they are finished.
+    public struct DependencyRequirements: OptionSet {
+        public let rawValue: UInt8
+        public init(rawValue: UInt8) { self.rawValue = rawValue }
+
+        public static let noFailed                  = DependencyRequirements(rawValue: 1 << 0)
+        public static let ignoreFailedIfCancelled   = DependencyRequirements(rawValue: 1 << 1)
+        public static let noCancelled               = DependencyRequirements(rawValue: 1 << 2)
+
+        public static let noFailedOrCancelled: DependencyRequirements = [.noFailed, .noCancelled]
+        public static let none: DependencyRequirements = []
+    }
+
+    fileprivate let stateLock = PThreadMutex()
+    private weak var _procedure: Procedure? = nil
+    fileprivate var _name: String? = nil // swiftlint:disable:this variable_name
+    private var _dependencyRequirements: DependencyRequirements = .none
+    fileprivate var _output: Pending<ConditionResult> = .pending // swiftlint:disable:this variable_name
+    private var _producedDependencies = Set<Operation>()
+    private var _dependencies = Set<Operation>()
+    private var _mutuallyExclusiveCategories = Set<String>()
+
+    /// Dependencies to produce and wait on.
+    ///
+    /// The framework will automatically schedule these dependencies to run
+    /// after all dependencies on the attached Procedure, and will wait for
+    /// these dependencies to finish before the Condition's
+    /// `evaluate(procedure:completion:)` function is called.
+    ///
+    /// It is programmer error to add an Operation to the `producedDependencies`
+    /// this is already scheduled for execution or executing, or that will be
+    /// scheduled for execution elsewhere.
+    public var producedDependencies: Set<Operation> {
+        return stateLock.withCriticalScope { _producedDependencies }
+    }
+
+    /// Dependencies to wait on, added via `add(dependency:)`.
+    ///
+    /// The framework will wait for these dependencies to finish
+    /// before the Condition's `evaluate(procedure:completion:)`
+    /// function is called.
+    public var dependencies: Set<Operation> {
+        return stateLock.withCriticalScope { _dependencies }
+    }
+
+    /// Mutually exclusive categories to apply to the attached Procedure.
+    ///
+    /// Only one Procedure with a particular mutuallyExclusiveCategory may
+    /// execute at a time.
+    public var mutuallyExclusiveCategories: Set<String> {
+        return stateLock.withCriticalScope { _mutuallyExclusiveCategories }
+    }
+
+    /// A descriptive name for the Condition. (optional)
+    public var name: String? {
+        get { return stateLock.withCriticalScope { _name } }
+        set { stateLock.withCriticalScope { _name = newValue } }
+    }
+
+    /// Requirements that must be satisfied after all dependencies are finished, before
+    /// the Condition is evaluated by the framework.
+    ///
+    /// If the requirements fail, the Condition will fail. See `DependencyRequirements`.
+    ///
+    /// The default is ".none", which performs no checks on the dependencies after they
+    /// are finished.
+    ///
+    /// - See: `DependencyRequirements`
+    public var dependencyRequirements: DependencyRequirements {
+        get { return stateLock.withCriticalScope { _dependencyRequirements } }
+        set {
+            stateLock.withCriticalScope {
+                guard _procedure == nil else {
+                    assertionFailure("Dependency requirement must be modified before the Condition is added to a Procedure.")
+                    return
+                }
+                _dependencyRequirements = newValue
             }
         }
     }
 
     /// The ConditionResult.
     /// Will be Pending.ready(ConditionResult) once the Condition has been evaluated.
-    public var output: Pending<ConditionResult> = .pending
-
-    /// Triggers evaluation of the Condition, unless the procedure no longer exists. Cannot be over-ridden
-    final public override func execute() {
-        guard let procedure = procedure else {
-            log.verbose(message: "Condition finishing before evaluation because procedure is nil.")
-            finish()
-            return
-        }
-        evaluate(procedure: procedure, completion: finish)
+    public var output: Pending<ConditionResult> {
+        return stateLock.withCriticalScope { _output }
     }
+
+    public init() { }
+
+    /// Called before a Condition is added to a Procedure.
+    ///
+    /// - Parameter procedure: the Procedure to which the Condition is being added
+    public func willAttach(to procedure: Procedure) {
+        stateLock.withCriticalScope {
+            guard _procedure == nil else {
+                assertionFailure("Cannot add a single Condition instance to multiple Procedures.")
+                return
+            }
+            _procedure = procedure
+        }
+    }
+
+    // MARK: Mutual Exclusivity
+
+    /// Adds a mutually exclusive category to be applied to the attached Procedure.
+    ///
+    /// Only one Procedure with a particular mutuallyExclusiveCategory may execute at a time.
+    ///
+    /// - Parameter mutuallyExclusiveCategory: a String, which should be unique per category
+    final public func addToAttachedProcedure(mutuallyExclusiveCategory: String) {
+        stateLock.withCriticalScope {
+            guard _procedure == nil else {
+                assertionFailure("Categories must be modified before the Condition is added to a Procedure.")
+                return
+            }
+            _mutuallyExclusiveCategories.insert(mutuallyExclusiveCategory)
+        }
+    }
+
+    // MARK: Dependencies
+
+    // Produce a dependency that the Condition runs before evaluation.
+    //
+    // Dependencies produced in this way are scheduled after all dependencies on 
+    // the attached Procedure, but prior to the `evaluate(procedure:completion)`
+    // method being called.
+    //
+    // The Condition "owns" the dependency, and the framework will handle
+    // scheduling and running the dependency at the appropriate time.
+    // Do *not* separately add the dependency to your own queue.
+    //
+    // If you want to add a dependency that has been or will be separately added
+    // to a queue (or otherwise scheduled for execution), use `add(dependency:)` instead.
+    //
+    // It is a programmer error to produce the same Operation instance on more than
+    // one Condition instance.
+    //
+    /// - Parameter dependency: an Operation to be produced as a dependency
+    final public func produce(dependency: Operation) {
+        assert(!dependency.isExecuting, "Do not call produce(dependency:) with an Operation that is already executing.")
+        assert(!dependency.isFinished, "Do not call produce(dependency:) with an Operation that is already finished.")
+        stateLock.withCriticalScope {
+            guard _procedure == nil else {
+                assertionFailure("Dependencies must be modified before the Condition is added to a Procedure.")
+                return
+            }
+            _producedDependencies.insert(dependency)
+        }
+    }
+
+    /// Adds a dependency, just like `Procedure.add(dependency:)`.
+    ///
+    /// The framework will wait for the dependency to finish before the Condition's 
+    /// `evaluate(procedure:completion:)` function is called.
+    ///
+    /// Does not schedule the dependency for execution. You must do this elsewhere by,
+    /// for example, adding it to an `OperationQueue` / `ProcedureQueue`.
+    ///
+    /// - Parameter dependency: an Operation to be added as a dependency
+    final public func add(dependency: Operation) {
+        stateLock.withCriticalScope {
+            guard _procedure == nil else {
+                assertionFailure("Dependencies must be modified before the Condition is added to a Procedure.")
+                return
+            }
+            _dependencies.insert(dependency)
+        }
+    }
+
+    /// Add dependencies, just like `Procedure.add(dependencies:)`.
+    ///
+    /// The framework will wait for the dependencies to finish before the Condition's
+    /// `evaluate(procedure:completion:)` function is called.
+    ///
+    /// Does not schedule the dependencies for execution. You must do this elsewhere by,
+    /// for example, adding it to an `OperationQueue` / `ProcedureQueue`.
+    ///
+    /// - Parameter dependencies: an array of Operations to be added as a dependencies
+    final public func add(dependencies: [Operation]) {
+        stateLock.withCriticalScope {
+            guard _procedure == nil else {
+                assertionFailure("Dependencies must be modified before the Condition is added to a Procedure.")
+                return
+            }
+            _dependencies.formUnion(dependencies)
+        }
+    }
+    final public func add(dependencies: Operation...) {
+        add(dependencies: dependencies)
+    }
+
+    /// Removes a dependency.
+    ///
+    /// - Parameter dependency: an Operation to be removed from the `producedDependencies` and/or `dependencies`.
+    public func remove(dependency: Operation) {
+        stateLock.withCriticalScope {
+            guard _procedure == nil else {
+                assertionFailure("Dependencies must be modified before the Condition is added to a Procedure.")
+                return
+            }
+            _dependencies.remove(dependency)
+            _producedDependencies.remove(dependency)
+        }
+    }
+
+    /// Removes dependencies.
+    ///
+    /// - Parameter dependencies: an array of Operations to be removed from the `producedDependencies` and/or `dependencies`.
+    public func remove(dependencies: [Operation]) {
+        stateLock.withCriticalScope {
+            guard _procedure == nil else {
+                assertionFailure("Dependencies must be modified before the Condition is added to a Procedure.")
+                return
+            }
+            dependencies.forEach {
+                _dependencies.remove($0)
+                _producedDependencies.remove($0)
+            }
+        }
+    }
+    public func remove(dependencies: Operation...) {
+        remove(dependencies: dependencies)
+    }
+
+    // MARK: Evaluate
 
     /// Must be overriden in Condition subclasses.
     /// Must always call `completion` with the result.
     open func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {
         let reason = "Condition must be subclassed, and \(#function) overridden."
         let result: ConditionResult = .failure(ProcedureKitError.programmingError(reason: reason))
-        output = .ready(result)
         completion(result)
     }
 
-    final internal func finish(withConditionResult conditionResult: ConditionResult) {
-        output = .ready(conditionResult)
-        finish(withError: conditionResult.error)
+    // MARK: Hashable
+
+    public static func ==(lhs: Condition, rhs: Condition) -> Bool {
+        return lhs === rhs
+    }
+
+    public var hashValue : Int {
+        return ObjectIdentifier(self).hashValue
+    }
+
+    // MARK: Internal Implementation
+
+    internal func evaluate(procedure: Procedure, withContext context: ConditionEvaluationContext, completion: @escaping (ConditionResult) -> Void) {
+        // Default is to ignore the context, and simply call the overriden open evaluate method
+        evaluate(procedure: procedure, completion: completion)
     }
 }
+
+extension Condition {
+    public var isMutuallyExclusive: Bool {
+        return !mutuallyExclusiveCategories.isEmpty
+    }
+}
+
+internal extension Condition {
+    /// Set a descriptive name for the Condition.
+    ///
+    /// - Parameters:
+    ///   - name: the new name (String)
+    ///   - ifNotAlreadySet: if `true` (the default), the new name will only be set if the existing name is `nil`
+    /// - Returns: the resulting name for the Condition
+    internal func set(name: String, ifNotAlreadySet: Bool = true) -> String {
+        return stateLock.withCriticalScope {
+            if ifNotAlreadySet, let existingName = _name {
+                return existingName
+            }
+            _name = name
+            return name
+        }
+    }
+
+    // Set the output (once the Condition has been evaluated).
+    internal func set(output: ConditionResult) {
+        stateLock.withCriticalScope {
+            assert(_output.isPending, "Trying to set output of Condition evaluation more than once.")
+            _output = .ready(output)
+        }
+    }
+}
+
+// MARK: - Condition Subclasses
 
 public class TrueCondition: Condition {
 
     public init(name: String = "TrueCondition", mutuallyExclusiveCategory: String? = nil) {
         super.init()
         self.name = name
-        self.mutuallyExclusiveCategory = mutuallyExclusiveCategory
+        if let category = mutuallyExclusiveCategory {
+            addToAttachedProcedure(mutuallyExclusiveCategory: category)
+        }
     }
 
     public override func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {
@@ -113,11 +506,253 @@ public class FalseCondition: Condition {
     public init(name: String = "FalseCondition", mutuallyExclusiveCategory: String? = nil) {
         super.init()
         self.name = name
-        self.mutuallyExclusiveCategory = mutuallyExclusiveCategory
+        if let category = mutuallyExclusiveCategory {
+            addToAttachedProcedure(mutuallyExclusiveCategory: category)
+        }
     }
 
     public override func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {
         completion(.failure(ProcedureKitError.FalseCondition()))
+    }
+}
+
+/**
+ A Condition subclass that evaluates a sequence of Conditions according to the desired
+ compound predicate. ("&&", "||")
+
+ For example, if you have two Conditions and you'd like the attached Procedure to
+ proceed if *either* of them evaluates successfully, you can use the "orPredicate"
+ behavior:
+
+ ```swift
+ // assuming "condition1" and "condition2" were previously defined
+ procedure.add(condition: CompoundCondition(orPredicateWith: [condition1, condition2]))
+ ```
+
+ You can also use the `AndCondition` and `OrCondition` subclasses of `CompoundCondition`,
+ if you prefer:
+
+ ```swift
+ // equivalent to the prior example
+ procedure.add(condition: OrCondition(condition1, condition2))
+ ```
+
+ -SeeAlso: `AndCondition`, `OrCondition`
+ */
+open class CompoundCondition: Condition {
+
+    public let conditions: [Condition]
+
+    private var _currentEvaluationContext: ConditionEvaluationContext? = nil
+    private var currentEvaluationContext: ConditionEvaluationContext? {
+        get { return stateLock.withCriticalScope { _currentEvaluationContext } }
+        set {
+            stateLock.withCriticalScope {
+                assert(_currentEvaluationContext == nil, "Evaluating the same Condition twice is not supported.")
+                _currentEvaluationContext = newValue
+            }
+        }
+    }
+
+    private enum Kind {
+        case andPredicate
+        case orPredicate
+
+        var resultAggregationBehavior: ConditionResultAggregationBehavior {
+            switch self {
+            case .andPredicate: return .andPredicate
+            case .orPredicate: return .orPredicate
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .andPredicate: return "&&"
+            case .orPredicate: return "||"
+            }
+        }
+    }
+    private let kind: Kind
+
+    // NOTE: A CompoundCondition, unlike a ComposedCondition, does not inherit its 
+    //       conditions dependencies / producedDependencies.
+    //
+    //       Internally, a CompoundCondition uses the Condition Collection extension
+    //       `evaluate(procedure:withAggregationBehavior:withQueue:completion)`
+    //       method which handles dependencies (while supporting short-cut evaluation).
+    //
+    //       This is the same method that the Procedure.EvaluateConditions operation uses.
+
+    // However, it's important to inherit mutually-exclusive categories from all the conditions,
+    // so they are applied to the Procedure to which this CompoundCondition is attached.
+    override public var mutuallyExclusiveCategories: Set<String> {
+        return super.mutuallyExclusiveCategories.union(conditions.mutuallyExclusiveCategories)
+    }
+
+    /// A descriptive name for the Condition. (optional)
+    ///
+    /// It may be expensive to generate a name for a CompoundCondition.
+    /// This override delays that generation until the name is first requested
+    /// (unless something else, like a subclass, explicitly sets a name).
+    override public var name: String? {
+        get {
+            if let name = super.name {
+                return name
+            }
+            else {
+                // generate and cache the CompoundCondition name
+                // if another name hasn't already been set
+                return set(name: computeName(), ifNotAlreadySet: true)
+            }
+        }
+        set {
+            super.name = newValue
+        }
+    }
+
+    override public func willAttach(to procedure: Procedure) {
+        conditions.forEach { $0.willAttach(to: procedure) }
+        super.willAttach(to: procedure)
+    }
+
+    // MARK: Init - AndPredicate
+
+    /// Initialize a CompoundCondition that evaluates to the logical "&&"
+    /// of all the supplied conditions.
+    ///
+    /// i.e. The CompoundCondition will only succeed if all the supplied
+    /// conditions succeed.
+    ///
+    /// - Parameter conditions: an array of Conditions
+    public init(andPredicateWith conditions: [Condition]) {
+        self.conditions = conditions
+        self.kind = .andPredicate
+        super.init()
+    }
+
+    /// Initialize a CompoundCondition that evaluates to the logical "&&"
+    /// of all the supplied conditions.
+    ///
+    /// i.e. The CompoundCondition will only succeed if all the supplied
+    /// conditions succeed.
+    ///
+    /// - Parameter conditions: an Sequence of Conditions
+    public init<S: Sequence>(andPredicateWith conditions: S) where S.Iterator.Element == Condition {
+        self.conditions = Array<Condition>(conditions)
+        self.kind = .andPredicate
+        super.init()
+    }
+
+    /// Initialize a CompoundCondition that evaluates to the logical "&&"
+    /// of all the supplied conditions.
+    ///
+    /// i.e. The CompoundCondition will only succeed if all the supplied
+    /// conditions succeed.
+    ///
+    /// - Parameter conditions: a sequence of Conditions
+    convenience public init(andPredicateWith conditions: Condition...) {
+        self.init(andPredicateWith: conditions)
+    }
+
+    // MARK: Init - OrPredicate
+
+    /// Initialize a CompoundCondition that evaluates to the logical "||"
+    /// of all the supplied conditions.
+    ///
+    /// i.e. As soon as one of the supplied conditions evaluates successfully,
+    /// the CompoundCondition will return success.
+    ///
+    /// - Parameter conditions: an array of Conditions
+    public init(orPredicateWith conditions: [Condition]) {
+        self.conditions = conditions
+        self.kind = .orPredicate
+        super.init()
+    }
+
+    /// Initialize a CompoundCondition that evaluates to the logical "||"
+    /// of all the supplied conditions.
+    ///
+    /// i.e. As soon as one of the supplied conditions evaluates successfully,
+    /// the CompoundCondition will return success.
+    ///
+    /// - Parameter conditions: a Sequence of Conditions
+    public init<S: Sequence>(orPredicateWith conditions: S) where S.Iterator.Element == Condition {
+        self.conditions = Array<Condition>(conditions)
+        self.kind = .orPredicate
+        super.init()
+    }
+
+    /// Initialize a CompoundCondition that evaluates to the logical "||"
+    /// of all the supplied conditions.
+    ///
+    /// i.e. As soon as one of the supplied conditions evaluates successfully,
+    /// the CompoundCondition will return success.
+    ///
+    /// - Parameter conditions: a sequence of Conditions
+    convenience public init(orPredicateWith conditions: Condition...) {
+        self.init(orPredicateWith: conditions)
+    }
+
+    // MARK: Evaluate Override
+
+    /// Override of public function
+    ///
+    /// If you subclass `CompoundCondition` and override this method, you must call
+    /// `super.evaluate(procedure: completion:)`.
+    public final override func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {
+        // Create an evaluation sub-context (if a current evaluation context is present)
+        let context = currentEvaluationContext?.subContext(withBehavior: kind.resultAggregationBehavior) ?? ConditionEvaluationContext(behavior: kind.resultAggregationBehavior)
+
+        // Utilize the Condition Collection extension `evaluate` method to
+        // evaluate the conditions (while handling dependencies and
+        // short-cut evaluation).
+        conditions.evaluate(procedure: procedure, withContext: context, completion: completion)
+    }
+
+    /// Override of internal function
+    internal override func evaluate(procedure: Procedure, withContext context: ConditionEvaluationContext, completion: @escaping (ConditionResult) -> Void) {
+        currentEvaluationContext = context
+        super.evaluate(procedure: procedure, withContext: context, completion: completion)
+    }
+
+    // MARK: Private Implementation
+
+    private func computeName() -> String {
+        func makeConditionsString(kind: Kind, conditions: [Condition]) {
+            var output: String = ""
+            for condition in conditions {
+                guard !output.isEmpty else {
+                    output.append("\(condition)")
+                    continue
+                }
+                output.append("\(kind.description) \(condition)")
+            }
+        }
+        return "CompoundCondition(\(makeConditionsString(kind: kind, conditions: conditions)))"
+    }
+}
+
+open class AndCondition: CompoundCondition {
+    public init(_ conditions: [Condition]){
+        super.init(andPredicateWith: conditions)
+    }
+    public init<S: Sequence>(_ conditions: S) where S.Iterator.Element == Condition {
+        super.init(andPredicateWith: conditions)
+    }
+    convenience public init(_ conditions: Condition...) {
+        self.init(conditions)
+    }
+}
+
+open class OrCondition: CompoundCondition {
+    public init(_ conditions: [Condition]){
+        super.init(orPredicateWith: conditions)
+    }
+    public init<S: Sequence>(_ conditions: S) where S.Iterator.Element == Condition {
+        super.init(orPredicateWith: conditions)
+    }
+    convenience public init(_ conditions: Condition...) {
+        self.init(conditions)
     }
 }
 
@@ -130,7 +765,7 @@ public class FalseCondition: Condition {
  - see: NegatedCondition
  - see: SilentCondition
  */
-open class ComposedCondition<C: Condition>: Condition, InputProcedure {
+open class ComposedCondition<C: Condition>: Condition {
 
     /**
      The composed condition.
@@ -139,48 +774,77 @@ open class ComposedCondition<C: Condition>: Condition, InputProcedure {
      */
     public let condition: C
 
-    override var directDependencies: Set<Operation> {
-        return super.directDependencies.union(condition.directDependencies)
-    }
-
-    public var input: Pending<ConditionResult> = .pending
-
-    override var procedure: Procedure? {
-        didSet {
-            condition.procedure = procedure
+    private var _currentEvaluationContext: ConditionEvaluationContext? = nil
+    private var currentEvaluationContext: ConditionEvaluationContext? {
+        get { return stateLock.withCriticalScope { _currentEvaluationContext } }
+        set {
+            stateLock.withCriticalScope {
+                assert(_currentEvaluationContext == nil, "Evaluating the same Condition twice is not supported.")
+                _currentEvaluationContext = newValue
+            }
         }
     }
 
+    override public var producedDependencies: Set<Operation> {
+        return super.producedDependencies.union(condition.producedDependencies)
+    }
+
+    override public var dependencies: Set<Operation> {
+        return super.dependencies.union(condition.dependencies)
+    }
+
+    override public var mutuallyExclusiveCategories: Set<String> {
+        return super.mutuallyExclusiveCategories.union(condition.mutuallyExclusiveCategories)
+    }
+
+    override public func willAttach(to procedure: Procedure) {
+        condition.willAttach(to: procedure)
+        super.willAttach(to: procedure)
+    }
+
     /**
-     Initializer which receives a conditon.
+     Initializer which receives a condition.
 
      - parameter [unnamed]: a nested `Condition` type.
      */
     public init(_ condition: C) {
         self.condition = condition
         super.init()
-        mutuallyExclusiveCategory = condition.mutuallyExclusiveCategory
         name = condition.name
-        inject(dependency: condition) { procedure, condition, _ in
-            procedure.input = condition.output
-        }
     }
 
     /// Override of public function
     open override func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {
-        guard let result = input.value else {
-            completion(.failure(ProcedureKitError.requirementNotSatisfied()))
-            return
+        // pass-through the Evaluation Context provided for the current evaluation (if present)
+        let context = currentEvaluationContext ?? ConditionEvaluationContext()
+
+        // evaluate the composed condition
+        condition.evaluate(procedure: procedure, withContext: context) { [weak self] result in
+            self?.condition.set(output: result)
+            // call the completion block with the composed condition's result
+            completion(result)
         }
-        completion(result)
     }
 
-    override func remove(directDependency: Operation) {
-        condition.remove(directDependency: directDependency)
-        super.remove(directDependency: directDependency)
+    override public func remove(dependency: Operation) {
+        condition.remove(dependency: dependency)
+        super.remove(dependency: dependency)
+    }
+
+    internal override func evaluate(procedure: Procedure, withContext context: ConditionEvaluationContext, completion: @escaping (ConditionResult) -> Void) {
+        currentEvaluationContext = context
+        super.evaluate(procedure: procedure, withContext: context, completion: completion)
     }
 }
+/**
+ A condition that treats failures from a composed condition as `.success(false)`.
 
+ Thus, the only two possible ConditionResult outputs from an IgnoredCondition are:
+ - `.success(true)`
+ - `.success(false)`
+
+ And any failure errors will not be propagated to the attached Procedure.
+ */
 public class IgnoredCondition<C: Condition>: ComposedCondition<C> {
 
     /// Public override of initializer.
@@ -199,5 +863,485 @@ public class IgnoredCondition<C: Condition>: ComposedCondition<C> {
                 completion(composedResult)
             }
         }
+    }
+}
+
+// MARK: - Condition Logical Operator Support
+
+public func &&(lhs: Condition, rhs: Condition) -> AndCondition {
+    return AndCondition([lhs, rhs])
+}
+
+public func ||(lhs: Condition, rhs: Condition) -> OrCondition {
+    return OrCondition([lhs, rhs])
+}
+
+public prefix func !<T: Condition>(rhs: T) -> NegatedCondition<T> {
+    return NegatedCondition(rhs)
+}
+
+// MARK: - Internal Helpers
+
+internal class ConditionEvaluationContext {
+    var procedureQueue: ProcedureQueue {
+        return stateLock.withCriticalScope { _procedureQueue }
+    }
+    var isCancelled: Bool {
+        return stateLock.withCriticalScope { _isCancelled }
+    }
+    let queue: DispatchQueue
+    fileprivate let aggregator: ConditionResultAggregator
+
+    init(queue: DispatchQueue = DispatchQueue(label: "run.kit.procedure.ProcedureKit.ConditionEvaluationContext", attributes: [.concurrent]), behavior: ConditionResultAggregationBehavior = .andPredicate) {
+        self.queue = queue
+        self.aggregator = ConditionResultAggregator(behavior: behavior)
+    }
+
+    private var stateLock = PThreadMutex()
+    private var _isCancelled: Bool = false
+    private var _subContexts: [ConditionEvaluationContext] = []
+    private var _procedureQueue: ProcedureQueue {
+        if __procedureQueue == nil {
+            // Lazily create a ProcedureQueue the first time it's needed
+            __procedureQueue = ProcedureQueue()
+            __procedureQueue!.underlyingQueue = queue
+        }
+        return __procedureQueue!
+    }
+    private var __procedureQueue: ProcedureQueue? = nil
+
+    func cancel() {
+        stateLock.withCriticalScope {
+            _isCancelled = true
+            if let procedureQueue = __procedureQueue {
+                procedureQueue.cancelAllOperations()
+            }
+            for subContext in _subContexts {
+                subContext.cancel()
+            }
+            aggregator.cancel(withResult: .failure(ProcedureKitError.ConditionEvaluationCancelled()))
+        }
+    }
+
+    func queue(operation: Operation) {
+        stateLock.withCriticalScope {
+            if _isCancelled { operation.cancel() }
+            _procedureQueue.add(operation: operation)
+        }
+    }
+
+    func queue<S>(operations: S) where S: Sequence, S.Iterator.Element: Operation {
+        stateLock.withCriticalScope {
+            if _isCancelled { operations.forEach { $0.cancel() } }
+            _procedureQueue.add(operations: operations)
+        }
+    }
+
+    func queue<S>(operations: S...) where S: Sequence, S.Iterator.Element: Operation {
+        stateLock.withCriticalScope {
+            for operations in operations {
+                if _isCancelled { operations.forEach { $0.cancel() } }
+                _procedureQueue.add(operations: operations)
+            }
+        }
+    }
+
+    func subContext(withBehavior behavior: ConditionResultAggregationBehavior = .andPredicate) -> ConditionEvaluationContext {
+        return stateLock.withCriticalScope {
+            let newContext = ConditionEvaluationContext(queue: queue, behavior: behavior)
+            if _isCancelled { newContext.cancel() }
+            _subContexts.append(newContext)
+            return newContext
+        }
+    }
+}
+
+/// The method of handling a new result for a particular ConditionResultAggregationBehavior.
+///
+/// - aggregate: Instructs the aggregator to aggregate the result.
+/// - finishWithResult: Instructs the aggregator to finish immediately with the supplied result.
+internal enum ConditionResultAggregationResult {
+    case aggregate
+    case finishWithResult(ConditionResult)
+}
+
+/// ConditionResultAggregationBehavior provides two main behaviors:
+///
+/// - andPredicate: Aggregates results with logical behavior that matches "&&". Results are aggregated until one fails (i.e. does not return `.success(true)`), at which point the failure is treated as the final result.
+/// - orPredicate: Aggregates results with logical behavior that matches "||". Results are aggregated until one succeeds (i.e. returns `.success(true)`), at which point the success is treated as the final result. (If no results are successful, then all the failures are the result.)
+internal enum ConditionResultAggregationBehavior {
+    case andPredicate
+    case orPredicate
+
+    func handle(newResult: ConditionResult) -> ConditionResultAggregationResult {
+        switch self {
+        case .andPredicate:
+            return andProcess(newResult: newResult)
+        case .orPredicate:
+            return orProcess(newResult: newResult)
+        }
+    }
+
+    private func andProcess(newResult: ConditionResult) -> ConditionResultAggregationResult {
+        switch newResult {
+        case .success(_): return .aggregate
+        default: return .finishWithResult(newResult)
+        }
+    }
+
+    private func orProcess(newResult: ConditionResult) -> ConditionResultAggregationResult {
+        switch newResult {
+        case .success(true): return .finishWithResult(newResult)
+        default: return .aggregate
+        }
+    }
+}
+
+fileprivate class ConditionResultAggregator {
+    enum Errors: Error {
+        case alreadyFinishedWithResult(ConditionResult)
+    }
+    private let stateLock = PThreadMutex()
+    private var _oustandingExpectations = 0
+    private var _aggregatedResults = [ConditionResult]()
+    private var _hasFinishedWithResult: ConditionResult? = nil
+    private let resultAggregationBehavior: ConditionResultAggregationBehavior
+    private let group = DispatchGroup()
+
+    var aggregatedResults: [ConditionResult] {
+        return stateLock.withCriticalScope { _aggregatedResults }
+    }
+
+    var result: ConditionResult {
+        return stateLock.withCriticalScope {
+            guard let result = _hasFinishedWithResult else {
+                // no explicit result was set, so get the
+                // _aggregatedResults array and compute its result
+                return _aggregatedResults.conditionResult
+            }
+            return result
+        }
+    }
+
+    /// Initialize a ConditionResultAggregator with a ConditionResultAggregationBehavior.
+    ///
+    /// - Parameter behavior: A `ConditionResultAggregationBehavior`.
+    init(behavior: ConditionResultAggregationBehavior) {
+        resultAggregationBehavior = behavior
+    }
+
+    /// Call once before every expected call to `fulfill(result:)`.
+    ///
+    /// NOTE: If the `ConditionResultAggregationBehavior` specifies that the
+    /// aggregator should `.finishWithResult(ConditionResult)`, it is acceptable
+    /// to short-cut any remaining calls to `fulfill(result:)`.
+    ///
+    /// i.e. If a call to `expectResult()` throws `Errors.alreadyFinishedWithResult`
+    /// you are permitted to handle that result immediately, and do not have to make
+    /// any other remaining `fulfill(result:)` calls (to balance out earlier
+    /// `expectResult()` calls).
+    ///
+    /// - Throws: throws Errors.alreadyFinishedWithResult
+    func expectResult() throws {
+        let error: Error? = stateLock.withCriticalScope {
+            if let result = _hasFinishedWithResult {
+                // has already finished with result
+                // throw an error so the caller can handle this case
+                return Errors.alreadyFinishedWithResult(result)
+            }
+            if _oustandingExpectations == 0 {
+                group.enter()
+            }
+            _oustandingExpectations += 1
+            return nil
+        }
+        if let error = error {
+            throw error
+        }
+    }
+
+    /// For every call to `fulfill(result:)`, you must first call `expectResult()`.
+    ///
+    /// However, a `ConditionResultAggregator` may finish with a result before
+    /// all paired `fulfill(result:)` calls are made (depending on its
+    /// `ConditionResultAggregationBehavior`), in which case you are not required
+    /// to make further (remaining) `fulfill(result:)` calls.
+    ///
+    /// - Parameter result: A ConditionResult that is aggregated, based on the
+    ///                     aggregator's `ConditionResultAggregationBehavior`.
+    func fulfill(result: ConditionResult) {
+        stateLock.withCriticalScope {
+            guard _oustandingExpectations > 0 else {
+                fatalError("Mis-matched expectResult() / fulfill(result:) calls.")
+            }
+            _oustandingExpectations -= 1
+            guard _hasFinishedWithResult == nil else { return }
+            switch resultAggregationBehavior.handle(newResult: result) {
+            case .aggregate:
+                _aggregatedResults.append(result)
+                guard _oustandingExpectations > 0 else {
+                    // no more outstanding expectations, decrease the group to 0
+                    group.leave()
+                    return
+                }
+            case .finishWithResult(let result):
+                // stop aggregating, and immediately trigger the completion with this result
+                _hasFinishedWithResult = result
+                group.leave()
+                return
+            }
+        }
+    }
+
+    func cancel(withResult result: ConditionResult) {
+        stateLock.withCriticalScope {
+            guard _hasFinishedWithResult == nil else { return }
+            // stop aggregating, and immediately trigger the completion with this result
+            _hasFinishedWithResult = result
+            guard _oustandingExpectations > 0 else { return }
+            group.leave()
+        }
+    }
+
+    func notify(queue: DispatchQueue, execute: @escaping (ConditionResult) -> ()) {
+        group.notify(queue: queue) {
+            execute(self.result)
+        }
+    }
+}
+
+internal extension Condition {
+
+    internal enum DependencyVerificationResult {
+        case success
+        case dependencyFailed
+        case dependencyCancelled
+    }
+
+    func verifyDependencyRequirements() -> DependencyVerificationResult {
+        let dependencyRequirements = self.dependencyRequirements
+        guard !dependencyRequirements.isEmpty else { return .success }
+
+        let dependencies = self.dependencies.union(self.producedDependencies)
+
+        if dependencyRequirements.contains(.noFailed) {
+            // Verify that there are no failed dependencies
+            if dependencyRequirements.contains(.ignoreFailedIfCancelled) {
+                // Ignore failed dependencies that are cancelled
+                for dependency in dependencies {
+                    guard let procedure = dependency as? Procedure else { continue }
+                    guard !procedure.failed || procedure.isCancelled else { return .dependencyFailed }
+                }
+            }
+            else {
+                for dependency in dependencies {
+                    guard let procedure = dependency as? Procedure else { continue }
+                    guard !procedure.failed else { return .dependencyFailed }
+                }
+            }
+        }
+
+        if dependencyRequirements.contains(.noCancelled) {
+            // Verify that there are no cancelled dependencies
+            for dependency in dependencies {
+                guard !dependency.isCancelled else { return .dependencyCancelled }
+            }
+        }
+
+        return .success
+    }
+}
+
+internal extension Collection where Iterator.Element == Condition {
+
+    internal var producedDependencies: Set<Operation> {
+        var result = Set<Operation>()
+        for condition in self {
+            result.formUnion(condition.producedDependencies)
+        }
+        return result
+    }
+
+    internal var dependencies: Set<Operation> {
+        var result = Set<Operation>()
+        for condition in self {
+            result.formUnion(condition.dependencies)
+        }
+        return result
+    }
+
+    internal var mutuallyExclusiveCategories: Set<String> {
+        var result = Set<String>()
+        for condition in self {
+            result.formUnion(condition.mutuallyExclusiveCategories)
+        }
+        return result
+    }
+
+    /// Evaluate a collection of Conditions on a Procedure, utilizing a context
+    /// containing a defined aggregation behavior to return an aggregated
+    /// ConditionResult as soon as it is known.
+    ///
+    /// For example, utilizing `.andPredicate` behavior ensures that the
+    /// ConditionResult aggregates successes, while returning immediately
+    /// for the first failure.
+    ///
+    /// The `ConditionResult` passed-in to the `completion` block is either
+    /// the final result determined by the aggregation behavior, or
+    /// (if the aggregation behavior does not instruct a final result)
+    /// the aggregate `ConditionResult` computed from the collection of
+    /// all results (once they are available).
+    ///
+    /// - Parameters:
+    ///   - procedure: a Procedure that is passed-in to every Condition's evaluate method
+    ///   - context: a ConditionEvaluationContext, containing parameters like the aggregation behavior
+    ///   - completion: the completion block that is called with a result as soon as it is known
+    internal func evaluate(procedure: Procedure, withContext context: ConditionEvaluationContext, completion: @escaping (ConditionResult) -> Void) {
+
+        let aggregator = context.aggregator
+        for condition in self {
+            do {
+                try aggregator.expectResult()
+            }
+            catch ConditionResultAggregator.Errors.alreadyFinishedWithResult(let result) {
+                // A result has been obtained (before all Conditions have been evaluated)
+
+                // Cancel the current evaluation context (since we have a result)
+                // (This cancels outstanding produced dependencies and dependent condition operations)
+                context.cancel()
+
+                // Immediately complete with the result
+                completion(result)
+
+                // Stop processing further conditions - return immediately
+                return
+            }
+            catch {
+                fatalError("Unexpected error: \(error)")
+            }
+
+            // Get any dependencies for this condition
+            let directDependencies = condition.dependencies
+            let producedDependencies = condition.producedDependencies
+            guard producedDependencies.isEmpty && directDependencies.isEmpty else {
+                // Must wait for dependencies to complete before evaluating the condition
+
+                // Create a new BlockOperation that wraps the call to `condition.evaluate`
+                let conditionEvaluateOperation = BlockOperation { [weak procedure, weak condition] in
+
+                    // Do not bother evaluating the Condition if the Procedure no longer exists
+                    guard let procedure = procedure else { return }
+                    guard let condition = condition else { return }
+
+                    // Check Dependencies (if required)
+                    switch condition.verifyDependencyRequirements() {
+                    case .success: break
+                    case .dependencyFailed:
+                        // one or more dependencies failed verification because they finished with errors
+                        // immediately fail this Condition
+                        aggregator.fulfill(result: .failure(ProcedureKitError.ConditionDependenciesFailed(condition: condition)))
+                        return
+                    case .dependencyCancelled:
+                        // one or more dependencies failed verification because they were cancelled
+                        // immediatelly fail this Condition
+                        aggregator.fulfill(result: .failure(ProcedureKitError.ConditionDependenciesCancelled(condition: condition)))
+                        return
+                    }
+
+                    // Evaluate the Condition
+                    condition.evaluate(procedure: procedure, withContext: context) { result in
+                        condition.set(output: result)
+                        aggregator.fulfill(result: result)
+                    }
+                }
+
+                // Set the conditionEvaluateOperation to be dependent on all the Condition dependencies
+                conditionEvaluateOperation.add(dependencies: directDependencies.union(producedDependencies))
+
+                // Sanity-Check the producedDependencies
+                //
+                // An Operation instance must be produced by a single Condition instance.
+                // (i.e. Should only be added to a single Condition instance via a single
+                // `produce(dependency:)` call, and must not be scheduled for execution via
+                // any other means.)
+                assert(producedDependencies.filter { $0.isExecuting || $0.isFinished }.isEmpty, "One or more produced dependencies are already executing or finished. Condition-produced dependencies must be produced by a single Condition instance, and not manually added to a queue, or executed, or produced by any other Condition instances. Problem Operations: \(producedDependencies.filter { $0.isExecuting || $0.isFinished })")
+
+                // Add the producedDependencies and the conditionEvaluateOperation to the procedureQueue
+                context.queue(operations: producedDependencies, [conditionEvaluateOperation])
+
+                // Skip to the next condition
+                continue
+            }
+
+            // Since this Condition has no dependencies, call the `evaluate` function directly
+            condition.evaluate(procedure: procedure, withContext: context) { result in
+                condition.set(output: result)
+                aggregator.fulfill(result: result)
+            }
+        }
+
+        aggregator.notify(queue: context.queue) { result in
+            // Cancel the current evaluation context (since we have a result)
+            // (This cancels outstanding produced dependencies and dependent condition operations)
+            context.cancel()
+
+            // Call the completion block
+            completion(result)
+        }
+    }
+}
+
+internal extension Collection where Iterator.Element == ConditionResult {
+
+    // Get a single conditionResult for a collection of results
+    internal var conditionResult: ConditionResult {
+        return self.reduce(.success(false)) { lhs, result in
+            // Unwrap the condition's output
+            let rhs = result
+
+            switch (lhs, rhs) {
+            // both results are failures
+            case let (.failure(error), .failure(anotherError)):
+                if let error = error as? ProcedureKitError.FailedConditions {
+                    return .failure(error.append(error: anotherError))
+                }
+                else if let anotherError = anotherError as? ProcedureKitError.FailedConditions {
+                    return .failure(anotherError.append(error: error))
+                }
+                else {
+                    return .failure(ProcedureKitError.FailedConditions(errors: [error, anotherError]))
+                }
+            // new condition failed - so return it
+            case (_, .failure(_)):
+                return rhs
+            // first condition is ignored - so return the new one
+            case (.success(false), _):
+                return rhs
+            default:
+                return lhs
+            }
+        }
+    }
+
+    // Determine if any result in a collection of results is `.success(true)`
+    internal var hasSuccessfulConditionResult: Bool {
+        for result in self {
+            switch result {
+            case .success(true): return true
+            default: continue
+            }
+        }
+        return false
+    }
+}
+
+// MARK: - Unavailable
+
+public extension Condition {
+    
+    @available(*, unavailable, renamed: "addToAttachedProcedure(mutuallyExclusiveCategory:)")
+    public var mutuallyExclusiveCategory: String? {
+        get { fatalError("Unavailable. Use `mutuallyExclusiveCategories` instead to query.") }
+        set { fatalError("Unavailable. Use `addToAttachedProcedure(mutuallyExclusiveCategory:)` instead to set.") }
     }
 }

--- a/Sources/ProcedureKit/Group.swift
+++ b/Sources/ProcedureKit/Group.swift
@@ -257,9 +257,6 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
     public func procedureQueue(_ queue: ProcedureQueue, willAddProcedure procedure: Procedure, context: Any?) -> ProcedureFuture? {
         guard queue === self.queue else { return nil }
 
-        /// If the operation is a Procedure.EvaluateConditions - exit early.
-        if procedure is Procedure.EvaluateConditions { return nil }
-
         return willAdd(operation: procedure, context: context)
     }
 
@@ -346,9 +343,6 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
 
         /// If the group is cancelled, exit early
         guard !isCancelled else { return nil }
-
-        /// If the operation is a Procedure.EvaluateConditions - exit early.
-        if procedure is Procedure.EvaluateConditions { return nil }
 
         let promise = ProcedurePromise()
         dispatchEvent {

--- a/Sources/ProcedureKit/MutualExclusion.swift
+++ b/Sources/ProcedureKit/MutualExclusion.swift
@@ -17,7 +17,7 @@ public final class MutuallyExclusive<T>: Condition {
     public init(category: String = "MutuallyExclusive<\(T.self)>") {
         super.init()
         name = "MutuallyExclusive<\(T.self)>"
-        mutuallyExclusiveCategory = category
+        addToAttachedProcedure(mutuallyExclusiveCategory: category)
     }
 
     /// Required public override, but there is no evaluation, so it just completes with `.Satisfied`.
@@ -31,56 +31,117 @@ final public class ExclusivityManager {
     static let sharedInstance = ExclusivityManager()
 
     fileprivate let queue = DispatchQueue(label: "run.kit.procedure.ProcedureKit.Exclusivity", qos: DispatchQoS.userInitiated) // serial dispatch queue
-    fileprivate var procedures: [String: [Procedure]] = [:]
+
+    fileprivate let completeLocksQueue = DispatchQueue(label: "run.kit.procedure.ProcedureKit.ExclusivityCompleteLocks", qos: DispatchQoS.userInitiated, attributes: [.concurrent])
+    fileprivate var categoryQueues: [String: [DispatchGroup]] = [:]
 
     private init() {
         // A private initalizer prevents any other part of the app
         // from creating an instance.
     }
 
-    func add(procedure: Procedure, category: String) -> Operation? {
-        return queue.sync { _add(procedure: procedure, category: category) }
-    }
-
-    func remove(procedure: Procedure, category: String) {
-        queue.async { self._remove(procedure: procedure, category: category) }
-    }
-
-    fileprivate func _add(procedure: Procedure, category: String) -> Operation? {
-        procedure.log.verbose(message: ">>> \(category)")
-
-        procedure.addDidFinishBlockObserver { [unowned self] (procedure, errors) in
-            self.remove(procedure: procedure, category: category)
+    internal func requestLock(for categories: Set<String>, completion: @escaping () -> Void) {
+        guard !categories.isEmpty else {
+            // No categories requested
+            assertionFailure("A request for Mutual Exclusivity locks was made with no categories specified. This request is unnecessary.")
+            completion()
+            return
         }
 
-        var proceduresWithThisCategory = procedures[category] ?? []
-
-        let previous = proceduresWithThisCategory.last
-
-        if let previous = previous {
-            procedure.add(dependencyOnPreviousMutuallyExclusiveProcedure: previous)
-        }
-
-        proceduresWithThisCategory.append(procedure)
-
-        procedures[category] = proceduresWithThisCategory
-
-        return previous
+        queue.async { self._requestLock(for: categories, completion: completion) }
     }
 
-    fileprivate func _remove(procedure: Procedure, category: String) {
-        procedure.log.verbose(message: "<<< \(category)")
+    private func _requestLock(for categories: Set<String>, completion: @escaping () -> Void) {
 
-        if let proceduresWithThisCategory = procedures[category], let index = proceduresWithThisCategory.index(of: procedure) {
-            var mutableProceduresWithThisCategory = proceduresWithThisCategory
-            mutableProceduresWithThisCategory.remove(at: index)
-            procedures[category] = mutableProceduresWithThisCategory
+        guard !categories.isEmpty else {
+            completion()
+            return
+        }
+
+        // Create a new dispatch group for this lock request
+        let categoriesGroup = DispatchGroup()
+
+        var unavailableCategories = 0
+        // Add the procedure to each category's queue
+        for category in categories {
+            switch _requestLock(forCategory: category, withGroup: categoriesGroup) {
+            case .immediatelyAvailable:
+                // Do nothing - continue directly to the next category
+                break
+            case .waitingForLock:
+                unavailableCategories += 1
+            }
+        }
+
+        // If the lock was immediately acquired for all categories:
+        if unavailableCategories == 0 {
+            // call completion now
+            //            completeLocksQueue.async {
+            completion()
+            //            }
+        }
+        else {
+            // Otherwise, wait on the DispatchGroup created for this lock request
+
+            // Enter it once for every category on which we must wait
+            (0..<unavailableCategories).forEach { _ in categoriesGroup.enter() }
+
+            // Schedule a notification when the lock for all those categories has been acquired
+            categoriesGroup.notify(queue: completeLocksQueue) {
+                completion()
+            }
+        }
+    }
+
+    private enum RequestLockResult {
+        case immediatelyAvailable
+        case waitingForLock
+    }
+    private func _requestLock(forCategory category: String, withGroup group: DispatchGroup) -> RequestLockResult {
+        var queueForThisCategory = categoryQueues[category] ?? []
+        let isFrontOfTheQueueForThisCategory = queueForThisCategory.isEmpty
+        queueForThisCategory.append(group)
+        categoryQueues[category] = queueForThisCategory
+
+        return (isFrontOfTheQueueForThisCategory) ? .immediatelyAvailable : .waitingForLock
+    }
+
+    internal func unlock(categories: Set<String>) {
+        queue.async { self._unlock(categories: categories) }
+    }
+
+    private func _unlock(categories: Set<String>) {
+        for category in categories {
+            _unlock(category: category)
+        }
+    }
+
+    internal func _unlock(category: String) {
+        guard var queueForThisCategory = categoryQueues[category] else { return }
+        // Remove the first item in the queue for this category
+        // (which should be the procedure that currently has the lock).
+        assert(!queueForThisCategory.isEmpty)
+        let _ = queueForThisCategory.removeFirst()
+
+        // If another operation is waiting on this particular lock
+        if let nextOperationForLock = queueForThisCategory.first {
+            // Leave its DispatchGroup (i.e. it "acquires" the lock for this category)
+            nextOperationForLock.leave()
+        }
+
+        if !queueForThisCategory.isEmpty {
+            categoryQueues[category] = queueForThisCategory
+        }
+        else {
+            categoryQueues.removeValue(forKey: category)
         }
     }
 }
 
 public extension ExclusivityManager {
 
+    /// This should only be used as part of the unit testing
+    /// Warning: This immediately frees up any oustanding mutual exclusion.
     static func __tearDownForUnitTesting() {
         sharedInstance.__tearDownForUnitTesting()
     }
@@ -88,12 +149,14 @@ public extension ExclusivityManager {
     /// This should only be used as part of the unit testing
     fileprivate func __tearDownForUnitTesting() {
         queue.sync {
-            for (category, procedures) in procedures {
-                for procedure in procedures {
-                    procedure.cancel()
-                    _remove(procedure: procedure, category: category)
+            for (_, dispatchGroups) in categoryQueues {
+                // Skip the first item in the category, because
+                // it's the one that currently holds the lock.
+                for group in dispatchGroups.suffix(from: 1) {
+                    group.leave()
                 }
             }
+            categoryQueues.removeAll()
         }
     }
 }

--- a/Sources/ProcedureKit/SilentCondition.swift
+++ b/Sources/ProcedureKit/SilentCondition.swift
@@ -13,7 +13,7 @@ public final class SilentCondition<C: Condition>: ComposedCondition<C> {
 
     /// Public override of initializer.
     public override init(_ condition: C) {
-        condition.removeAllDependencies()
+        condition.producedDependencies.forEach { condition.remove(dependency: $0) }
         super.init(condition)
         name = condition.name.map { "Silent<\($0)>" }
     }

--- a/Sources/TestingProcedureKit/TestCondition.swift
+++ b/Sources/TestingProcedureKit/TestCondition.swift
@@ -11,11 +11,11 @@ open class TestCondition: Condition {
 
     let evaluate: () throws -> ConditionResult
 
-    public init(name: String = "TestCondition", dependencies: [Operation] = [], evaluate: @escaping () throws -> ConditionResult) {
+    public init(name: String = "TestCondition", producedDependencies: [Operation] = [], evaluate: @escaping () throws -> ConditionResult) {
         self.evaluate = evaluate
         super.init()
         self.name = name
-        self.add(dependencies: dependencies)
+        producedDependencies.forEach { produce(dependency: $0) }
     }
 
     open override func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {
@@ -27,5 +27,22 @@ open class TestCondition: Condition {
             result = .failure(error)
         }
         completion(result)
+    }
+}
+
+open class AsyncTestCondition: Condition {
+
+    public typealias EvaluateBlock = (@escaping (ConditionResult) -> Void) -> Void
+    let evaluate: EvaluateBlock
+
+    public init(name: String = "TestCondition", producedDependencies: [Operation] = [], evaluate: @escaping EvaluateBlock) {
+        self.evaluate = evaluate
+        super.init()
+        self.name = name
+        producedDependencies.forEach { produce(dependency: $0) }
+    }
+
+    open override func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {
+        evaluate(completion)
     }
 }

--- a/Sources/TestingProcedureKit/XCTAsserts.swift
+++ b/Sources/TestingProcedureKit/XCTAsserts.swift
@@ -196,6 +196,18 @@ public extension ProcedureKitTestCase {
         }
     }
 
+    public func XCTAssertProcedure<T: ProcedureProtocol, E: Error>(_ exp: @autoclosure () throws -> T, firstErrorEquals firstError: E, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where E: Equatable {
+        __XCTEvaluateAssertion(testCase: self, message, file: file, line: line) {
+            let procedure = try exp()
+            guard procedure.failed else {
+                return .expectedFailure("\(procedure.procedureName) did not have any errors.")
+            }
+            guard procedure.errors[0] as? E == firstError else {
+                return .expectedFailure("\(procedure.procedureName) first error is not expected error. Errors are: \(procedure.errors)")
+            }
+            return .success
+        }
+    }
 }
 
 // MARK: Constrained to TestProcedure

--- a/Tests/ProcedureKitStressTests/ProcedureStressTests.swift
+++ b/Tests/ProcedureKitStressTests/ProcedureStressTests.swift
@@ -98,7 +98,7 @@ class ProcedureConditionStressTest: StressTestCase {
     func test__adding_many_conditions_each_with_single_dependency() {
 
         StressLevel.custom(1, 10_000).forEach { _, _ in
-            procedure.add(condition: TestCondition(dependencies: [TestProcedure()]) { .success(true) })
+            procedure.add(condition: TestCondition(producedDependencies: [TestProcedure()]) { .success(true) })
         }
         wait(for: procedure, withTimeout: 10)
         XCTAssertProcedureFinishedWithoutErrors()

--- a/Tests/ProcedureKitTests/ConditionTests.swift
+++ b/Tests/ProcedureKitTests/ConditionTests.swift
@@ -739,6 +739,24 @@ class ConditionTests: ProcedureKitTestCase {
         XCTAssertEqual(compoundCondition2.mutuallyExclusiveCategories, ["test0", "test1", "test2"])
     }
 
+    func test__compound_condition_and_predicate_filters_duplicates() {
+        let evaluationCount = Protector<Int>(0)
+        let condition1 = TestCondition() { evaluationCount.advance(by: 1); return .success(true) }
+        let compoundCondition = CompoundCondition(andPredicateWith: condition1, condition1, condition1)
+        procedure.add(condition: compoundCondition)
+        wait(for: procedure)
+        XCTAssertEqual(evaluationCount.access, 1)
+    }
+
+    func test__compound_condition_or_predicate_filters_duplicates() {
+        let evaluationCount = Protector<Int>(0)
+        let condition1 = TestCondition() { evaluationCount.advance(by: 1); return .success(false) }
+        let compoundCondition = CompoundCondition(orPredicateWith: condition1, condition1, condition1)
+        procedure.add(condition: compoundCondition)
+        wait(for: procedure)
+        XCTAssertEqual(evaluationCount.access, 1)
+    }
+
     // MARK: - Compound Conditions - &&
 
     func test__and_condition__with_no_conditions_cancels_without_errors() {

--- a/Tests/ProcedureKitTests/ConditionTests.swift
+++ b/Tests/ProcedureKitTests/ConditionTests.swift
@@ -5,10 +5,79 @@
 //
 
 import XCTest
-import TestingProcedureKit
+@testable import TestingProcedureKit
 @testable import ProcedureKit
 
 class ConditionTests: ProcedureKitTestCase {
+
+    // MARK: - Condition Properties
+
+    func test__condition__produce_dependency() {
+        let condition = TrueCondition()
+        let dependency = TestProcedure()
+        condition.produce(dependency: dependency)
+        XCTAssertEqual(condition.producedDependencies.count, 1)
+        XCTAssertEqual(condition.producedDependencies.first, dependency)
+        XCTAssertEqual(condition.dependencies.count, 0)
+    }
+
+    func test__condition__add_dependency() {
+        let condition = TrueCondition()
+        let dependency = TestProcedure()
+        condition.add(dependency: dependency)
+        XCTAssertEqual(condition.dependencies.count, 1)
+        XCTAssertEqual(condition.dependencies.first, dependency)
+        XCTAssertEqual(condition.producedDependencies.count, 0)
+    }
+
+    func test__condition__remove_dependency() {
+        let condition = TrueCondition()
+        let dependency = TestProcedure()
+        let producedDependency = TestProcedure()
+        condition.add(dependency: dependency)
+        condition.produce(dependency: producedDependency)
+        XCTAssertEqual(condition.dependencies.count, 1)
+        XCTAssertEqual(condition.dependencies.first, dependency)
+        XCTAssertEqual(condition.producedDependencies.count, 1)
+        XCTAssertEqual(condition.producedDependencies.first, producedDependency)
+
+        condition.remove(dependency: producedDependency)
+        XCTAssertEqual(condition.producedDependencies.count, 0, "Produced dependency not removed.")
+
+        condition.remove(dependency: dependency)
+        XCTAssertEqual(condition.producedDependencies.count, 0, "Dependency not removed.")
+    }
+
+    func test__condition__name() {
+        let condition = TrueCondition()
+        let testName = "Test Name"
+        condition.name = testName
+        XCTAssertEqual(condition.name, testName)
+    }
+
+    func test__condition__mutually_exclusive_categories() {
+        let condition = TrueCondition()
+        XCTAssertTrue(condition.mutuallyExclusiveCategories.isEmpty)
+        let category1 = "Test Category"
+        let category2 = "Test Category B"
+
+        condition.addToAttachedProcedure(mutuallyExclusiveCategory: category1)
+        XCTAssertEqual(condition.mutuallyExclusiveCategories, Set([category1]))
+
+        condition.addToAttachedProcedure(mutuallyExclusiveCategory: category2)
+        XCTAssertEqual(condition.mutuallyExclusiveCategories, Set([category1, category2]))
+    }
+
+    func test__condition__equality() {
+        let condition1 = TrueCondition()
+        let condition1alias = condition1
+        let condition2 = TrueCondition()
+
+        XCTAssertEqual(condition1, condition1)
+        XCTAssertEqual(condition1, condition1alias)
+        XCTAssertNotEqual(condition1, condition2)
+        XCTAssertNotEqual(condition1alias, condition2)
+    }
 
     // MARK: - Condition Unit Tests
 
@@ -29,12 +98,6 @@ class ConditionTests: ProcedureKitTestCase {
             }
             XCTAssertTrue(error is ProcedureKitError.FalseCondition)
         }
-    }
-
-    func test__condition_which_is_executed_without_a_procedure() {
-        let condition = TrueCondition()
-        wait(for: condition)
-        XCTAssertProcedureFinishedWithoutErrors(condition)
     }
 
     // MARK: - Single Attachment
@@ -66,7 +129,7 @@ class ConditionTests: ProcedureKitTestCase {
         procedure.add(condition: FalseCondition())
         procedure.add(condition: FalseCondition())
         wait(for: procedure)
-        XCTAssertProcedureCancelledWithErrors(count: 3)
+        XCTAssertProcedureCancelledWithErrors(count: 1)
     }
 
     func test__multiple_conditions_where_one_succeeds() {
@@ -74,7 +137,7 @@ class ConditionTests: ProcedureKitTestCase {
         procedure.add(condition: FalseCondition())
         procedure.add(condition: FalseCondition())
         wait(for: procedure)
-        XCTAssertProcedureCancelledWithErrors(count: 2)
+        XCTAssertProcedureCancelledWithErrors(count: 1)
     }
 
     func test__multiple_conditions_where_one_fails() {
@@ -85,22 +148,209 @@ class ConditionTests: ProcedureKitTestCase {
         XCTAssertProcedureCancelledWithErrors(count: 1)
     }
 
-    // MARK: - Nested Conditions
+    // MARK: - Shortcut Processing
 
-    func test__single_condition_with_single_condition_which_both_succeed__executes() {
-        let condition = TrueCondition()
-        condition.add(condition: TrueCondition())
-        procedure.add(condition: condition)
-        wait(for: procedure)
-        XCTAssertProcedureFinishedWithoutErrors()
+    func test__long_running_condition_with_dependency_is_cancelled_if_a_result_is_determined_by_another_condition() {
+        // Two conditions:
+        //  - One that is dependent on a long-running produced operation
+        //  - And a second that immediately returns false
+        //
+        // The Procedure should fail with the immediate failure of the second
+        // Condition, and not wait for the first Condition (and its
+        // long-running produced dependency) to also complete.
+        //
+        // Additionally, the long-running dependency should be cancelled
+        // once the overall condition evaluation result is known.
+
+        let longRunningCondition = TestCondition() {
+            return .success(true)
+        }
+        let didStartLongRunningDependencyGroup = DispatchGroup()
+        didStartLongRunningDependencyGroup.enter()
+        let longRunningDependency = AsyncBlockProcedure { completion in
+            didStartLongRunningDependencyGroup.leave()
+            // never finishes by itself
+        }
+        longRunningDependency.addDidCancelBlockObserver { _, _ in
+            // finishes when cancelled
+            longRunningDependency.finish()
+        }
+        let dispatchGroup = DispatchGroup()
+        dispatchGroup.enter()
+        longRunningDependency.addDidFinishBlockObserver { _, _ in
+            dispatchGroup.leave()
+        }
+        longRunningCondition.produce(dependency: longRunningDependency)
+
+        let failSecondCondition = AsyncTestCondition { completion in
+            // To ensure order of operations, finish this condition async once the
+            // longRunningCondition's long-running dependency has started.
+            //
+            // Otherwise, there is no guarantee that the `longRunningCondition` will
+            // be processed (and produce its dependencies) prior to being shortcut
+            // by the result of this condition.
+            didStartLongRunningDependencyGroup.notify(queue: DispatchQueue.global()) {
+                completion(.failure(ProcedureKitError.FalseCondition()))
+            }
+        }
+
+        procedure.add(condition: longRunningCondition)
+        procedure.add(condition: failSecondCondition)
+
+        wait(for: procedure, withTimeout: 2)
+
+        // ensure that the longRunningDependency is fairly quickly cancelled and finished
+        guard longRunningDependency.isEnqueued else {
+            XCTFail("The long-running dependency was not enqueued. This is unexpected, since the evaluation order should be guaranteed by the test.")
+            return
+        }
+        // wait for the long-running dependency to be cancelled and finish
+        weak var expLongRunningProducedDependencyCancelled = expectation(description: "did cancel and finish long-running produced dependency")
+        dispatchGroup.notify(queue: DispatchQueue.main) {
+            expLongRunningProducedDependencyCancelled?.fulfill()
+        }
+        waitForExpectations(timeout: 2)
+        XCTAssertProcedureCancelledWithoutErrors(longRunningDependency)
     }
 
-    func test__single_condition_which_succeeds_with_single_condition_which_fails__cancelled() {
-        let condition = TrueCondition(name: "Condition 1")
-        condition.add(condition: FalseCondition(name: "Nested Condition 1"))
+    // MARK: - Condition Dependency Requirement
+
+    func test__condition_dependency_requirement_none_still_evaluates_when_dependency_fails() {
+        XCTAssertEqual(Condition.DependencyRequirements.none, [])
+
+        let failingDependency = TestProcedure(error: TestError())
+        conditionDependencyRequirementTest(
+            requirements: .none,
+            conditionProducedDependency: failingDependency) { result in
+                XCTAssertTrue(result.didEvaluateCondition, "Condition was not evaluated.")
+                XCTAssertProcedureFinishedWithoutErrors(result.procedure)
+        }
+    }
+
+    func test__condition_dependency_requirement_noFailed_skips_evaluate_when_dependency_fails() {
+        let failingDependency = TestProcedure(error: TestError())
+        conditionDependencyRequirementTest(
+            requirements: .noFailed,
+            conditionProducedDependency: failingDependency) { result in
+                XCTAssertFalse(result.didEvaluateCondition, "Condition evaluate was called, despite dependency requirement and failed dependency.")
+                XCTAssertProcedureCancelledWithErrors(result.procedure, count: 1)
+                XCTAssertProcedure(result.procedure, firstErrorEquals: ProcedureKitError.ConditionDependenciesFailed(condition: result.condition))
+        }
+    }
+
+    func test__condition_dependency_requirement_noFailed_ignores_dependency_cancelled_without_errors() {
+        let cancelledDependency = TestProcedure()
+        cancelledDependency.cancel()
+        conditionDependencyRequirementTest(
+            requirements: .noFailed,
+            conditionProducedDependency: cancelledDependency) { result in
+                XCTAssertTrue(result.didEvaluateCondition)
+                XCTAssertProcedureFinishedWithoutErrors(result.procedure)
+        }
+    }
+
+    func test__condition_dependency_requirement_noFailed_skips_evaluate_when_dependency_iscancelled_with_errors() {
+        let cancelledDependency = TestProcedure()
+        cancelledDependency.cancel(withError: TestError())
+        conditionDependencyRequirementTest(
+            requirements: .noFailed,
+            conditionProducedDependency: cancelledDependency) { result in
+                XCTAssertFalse(result.didEvaluateCondition)
+                XCTAssertProcedureCancelledWithErrors(result.procedure, count: 1)
+                XCTAssertProcedure(result.procedure, firstErrorEquals: ProcedureKitError.ConditionDependenciesFailed(condition: result.condition))
+        }
+    }
+
+    func test__condition_dependency_requirement_noCancelled_skips_evaluate_when_dependency_is_cancelled() {
+        let cancelledDependency = TestProcedure(error: TestError())
+        cancelledDependency.cancel()
+        conditionDependencyRequirementTest(
+            requirements: .noCancelled,
+            conditionProducedDependency: cancelledDependency) { result in
+                XCTAssertFalse(result.didEvaluateCondition, "Condition evaluate was called, despite dependency requirement and cancelled dependency.")
+                XCTAssertProcedureCancelledWithErrors(result.procedure, count: 1)
+                XCTAssertProcedure(result.procedure, firstErrorEquals: ProcedureKitError.ConditionDependenciesCancelled(condition: result.condition))
+        }
+    }
+
+    func test__condition_dependency_requirement_noCancelled_ignores_non_cancelled_failures() {
+        let failedDependency = TestProcedure(error: TestError()) // failed, not cancelled
+        conditionDependencyRequirementTest(
+            requirements: .noCancelled,
+            conditionProducedDependency: failedDependency) { result in
+                XCTAssertTrue(result.didEvaluateCondition)
+                XCTAssertProcedureFinishedWithoutErrors(result.procedure)
+        }
+    }
+
+    func test__condition_dependency_requirement_noFailed_with_ignoreCancellations() {
+        // cancelled failing dependency should be ignored - and evaluate should be called
+        let cancelledDependency = TestProcedure()
+        cancelledDependency.cancel(withError: TestError())
+        conditionDependencyRequirementTest(
+            requirements: [.noFailed, .ignoreFailedIfCancelled],
+            conditionProducedDependency: cancelledDependency) { result in
+                XCTAssertTrue(result.didEvaluateCondition)
+                XCTAssertProcedureFinishedWithoutErrors(result.procedure)
+        }
+
+        // whereas a non-cancelled failing dependency should still cause an immediate failure
+        let failingDependency = TestProcedure(error: TestError())
+        conditionDependencyRequirementTest(
+            requirements: [.noFailed, .ignoreFailedIfCancelled],
+            conditionProducedDependency: failingDependency) { result in
+                XCTAssertFalse(result.didEvaluateCondition)
+                XCTAssertProcedureCancelledWithErrors(result.procedure, count: 1)
+                XCTAssertProcedure(result.procedure, firstErrorEquals: ProcedureKitError.ConditionDependenciesFailed(condition: result.condition))
+        }
+    }
+
+    private struct ConditionDependencyRequirementTestResult {
+        let procedure: Procedure
+        let didEvaluateCondition: Bool
+        let condition: Condition
+    }
+
+    private func conditionDependencyRequirementTest(
+        requirements: Condition.DependencyRequirements,
+        conditionProducedDependency dependency: Procedure,
+        withAdditionalConditions additionalConditions: [Condition] = [],
+        completion: (ConditionDependencyRequirementTestResult) -> Void) {
+        conditionDependencyRequirementTest(requirements: requirements,
+                                           conditionProducedDependencies: [dependency],
+                                           withAdditionalConditions: additionalConditions,
+                                           completion: completion)
+    }
+
+    private func conditionDependencyRequirementTest(
+        requirements: Condition.DependencyRequirements,
+        conditionProducedDependencies dependencies: [Procedure],
+        withAdditionalConditions additionalConditions: [Condition] = [],
+        completion: (ConditionDependencyRequirementTestResult) -> Void)
+    {
+        let procedure = TestProcedure()
+
+        let didEvaluateConditionGroup = DispatchGroup()
+        didEvaluateConditionGroup.enter()
+        let condition = TestCondition {
+            didEvaluateConditionGroup.leave()
+            return .success(true)
+        }
+        dependencies.forEach { condition.produce(dependency: $0) }
+        condition.dependencyRequirements = requirements
+
         procedure.add(condition: condition)
+        additionalConditions.forEach { procedure.add(condition: $0) }
         wait(for: procedure)
-        XCTAssertProcedureCancelledWithErrors(count: 1)
+
+        let didEvaluateCondition = didEvaluateConditionGroup.wait(timeout: .now()) == .success
+
+        // clean-up
+        if !didEvaluateCondition {
+            didEvaluateConditionGroup.leave()
+        }
+
+        completion(ConditionDependencyRequirementTestResult(procedure: procedure, didEvaluateCondition: didEvaluateCondition, condition: condition))
     }
 
     // MARK: - Conditions with Dependencies
@@ -118,7 +368,7 @@ class ConditionTests: ProcedureKitTestCase {
         conditionDependency1.name = "Condition 1 Dependency"
 
         let condition1 = TrueCondition(name: "Condition 1")
-        condition1.add(dependency: conditionDependency1)
+        condition1.produce(dependency: conditionDependency1)
 
 
         let conditionDependency2 = BlockOperation {
@@ -128,7 +378,7 @@ class ConditionTests: ProcedureKitTestCase {
         conditionDependency2.name = "Condition 2 Dependency"
 
         let condition2 = TrueCondition(name: "Condition 2")
-        condition2.add(dependency: conditionDependency2)
+        condition2.produce(dependency: conditionDependency2)
 
         procedure.add(condition: condition1)
         procedure.add(condition: condition2)
@@ -141,14 +391,14 @@ class ConditionTests: ProcedureKitTestCase {
         XCTAssertProcedureFinishedWithoutErrors()
     }
 
-    func test__dependencies_contains_direct_dependencies_and_indirect_dependencies() {
+    func test__procedure_dependencies_only_contain_direct_dependencies() {
 
         let dependency1 = TestProcedure()
         let dependency2 = TestProcedure()
         let condition1 = TrueCondition(name: "Condition 1")
-        condition1.add(dependency: TestProcedure())
+        condition1.produce(dependency: TestProcedure())
         let condition2 = TrueCondition(name: "Condition 2")
-        condition2.add(dependency: TestProcedure())
+        condition2.produce(dependency: TestProcedure())
 
         procedure.add(dependency: dependency1)
         procedure.add(dependency: dependency2)
@@ -158,7 +408,7 @@ class ConditionTests: ProcedureKitTestCase {
         run(operations: dependency1, dependency2)
         wait(for: procedure)
 
-        XCTAssertEqual(procedure.dependencies.count, 4)
+        XCTAssertEqual(procedure.dependencies.count, 2)
     }
 
     func test__target_and_condition_have_same_dependency() {
@@ -200,6 +450,194 @@ class ConditionTests: ProcedureKitTestCase {
         XCTAssertProcedureFinishedWithoutErrors(procedure2)
     }
 
+    func test__dependency_added_by_queue_delegate_will_add_also_affects_evaluating_conditions() {
+        // A dependency that is added in a ProcedureQueue delegate's willAddProcedure method
+        // should also properly delay the evaluation of Conditions.
+
+        class CustomQueueDelegate: ProcedureQueueDelegate {
+            typealias DidAddProcedureBlock = (Procedure) -> Void
+            private let dependenciesToAddInWillAdd: [Operation]
+            private let didAddProcedureBlock: DidAddProcedureBlock
+            init(dependenciesToAddInWillAdd: [Operation], didAddProcedureBlock: @escaping DidAddProcedureBlock) {
+                self.dependenciesToAddInWillAdd = dependenciesToAddInWillAdd
+                self.didAddProcedureBlock = didAddProcedureBlock
+            }
+            func procedureQueue(_ queue: ProcedureQueue, willAddProcedure procedure: Procedure, context: Any?) -> ProcedureFuture? {
+                let promise = ProcedurePromise()
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { [dependenciesToAddInWillAdd] in
+                    defer { promise.complete() }
+                    guard !dependenciesToAddInWillAdd.contains(procedure) else { return }
+                    procedure.add(dependencies: dependenciesToAddInWillAdd)
+                }
+                return promise.future
+            }
+            func procedureQueue(_ queue: ProcedureQueue, didAddProcedure procedure: Procedure, context: Any?) {
+                didAddProcedureBlock(procedure)
+            }
+        }
+
+        let procedureDidFinishGroup = DispatchGroup()
+        let conditionEvaluatedGroup = DispatchGroup()
+        let dependency = AsyncBlockProcedure { completion in
+            // does not finish
+        }
+        let procedure = TestProcedure()
+        procedureDidFinishGroup.enter()
+        procedure.addDidFinishBlockObserver { _, _ in
+            procedureDidFinishGroup.leave()
+        }
+        conditionEvaluatedGroup.enter()
+        procedure.add(condition: TestCondition(evaluate: {
+            // signal when evaluated
+            conditionEvaluatedGroup.leave()
+            return .success(true)
+        }))
+
+        weak var expDidAddProcedure = expectation(description: "Did Add Procedure to queue")
+        let customDelegate = CustomQueueDelegate(dependenciesToAddInWillAdd: [dependency]) { addedProcedure in
+            // did add Procedure to queue
+            guard addedProcedure === procedure else { return }
+            DispatchQueue.main.async {
+                expDidAddProcedure?.fulfill()
+            }
+        }
+        queue.delegate = customDelegate
+        queue.add(operations: procedure, dependency)
+
+        // wait until the procedure has been added to the queue
+        waitForExpectations(timeout: 2)
+
+        // sleep for 0.05 seconds to give a chance for the Condition to be improperly evaluated
+        usleep(50000)
+
+        // verify that the procedure *and the Condition* are not ready to execute,
+        // nor executing, nor finished
+        // (they should both be waiting on the dependency added in the ProcedureQueue
+        // delegate's willAddProcedure handler, which won't finish until it's triggered)
+
+        XCTAssertProcedureIsWaiting(procedure, withDependency: dependency)
+        XCTAssertEqual(conditionEvaluatedGroup.wait(timeout: .now()), .timedOut, "The Condition has already evaluated, and did not wait on the dependency.")
+
+        // finish the dependency
+        dependency.finish()
+
+        // wait for the procedure to finish
+        weak var expProcedureDidFinish = expectation(description: "test procedure Did Finish")
+        procedureDidFinishGroup.notify(queue: DispatchQueue.main) {
+            expProcedureDidFinish?.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        XCTAssertEqual(conditionEvaluatedGroup.wait(timeout: .now()), .success, "The Condition was never evaluated.")
+    }
+
+    func test__dependency_added_before_another_dependency_finishes_also_affects_conditions() {
+        // A dependency that is added in (for example) an existing dependency's willFinish
+        // observer should also properly delay the evaluation of Conditions.
+
+        let procedure = TestProcedure()
+        let procedureDidFinishGroup = DispatchGroup()
+        let conditionEvaluatedGroup = DispatchGroup()
+
+        let dependency = TestProcedure()
+        let additionalDependency = AsyncBlockProcedure { completion in
+            // does not finish
+        }
+        dependency.addWillFinishBlockObserver { _, _, _ in
+            // add another dependency, before the first dependency finishes
+            procedure.add(dependency: additionalDependency)
+        }
+
+        weak var expDependencyDidFinish = expectation(description: "First dependency did finish")
+        dependency.addDidFinishBlockObserver { _, _ in
+            DispatchQueue.main.async {
+                expDependencyDidFinish?.fulfill()
+            }
+        }
+
+        procedureDidFinishGroup.enter()
+        procedure.addDidFinishBlockObserver { _, _ in
+            procedureDidFinishGroup.leave()
+        }
+        conditionEvaluatedGroup.enter()
+        procedure.add(condition: TestCondition(evaluate: {
+            // signal when evaluated
+            conditionEvaluatedGroup.leave()
+            return .success(true)
+        }))
+        procedure.add(dependency: dependency)
+
+        queue.add(operations: procedure, dependency, additionalDependency)
+
+        // wait until the first dependency has finished
+        waitForExpectations(timeout: 2)
+
+        // sleep for 0.05 seconds to give a chance for the Condition to be improperly evaluated
+        usleep(50000)
+
+        // verify that the procedure *and the Condition* are not ready to execute,
+        // nor executing, nor finished
+        // (they should both be waiting on the dependency added in the ProcedureQueue
+        // delegate's willAddProcedure handler, which won't finish until it's triggered)
+
+        XCTAssertProcedureIsWaiting(procedure, withDependency: dependency)
+        XCTAssertEqual(conditionEvaluatedGroup.wait(timeout: .now()), .timedOut, "The Condition has already evaluated, and did not wait on the dependency.")
+
+        // finish the additional dependency
+        additionalDependency.finish()
+
+        // wait for the procedure to finish
+        weak var expProcedureDidFinish = expectation(description: "test procedure Did Finish")
+        procedureDidFinishGroup.notify(queue: DispatchQueue.main) {
+            expProcedureDidFinish?.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+
+        XCTAssertEqual(conditionEvaluatedGroup.wait(timeout: .now()), .success, "The Condition was never evaluated.")
+    }
+
+    // Verifies that a Procedure (and its condition evaluator) have a dependency and are waiting
+    private func XCTAssertProcedureIsWaiting<T: Procedure>(_ exp: @autoclosure () throws -> T, withDependency dependency: Operation, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) {
+        __XCTEvaluateAssertion(testCase: self, message, file: file, line: line) {
+            let procedure = try exp()
+
+            guard procedure.isEnqueued else {
+                return .expectedFailure("\(procedure.procedureName) has not been added to a queue yet.")
+            }
+            guard procedure.dependencies.contains(dependency) else {
+                return .expectedFailure("\(procedure.procedureName) does not have dependency: \(dependency)")
+            }
+            guard !procedure.isReady else {
+                return .expectedFailure("\(procedure.procedureName) is ready")
+            }
+            guard !procedure.isExecuting else {
+                return .expectedFailure("\(procedure.procedureName) is executing")
+            }
+            guard !procedure.isFinished else {
+                return .expectedFailure("\(procedure.procedureName) is finished")
+            }
+            if !procedure.conditions.isEmpty {
+                guard let conditionEvaluator = procedure.evaluateConditionsProcedure else {
+                    return .expectedFailure("Unable to obtain condition evaluator from the Procedure.")
+                }
+                guard conditionEvaluator.dependencies.contains(dependency) else {
+                    return .expectedFailure("\(procedure.procedureName)'s condition evaluator does not have dependency: \(dependency)")
+                }
+                guard !conditionEvaluator.isReady else {
+                    return .expectedFailure("\(procedure.procedureName)'s condition evaluator is ready")
+                }
+                guard !conditionEvaluator.isExecuting else {
+                    return .expectedFailure("\(procedure.procedureName)'s condition evaluator is executing")
+                }
+                guard !conditionEvaluator.isFinished else {
+                    return .expectedFailure("\(procedure.procedureName)'s condition evaluator is finished")
+                }
+            }
+
+            return .success
+        }
+    }
+
     // MARK: - Ignored Conditions
 
     func test__ignored_failing_condition_does_not_result_in_failure() {
@@ -235,56 +673,416 @@ class ConditionTests: ProcedureKitTestCase {
         XCTAssertProcedureCancelledWithoutErrors()
     }
 
-    // MARK: - Condition Cancellation
+    func test__ignored_failing_condition_plus_successful_condition_succeeds() {
+        // A Procedure with one or more ignored conditions and at least one
+        // successful condition should be allowed to proceed with execution.
+        let procedure1 = TestProcedure(name: "Procedure 1")
+        procedure1.add(condition: IgnoredCondition(FalseCondition()))
+        procedure1.add(condition: TrueCondition())
 
-    func test__condition_cancelled_before_evaluation_skips_evaluation() {
-        var didEvaluateCondition = false
-        let condition = TestCondition() {
-            didEvaluateCondition = true
-            return ConditionResult.success(true)
+        wait(for: procedure1)
+
+        XCTAssertProcedureFinishedWithoutErrors(procedure1)
+    }
+    
+    // MARK: - Compound Conditions
+
+    func test__compound_condition_produced_dependencies() {
+        let conditions: [Condition] = (0..<3).map {
+            let condition = TrueCondition(name: "Condition \($0)")
+            condition.produce(dependency: TestProcedure())
+            return condition
         }
-        procedure.add(condition: condition)
-        condition.cancel()
+        let compoundCondition = CompoundCondition(andPredicateWith: conditions)
+        let nestedProducedDependencies = conditions.producedDependencies
+        XCTAssertEqual(nestedProducedDependencies.count, 3)
+        XCTAssertEqual(compoundCondition.producedDependencies.count, 0)
+
+        let producedDependency = TestProcedure()
+        compoundCondition.produce(dependency: producedDependency)
+        XCTAssertTrue(Array(compoundCondition.producedDependencies) == [producedDependency])
+    }
+
+    func test__compound_condition_added_dependencies() {
+        let conditions: [Condition] = (0..<3).map {
+            let condition = TrueCondition(name: "Condition \($0)")
+            condition.add(dependency: TestProcedure())
+            return condition
+        }
+        let compoundCondition = CompoundCondition(andPredicateWith: conditions)
+        let nestedDependencies = conditions.dependencies
+        XCTAssertEqual(nestedDependencies.count, 3)
+        XCTAssertEqual(compoundCondition.dependencies.count, 0)
+
+        let dependency = TestProcedure()
+        compoundCondition.add(dependency: dependency)
+        XCTAssertTrue(Array(compoundCondition.dependencies) == [dependency])
+    }
+
+    func test__compound_condition_mutually_exclusive_categories() {
+        // give all the conditions the same category
+        let conditions: [Condition] = (0..<3).map {
+            let condition = TrueCondition(name: "Condition \($0)")
+            condition.addToAttachedProcedure(mutuallyExclusiveCategory: "test")
+            return condition
+        }
+        let compoundCondition = CompoundCondition(andPredicateWith: conditions)
+        XCTAssertEqual(compoundCondition.mutuallyExclusiveCategories, ["test"])
+
+        // give all the conditions different categories
+        let conditions2: [Condition] = (0..<3).map {
+            let condition = TrueCondition(name: "Condition \($0)")
+            condition.addToAttachedProcedure(mutuallyExclusiveCategory: "test\($0)")
+            return condition
+        }
+        let compoundCondition2 = CompoundCondition(andPredicateWith: conditions2)
+        XCTAssertEqual(compoundCondition2.mutuallyExclusiveCategories, ["test0", "test1", "test2"])
+    }
+
+    // MARK: - Compound Conditions - &&
+
+    func test__and_condition__with_no_conditions_cancels_without_errors() {
+        procedure.add(condition: AndCondition([]))
         wait(for: procedure)
-        XCTAssertFalse(didEvaluateCondition)
+        XCTAssertProcedureCancelledWithoutErrors()
+    }
+
+    func test__and_condition__with_single_successful_condition__succeeds() {
+        procedure.add(condition: AndCondition([TrueCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureFinishedWithoutErrors()
+    }
+
+    func test__and_condition__with_single_failing_condition__fails() {
+        procedure.add(condition: AndCondition([FalseCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithErrors(procedure, count: 1)
+    }
+
+    func test__and_condition__with_single_ignored_condition__does_not_fail() {
+        procedure.add(condition: AndCondition([IgnoredCondition(FalseCondition())]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithoutErrors()
+    }
+
+    func test__and_condition__with_two_successful_conditions__succeeds() {
+        procedure.add(condition: AndCondition([TrueCondition(), TrueCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureFinishedWithoutErrors()
+    }
+
+    func test__and_condition__with_successful_and_failing_conditions__fails() {
+        procedure.add(condition: AndCondition([TrueCondition(), FalseCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithErrors(procedure, count: 1)
+    }
+
+    func test__and_condition__with_failing_and_successful_conditions__fails() {
+        procedure.add(condition: AndCondition([FalseCondition(), TrueCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithErrors(procedure, count: 1)
+    }
+
+    func test__and_condition__with_successful_and_ignored_condition__does_not_fail() {
+        procedure.add(condition: AndCondition([IgnoredCondition(FalseCondition()), TrueCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureFinishedWithoutErrors()
+    }
+
+    func test__and_condition__with_failing_and_ignored_condition__fails() {
+        procedure.add(condition: AndCondition([IgnoredCondition(FalseCondition()), FalseCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithErrors(procedure, count: 1)
+    }
+
+    func test__and_condition__with_two_ignored_conditions__does_not_fail() {
+        procedure.add(condition: AndCondition([IgnoredCondition(FalseCondition()), IgnoredCondition(FalseCondition())]))
+        wait(for: procedure)
         XCTAssertProcedureCancelledWithoutErrors(procedure)
     }
 
-    func test_condition_cancelled_before_evaluation_but_after_procedure_is_added_to_queue_is_immediately_finished() {
-        let dependencySemaphore = DispatchSemaphore(value: 0)
-        let dependency = BlockProcedure {
-            // prevent the dependency procedure from finishing before signaled
-            dependencySemaphore.wait()
-        }
-        var didEvaluateCondition = false
-        let condition = TestCondition() {
-            didEvaluateCondition = true
-            return ConditionResult.success(true)
-        }
-        let procedureSemaphore = DispatchSemaphore(value: 0)
-        let procedure = BlockProcedure {
-            // prevent the main procedure from finishing before signaled (unless cancelled)
-            procedureSemaphore.wait()
-        }
-        procedure.add(condition: condition)
-        procedure.add(dependency: dependency)
-        check(procedure: procedure, withAdditionalProcedures: dependency) { _ in
-            let conditionFinishedSemaphore = DispatchSemaphore(value: 0)
-            condition.addDidFinishBlockObserver(block: { (_, _) in
-                conditionFinishedSemaphore.signal()
-            })
-            condition.cancel()
-            dependencySemaphore.signal()
-            // the condition is now cancelled and should be unblocked from running
-            // as its dependency is able to finish
-            // wait 1 second to see if the condition finishes
-            guard conditionFinishedSemaphore.wait(timeout: .now() + 1.0) == .success else {
-                XCTFail("Condition did not finish immediately after it was cancelled.")
-                return
+    func test__nested_successful_and_conditions() {
+        procedure.add(condition: AndCondition([AndCondition([TrueCondition(), TrueCondition()]), AndCondition([TrueCondition(), TrueCondition()])]))
+        wait(for: procedure)
+        XCTAssertProcedureFinishedWithoutErrors()
+    }
+
+    func test__nested_failing_and_conditions() {
+        procedure.add(condition: AndCondition([AndCondition([FalseCondition(), FalseCondition()]), AndCondition([FalseCondition(), FalseCondition()])]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithErrors(procedure, count: 1)
+    }
+
+    func test__ignored_and_condition_does_not_fail() {
+        procedure.add(condition: IgnoredCondition(AndCondition([TrueCondition(), FalseCondition()])))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithoutErrors(procedure)
+    }
+
+    // MARK: - Compound Conditions - ||
+
+    func test__or_condition__with_no_conditions_cancels_without_errors() {
+        procedure.add(condition: OrCondition([]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithoutErrors()
+    }
+
+    func test__or_condition__with_single_successful_condition__succeeds() {
+        procedure.add(condition: OrCondition([TrueCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureFinishedWithoutErrors()
+    }
+
+    func test__or_condition__with_single_failing_condition__fails() {
+        procedure.add(condition: OrCondition([FalseCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithErrors(procedure, count: 1)
+    }
+
+    func test__or_condition__with_single_ignored_condition__does_not_fail() {
+        procedure.add(condition: OrCondition([IgnoredCondition(FalseCondition())]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithoutErrors()
+    }
+
+    func test__or_condition__with_two_successful_conditions__succeeds() {
+        procedure.add(condition: OrCondition([TrueCondition(), TrueCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureFinishedWithoutErrors()
+    }
+
+    func test__or_condition__with_successful_and_failing_conditions__succeeds() {
+        procedure.add(condition: OrCondition([TrueCondition(), FalseCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureFinishedWithoutErrors()
+    }
+
+    func test__or_condition__with_failing_and_successful_conditions__succeeds() {
+        procedure.add(condition: OrCondition([FalseCondition(), TrueCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureFinishedWithoutErrors()
+    }
+
+    func test__or_condition__with_successful_and_ignored_condition__succeeds() {
+        procedure.add(condition: OrCondition([IgnoredCondition(FalseCondition()), TrueCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureFinishedWithoutErrors()
+    }
+
+    func test__or_condition__with_failing_and_ignored_condition__fails() {
+        procedure.add(condition: OrCondition([IgnoredCondition(FalseCondition()), FalseCondition()]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithErrors(procedure, count: 1)
+    }
+
+    func test__or_condition__with_two_ignored_conditions__does_not_fail() {
+        procedure.add(condition: OrCondition([IgnoredCondition(FalseCondition()), IgnoredCondition(FalseCondition())]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithoutErrors(procedure)
+    }
+
+    func test__nested_successful_or_conditions() {
+        procedure.add(condition: OrCondition([OrCondition([TrueCondition(), TrueCondition()]), OrCondition([TrueCondition(), TrueCondition()])]))
+        wait(for: procedure)
+        XCTAssertProcedureFinishedWithoutErrors()
+    }
+
+    func test__nested_failing_or_conditions() {
+        procedure.add(condition: OrCondition([OrCondition([FalseCondition(), FalseCondition()]), OrCondition([FalseCondition(), FalseCondition()])]))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithErrors(procedure, count: 4)
+    }
+
+    func test__ignored_or_condition_does_not_fail() {
+        procedure.add(condition: IgnoredCondition(OrCondition([FalseCondition()])))
+        wait(for: procedure)
+        XCTAssertProcedureCancelledWithoutErrors(procedure)
+    }
+
+    // MARK: - Concurrency
+
+    func test__procedure_cancelled_while_conditions_are_being_evaluated_finishes_before_blocked_condition() {
+
+        class CustomTestCondition: AsyncTestCondition {
+            typealias DeinitBlockType = () -> Void
+            var deinitBlock: DeinitBlockType? = nil
+            deinit {
+                deinitBlock?()
             }
         }
-        XCTAssertFalse(didEvaluateCondition)
+
+        // to allow the Procedures to deallocate as soon as they are done
+        // the QueueTestDelegate must be removed (as it holds references)
+        queue.delegate = nil
+
+        [true, false].forEach { waitOnEvaluatorReference in
+
+            var procedure: TestProcedure? = TestProcedure()
+            let procedureDidFinishGroup = DispatchGroup()
+            let customQueue = DispatchQueue(label: "test")
+            let conditionGroup = DispatchGroup()
+            conditionGroup.enter()
+            var condition: CustomTestCondition? = CustomTestCondition { completion in
+                // only succeed once the group has been completed
+                conditionGroup.notify(queue: customQueue) {
+                    completion(.success(true))
+                }
+            }
+            let conditionWillDeinitGroup = DispatchGroup()
+            conditionWillDeinitGroup.enter()
+            condition!.deinitBlock = {
+                conditionWillDeinitGroup.leave()
+            }
+            procedureDidFinishGroup.enter()
+            procedure!.addDidFinishBlockObserver { _, _ in
+                procedureDidFinishGroup.leave()
+            }
+            procedure!.add(condition: condition!)
+
+            // remove local reference to the Condition
+            condition = nil
+
+            // then start the procedure
+            run(operation: procedure!)
+
+            var evaluateConditionsOperation: Procedure.EvaluateConditions? = nil
+            // obtain a reference to the EvaluateConditions operation
+            if waitOnEvaluatorReference {
+                guard let evaluator = procedure!.evaluateConditionsProcedure else {
+                    XCTFail("Unexpectedly no EvaluateConditions procedure")
+                    return
+                }
+                evaluateConditionsOperation = evaluator
+            }
+
+            // the Procedure should not finish, as it should be waiting on the Condition to evaluate
+            XCTAssertEqual(procedureDidFinishGroup.wait(timeout: .now() + 0.2), .timedOut)
+
+            // cancel the Procedure, which should allow it to rapidly finish
+            // (despite the Condition *still* not being completed)
+            procedure!.cancel()
+
+            weak var expProcedureDidFinish = expectation(description: "procedure did finish")
+            procedureDidFinishGroup.notify(queue: DispatchQueue.main) {
+                expProcedureDidFinish?.fulfill()
+            }
+            waitForExpectations(timeout: 2)
+            XCTAssertProcedureCancelledWithoutErrors(procedure!)
+
+            // remove local reference to the Procedure
+            procedure = nil
+
+            // signal for the condition to finally complete
+            conditionGroup.leave()
+
+            if waitOnEvaluatorReference {
+                // wait for the Condition evaluation to complete
+                evaluateConditionsOperation!.waitUntilFinished()
+
+                // verify that the Condition Evaluator was cancelled
+                XCTAssertTrue(evaluateConditionsOperation!.isCancelled)
+            }
+            else {
+                // wait for the Condition to begin to deinit
+                weak var expConditionWillDeinit = expectation(description: "condition will deinit")
+                conditionWillDeinitGroup.notify(queue: DispatchQueue.main) {
+                    expConditionWillDeinit?.fulfill()
+                }
+                waitForExpectations(timeout: 1)
+
+                // then wait for an additional short delay to give the condition
+                // evaluator operation a chance to deinit
+                weak var expDelayPassed = expectation(description: "delay passed")
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                    expDelayPassed?.fulfill()
+                }
+                waitForExpectations(timeout: 1)
+
+                // nothing should have caused a crash
+                XCTAssertTrue(true)
+            }
+        }
+    }
+
+    func test__procedure_cancelled_while_conditions_are_being_evaluated_cancels_condition_produced_dependencies() {
+        let procedure = TestProcedure()
+
+        // The following order of operations is enforced below:
+        //  1. dependentCondition's `conditionProducedDependency` is produced by the dependentCondition,
+        //     and is executed (but does not finish)
+        //      AND
+        //     `normalDependency` is executed (but does not finish)
+        //  2. then, `cancelsProcedureCondition` cancels the procedure (while conditions are
+        //     being evaluated, and while the condition-produced `conditionProducedDependency` and
+        //     the (non-condition-produced) `normalDependency` are executing)
+
+        // The expected result is:
+        //  - `conditionProducedDependency` is cancelled (by the Procedure's cancellation propagating
+        //    through the active Condition Evaluation to cancel any active condition-produced
+        //    dependencies)
+        //  - `normalDependency` is not cancelled
+
+        let testDependencyExecutedGroup = DispatchGroup() // signaled once testDependency has executed
+        testDependencyExecutedGroup.enter()
+        let conditionProducedDependency = AsyncResultProcedure<Bool> { _ in
+            testDependencyExecutedGroup.leave()
+            // do not finish
+        }
+        conditionProducedDependency.addDidCancelBlockObserver { conditionProducedDependency, _ in
+            // only finish once cancelled
+            conditionProducedDependency.finish(withResult: .success(true))
+        }
+
+        testDependencyExecutedGroup.enter()
+        let normalDependency = AsyncBlockProcedure { _ in
+            testDependencyExecutedGroup.leave()
+            // do not finish
+        }
+        let normalDependencyDidFinishGroup = DispatchGroup()
+        normalDependencyDidFinishGroup.enter()
+        normalDependency.addDidFinishBlockObserver { _, _ in
+            normalDependencyDidFinishGroup.leave()
+        }
+
+        let cancelsProcedureCondition = AsyncTestCondition { completion in
+            // do not do this - this is just to ensure that the procedure cancels in the middle of
+            // condition evaluation for this test
+            //
+            // wait for the dependencies of the other condition to be executed before
+            // cancelling the procedure and completing this condition
+            testDependencyExecutedGroup.notify(queue: DispatchQueue.global()) {
+                procedure.cancel()
+                completion(.success(true))
+            }
+        }
+
+        let dependentCondition = TrueCondition()
+        dependentCondition.produce(dependency: conditionProducedDependency)
+        dependentCondition.add(dependency: normalDependency)
+        procedure.add(condition: AndCondition(TrueCondition(), dependentCondition, cancelsProcedureCondition))
+
+        // wait on the conditionProducedDependency to finish - but since it is scheduled
+        // (and produced) by the dependentCondition, simply add a completion block
+        addCompletionBlockTo(procedure: conditionProducedDependency)
+
+        // normalDependency is not expected to finish (nor cancel), so run it and check
+        // finish status later (do not wait on it)
+        run(operation: normalDependency)
+
+        wait(for: procedure)
+
         XCTAssertProcedureCancelledWithoutErrors(procedure)
+
+        // the condition-produced dependency should have been cancelled
+        XCTAssertProcedureCancelledWithoutErrors(conditionProducedDependency)
+        XCTAssertTrue(conditionProducedDependency.output.value?.value ?? false)
+
+        // whereas the non-condition-produced dependency should *not* be cancelled, nor finished
+        XCTAssertEqual(normalDependencyDidFinishGroup.wait(timeout: .now() + 0.1), .timedOut, "The normal condition dependency finished. It should not be cancelled, nor finished.")
+        XCTAssertFalse(normalDependency.isCancelled)
+
+        // clean-up: finish the normalDependency
+        normalDependency.finish()
     }
 }
 

--- a/Tests/ProcedureKitTests/MutualExclusivityTests.swift
+++ b/Tests/ProcedureKitTests/MutualExclusivityTests.swift
@@ -17,7 +17,7 @@ class MutualExclusiveTests: ProcedureKitTestCase {
 
     func test__mutual_exclusive_category() {
         let condition = MutuallyExclusive<Procedure>(category: "testing")
-        XCTAssertEqual(condition.category, "testing")
+        XCTAssertEqual(condition.mutuallyExclusiveCategories, ["testing"])
     }
 
     func test__alert_presentation_is_mutually_exclusive() {

--- a/Tests/ProcedureKitTests/SilentConditionTests.swift
+++ b/Tests/ProcedureKitTests/SilentConditionTests.swift
@@ -15,11 +15,11 @@ class SilentConditionTests: ProcedureKitTestCase {
         XCTAssertEqual(silent.name, "Silent<FalseCondition>")
     }
 
-    func test__silent_condition_removes_dependencies_from_composed_condition() {
+    func test__silent_condition_removes_produced_dependencies_from_composed_condition() {
         let dependency = TestProcedure()
         let condition = TrueCondition()
-        condition.add(dependency: dependency)
+        condition.produce(dependency: dependency)
         let _ = SilentCondition(condition)
-        XCTAssertEqual(condition.dependencies.count, 0)
+        XCTAssertEqual(condition.producedDependencies.count, 0)
     }
 }


### PR DESCRIPTION
This PR encompasses a major refactor of Conditions in ProcedureKit, improving performance, fixing bugs, and adding new features (while also expanding test coverage and documentation).

## Highlights:

- `Conditions` are no longer `Procedure` subclasses, and are lighter-weight.
- `Condition` processing is faster, and supports short-circuit evaluation for considerable performance improvements.
- MutualExclusivity is now evaluated post-dependencies and condition evaluation (i.e. immediately before execute), resolving numerous issues and edge cases.
- Bugs have been fixed.
- Internal implementation details are no longer exposed to user code unexpectedly.
- Added a new `CompoundCondition` (and `AndCondition` / `OrCondition`) to support logical “&&” and “||” operations on `Conditions`.
- A *lot* more documentation.

## Breaking Changes (from prior ProcedureKit v4 betas):

**TL/DR:** Almost all code built using the prior beta of ProcedureKit v4 will work with these new improvements while requiring only minimal changes.

The few areas of change that may impact existing code are:

### For Condition subclasses:
- `Condition.add(dependency:)` now functions exactly the same as `Procedure.add(dependency:)`. It does **_not_** result in the framework automatically enqueuing / running the dependency.
    - **Solutions:**
        - If you add the dependency to a queue yourself (or otherwise cause it to run), continue using `add(dependency:)`.
        - If you want the framework to schedule the dependency for execution immediately prior to evaluating the `Condition`, use the new **`Condition.produce(dependency:)`** method.
- `var mutuallyExclusiveCategory: String?` is no longer available.
    - **Solutions:**
        - Use **`Condition.addToAttachedProcedure(mutuallyExclusiveCategory:)`** instead to add a mutually-exclusive category to the `Procedure` to which your custom `Condition` is added.
        - Use `var mutuallyExclusiveCategories` to query the currently-set categories (rarely needed outside the framework).
- You can no longer call `add(condition:)` on a `Condition`.
    - Since `Condition` is no longer a `Procedure` subclass, it makes no sense to add a `Condition` (which is evaluated on a `Procedure`) to a `Condition`. However, `ComposedCondition` and `CompoundCondition` provide supported alternative patterns.
    - **Solution:**
        - Investigate `ComposedCondition` and `CompoundCondition`. These support almost all common scenarios.
        - For cases in which you previously attached a `NoFailedDependenciesCondition` to a `Condition`, you can **use the new `Condition.dependencyRequirements` to automate checking for dependency failures / cancellation** (so you don't have to bother doing this yourself in your `evaluate` override).

## How Conditions are Scheduled and Evaluated

Here’s the new order of operations / evaluation / scheduling:

- All of a `Procedure`’s (direct) **dependencies** must finish.
- Then, asynchronous processing of the`Conditions` begins. For each `Condition`:
    - If it has `dependencies` or `producedDependencies`:
        - The `Condition` evaluation (call to `evaluate(procedure:completion:)`) is wrapped in a `BlockOperation`.
        - All `dependencies` and `producedDependencies` are added as dependencies to the `BlockOperation`.
        - The `producedDependencies` and `BlockOperation` are added to an internal queue.
        - (Thus, all `Condition` dependencies must finish before the wrapped `Condition` evaluation is executed.)
    - Otherwise, the `Condition`’s `evaluate(procedure:completion:)` is called directly.
- **Condition results are aggregated until the final result is known**. This may be before all Conditions are processed (as short-circuit evaluation is now supported). If the final result is known before all Conditions have been evaluated, any remaining Conditions may be skipped (and any remaining Condition-produced dependencies may be cancelled / never scheduled for execution).
- If the final result is a failure, **the attached `Procedure` is cancelled** (with / without errors depending on whether the final result is `.failure(error)` or `.success(false)`). **Processing is complete.**
- Otherwise, if the final result is a success (`.success(true)`):
    - If no mutually-exclusive categories exist on any of the `Procedure`’s `Conditions`, **the `Procedure` is ready to execute.**
    - If mutually-exclusive categories exist on any of the `Procedure`’s `Conditions`:
        - A single asynchronous lock request is made for the union of all of the mutually-exclusive categories.
        - **Once the lock request is granted**, the internal `EvaluateConditions` operation finishes, and **the `Procedure` is ready to execute**.
        - (The locks are released once the `Procedure` has finished.)


## Additional Details

- Mutual Exclusivity is now evaluated when `Procedures` are **ready to execute** (as the final step of Condition evaluation), instead of when `Procedures` are added to the queue.
    - This **resolves several deadlock and unexpected dependency scenarios**, while still ensuring that only one Procedure with each mutual exclusivity category is running simultaneously.
    - It also **improves performance** by only acquiring locks in a single request, and only when the `Procedure` is otherwise ready to execute.
- The internal `EvaluateConditions` operation - and any `Condition`-produced dependencies - are no longer added to a user-visible queue.
    - Improved encapsulation of internal implementation details.
    - Prevents unexpected user queue starvation as a result of many long-running, outstanding condition evaluations / produced dependencies.
- `Conditions` and `Condition` dependencies no longer appear in the `Procedure.dependencies`.
    - Improved encapsulation of internal implementation details.
    - Fixes edge-case bugs with things like NoFailedDependenciesCondition (issue: #515).
- `Condition` evaluation now supports **short-circuit evaluation, dramatically speeding-up performance** in many cases.
    - The result of `Condition` evaluation may be known before all `Conditions` are evaluated. (For example, if a Procedure has multiple Conditions, as soon as one of them fails, the ultimate result is guaranteed to be a failure.) Thus, we can avoid evaluating any remaining conditions as soon as the result is known.
    - **Minor Backwards-Compatibility Note**: 
        - This means that `Procedures` will fail with the **_first_ failure error that is returned by a `Condition`**.
        - `Condition` evaluation is _asynchronous_, and _the order in which a `Procedure`’s conditions are evaluated is not guaranteed_. Whichever `Condition` fails first will provide the failure error.
        - If you are relying on `Procedures` cancelling with information about _every_ failing `Condition` (or a specific `Condition` error amongst many possible), you will need to modify your expectations to match the new behavior. (This will likely only affect exhaustive test-cases that verify the cancellation errors in-depth.)
        - `OrCondition` may fail with multiple errors, as its evaluation can only be short-circuited if at least one `Condition` succeeds.

## New Features:

- **`CompoundCondition`** is now supported, to provide support for logical “&&” and “||” operations on a sequence of `Conditions`. (As a short-cut, you can also use `AndCondition` and `OrCondition`.)

    ```swift
    let condition1 = TrueCondition()
    let condition2 = FalseCondition()

    // The following are each equivalent to a Condition encompassing “condition1 || condition2”
    // i.e. if either condition1 or condition2 succeeds, the “orCondition” succeeds
    let orCondition1 = OrCondition(condition1, condition2)
    let orCondition2 = CompoundCondition(orPredicateWith: [condition1, condition2])
    let orCondition3 = condition1 || condition2
    ```

    `CompoundCondition` supports short-circuit evaluation, for improved performance.