### PR TITLE
AsyncResultProcedure design: no way to access self in block

### DIFF
--- a/Sources/ProcedureKit/Block.swift
+++ b/Sources/ProcedureKit/Block.swift
@@ -29,7 +29,7 @@ open class BlockProcedure: ResultProcedure<Void> { }
 open class AsyncResultProcedure<Output>: Procedure, OutputProcedure {
 
     public typealias FinishingBlock = (ProcedureResult<Output>) -> Void
-    public typealias Block = (AsyncResultProcedure, @escaping FinishingBlock) -> Void
+    public typealias Block = (AsyncResultProcedure?, @escaping FinishingBlock) -> Void
 
     private var block: Block
 
@@ -41,7 +41,8 @@ open class AsyncResultProcedure<Output>: Procedure, OutputProcedure {
     }
 
     open override func execute() {
-        block(self) { self.finish(withResult: $0) }
+        weak var weakSelf = self
+        block(weakSelf) { self.finish(withResult: $0) }
     }
 }
 

--- a/Sources/ProcedureKit/Block.swift
+++ b/Sources/ProcedureKit/Block.swift
@@ -29,9 +29,9 @@ open class BlockProcedure: ResultProcedure<Void> { }
 open class AsyncResultProcedure<Output>: Procedure, OutputProcedure {
 
     public typealias FinishingBlock = (ProcedureResult<Output>) -> Void
-    public typealias Block = (@escaping FinishingBlock) -> Void
+    public typealias Block = (AsyncResultProcedure, @escaping FinishingBlock) -> Void
 
-    private let block: Block
+    private var block: Block
 
     public var output: Pending<ProcedureResult<Output>> = .pending
 
@@ -41,7 +41,7 @@ open class AsyncResultProcedure<Output>: Procedure, OutputProcedure {
     }
 
     open override func execute() {
-        block { self.finish(withResult: $0) }
+        block(self) { self.finish(withResult: $0) }
     }
 }
 

--- a/Tests/ProcedureKitTests/BlockProcedureTests.swift
+++ b/Tests/ProcedureKitTests/BlockProcedureTests.swift
@@ -58,7 +58,7 @@ class AsyncBlockProcedureTests: ProcedureKitTestCase {
 
     func test__block_executes() {
         var blockDidExecute = false
-        let block = AsyncBlockProcedure { finishWithResult in
+        let block = AsyncBlockProcedure { _, finishWithResult in
             self.dispatchQueue.async {
                 blockDidExecute = true
                 finishWithResult(success)
@@ -70,7 +70,7 @@ class AsyncBlockProcedureTests: ProcedureKitTestCase {
 
     func test__block_does_not_execute_if_cancelled() {
         var blockDidExecute = false
-        let block = AsyncBlockProcedure { finishWithResult in
+        let block = AsyncBlockProcedure { _, finishWithResult in
             self.dispatchQueue.async {
                 blockDidExecute = true
                 finishWithResult(success)
@@ -82,7 +82,7 @@ class AsyncBlockProcedureTests: ProcedureKitTestCase {
     }
 
     func test__block_which_finishes_with_error() {
-        let block = AsyncBlockProcedure { finishWithResult in
+        let block = AsyncBlockProcedure { _, finishWithResult in
             self.dispatchQueue.async {
                 finishWithResult(.failure(TestError()))
             }
@@ -92,7 +92,7 @@ class AsyncBlockProcedureTests: ProcedureKitTestCase {
     }
 
     func test__block_did_execute_observer() {
-        let block = AsyncBlockProcedure { finishWithResult in
+        let block = AsyncBlockProcedure { _, finishWithResult in
             self.dispatchQueue.async { finishWithResult(success) }
         }
         var didExecuteBlockObserver = false


### PR DESCRIPTION
Hi, 

I am implementing network requests as subclasses of `AsyncResultProcedure` / `AsyncBlockProcedure`. As of the current design with passing the super classes init a block there seems to be no way to access self (the subclass procedure). This prohibits accessing helper methods or the logging system. 

As of now I use this workaround approach: 

```swift
    init() {
        super.init(block: { _ in }) // passing in an empty block as it wont get called due to overriding execute()
    }
    
    // since it's not possible to access self in the block to be set in init() override execute instead
    override func execute() {
        fetch { self.finish(withResult: $0) }
    }

    func fetch(_ completion: @escaping FinishingBlock) {
        // ...
    }
```

Alternatively the `AsyncResultProcedure` could pass a reference to weak self into the block. 

