### PR TITLE
Dependency injection cancellation error

### DIFF
--- a/Sources/ProcedureKit/ProcedureResult.swift
+++ b/Sources/ProcedureKit/ProcedureResult.swift
@@ -151,7 +151,7 @@ public extension ProcedureProtocol {
 
         dependency.addDidCancelBlockObserver { [weak self] _, errors in
             if let strongSelf = self {
-                strongSelf.cancel(withError: ProcedureKitError.parent(cancelledWithErrors: errors))
+                strongSelf.cancel(withError: ProcedureKitError.dependency(cancelledWithErrors: errors))
             }
         }
 

--- a/Tests/ProcedureKitTests/ResultInjectionTests.swift
+++ b/Tests/ProcedureKitTests/ResultInjectionTests.swift
@@ -110,7 +110,7 @@ class ResultInjectionTests: ResultInjectionTestCase {
             guard let procedureKitError = errors.first as? ProcedureKitError else {
                 XCTFail("Incorrect error received"); return
             }
-            XCTAssertEqual(procedureKitError.context, .parentCancelledWithErrors)
+            XCTAssertEqual(procedureKitError.context, .dependencyCancelledWithErrors)
         }
         procedure.cancel()
         wait(for: processing, procedure)


### PR DESCRIPTION
Currently, dependency injection uses the error `parentCancelledWithErrors` when the dependency has been cancelled. To aide debugging, we should probably add a new unique error for this case (suggestion: `dependencyCancelledWithErrors`).

```swift
dependency.addDidCancelBlockObserver { [weak self] dependency, errors in
    if let strongSelf = self {
        strongSelf.cancel(withError: ProcedureKitError.parent(cancelledWithErrors: errors))
    }
}
```

See: https://github.com/ProcedureKit/ProcedureKit/blob/08a0d37ba66f084073fd687bbd99a34fa9fe1fff/Sources/ProcedureKit/ProcedureResult.swift#L156