### PR TITLE
Robustness fixes for tests

### DIFF
--- a/Sources/TestingProcedureKit/ConcurrencyTestCase.swift
+++ b/Sources/TestingProcedureKit/ConcurrencyTestCase.swift
@@ -160,8 +160,9 @@ open class ConcurrencyRegistrar {
 // MARK: - TestConcurrencyTrackingProcedure
 
 open class TestConcurrencyTrackingProcedure: Procedure {
-    private weak var concurrencyRegistrar: ConcurrencyRegistrar?
-    private let microsecondsToSleep: useconds_t
+    private(set) weak var concurrencyRegistrar: ConcurrencyRegistrar?
+    let microsecondsToSleep: useconds_t
+
     init(name: String = "TestConcurrencyTrackingProcedure", microsecondsToSleep: useconds_t, registrar: ConcurrencyRegistrar) {
         self.concurrencyRegistrar = registrar
         self.microsecondsToSleep = microsecondsToSleep

--- a/Sources/TestingProcedureKit/GroupTestCase.swift
+++ b/Sources/TestingProcedureKit/GroupTestCase.swift
@@ -9,10 +9,12 @@ import XCTest
 import ProcedureKit
 
 open class TestGroupProcedure: GroupProcedure {
-    public private(set) var didExecute = false
+    public var didExecute: Bool { return _didExecute.access }
+
+    private var _didExecute = Protector(false)
 
     open override func execute() {
-        didExecute = true
+        _didExecute.overwrite(with: true)
         super.execute()
     }
 }

--- a/Tests/ProcedureKitTests/ConditionTests.swift
+++ b/Tests/ProcedureKitTests/ConditionTests.swift
@@ -478,8 +478,12 @@ class ConditionTests: ProcedureKitTestCase {
 
         let procedureDidFinishGroup = DispatchGroup()
         let conditionEvaluatedGroup = DispatchGroup()
+        weak var expDependencyDidStart = expectation(description: "Did Start Dependency")
         let dependency = AsyncBlockProcedure { completion in
-            // does not finish
+            DispatchQueue.main.async {
+                expDependencyDidStart?.fulfill()
+            }
+            // does not finish - the test handles that later for timing reasons
         }
         let procedure = TestProcedure()
         procedureDidFinishGroup.enter()
@@ -505,6 +509,7 @@ class ConditionTests: ProcedureKitTestCase {
         queue.add(operations: procedure, dependency)
 
         // wait until the procedure has been added to the queue
+        // and the dependency has been started
         waitForExpectations(timeout: 2)
 
         // sleep for 0.05 seconds to give a chance for the Condition to be improperly evaluated
@@ -539,8 +544,12 @@ class ConditionTests: ProcedureKitTestCase {
         let procedureDidFinishGroup = DispatchGroup()
         let conditionEvaluatedGroup = DispatchGroup()
 
+        weak var expDependencyDidStart = expectation(description: "Did Start additionalDependency")
         let dependency = TestProcedure()
         let additionalDependency = AsyncBlockProcedure { completion in
+            DispatchQueue.main.async {
+                expDependencyDidStart?.fulfill()
+            }
             // does not finish
         }
         dependency.addWillFinishBlockObserver { _, _, _ in
@@ -569,7 +578,8 @@ class ConditionTests: ProcedureKitTestCase {
 
         queue.add(operations: procedure, dependency, additionalDependency)
 
-        // wait until the first dependency has finished
+        // wait until the first dependency has finished,
+        // and the additionalDependency has started
         waitForExpectations(timeout: 2)
 
         // sleep for 0.05 seconds to give a chance for the Condition to be improperly evaluated

--- a/Tests/ProcedureKitTests/NetworkObserverTests.swift
+++ b/Tests/ProcedureKitTests/NetworkObserverTests.swift
@@ -37,8 +37,9 @@ class NetworkObserverTests: ProcedureKitTestCase {
         super.setUp()
         weak var indicatorExpectation = expectation(description: "Indicator Expectation")
         _changes = Protector<[Bool]>([])
-        indicator = TestableNetworkActivityIndicator { visibility in
-            self._changes.append(visibility)
+        indicator = TestableNetworkActivityIndicator { [weak weakChanges = _changes] visibility in
+            guard let changes = weakChanges else { return }
+            changes.append(visibility)
             if !visibility {
                 DispatchQueue.main.async {
                     guard let indicatorExpectation = indicatorExpectation else { return }

--- a/Tests/ProcedureKitTests/TimeoutObserverTests.swift
+++ b/Tests/ProcedureKitTests/TimeoutObserverTests.swift
@@ -27,7 +27,8 @@ final class TimeoutObserverTests: ProcedureKitTestCase {
     func test__timeout_observer_where_procedure_is_already_cancelled() {
         procedure = TestProcedure(delay: 0.5)
         procedure.add(observer: TimeoutObserver(until: Date() + 0.1))
-        check(procedure: procedure) { $0.cancel() }
+        procedure.cancel()
+        wait(for: procedure)
         XCTAssertProcedureCancelledWithoutErrors()
     }
 


### PR DESCRIPTION
1. Two of the dependency-related Condition tests could (rarely) fail due to a race condition in the tests themselves.

2. `test__timeout_observer_where_procedure_is_already_cancelled` could fail because the Procedure was being cancelled via a call to `check(procedure:)` (which executes its block after the Procedure has been added to a queue).

3. Robustness improvements to NetworkObserverTests.

    The block inside the `TestableNetworkActivityIndicator` is ultimately dispatched asynchronously by the `NetworkActivityController` and, thus, its ordering relative to an individual test finishing (and `tearDown()` being called) may depend on the test specifics and other factors. Therefore, do not use `self._changes`; instead capture the specific  `_changes` for the test.

4. Robustness improvements to MutualExclusivityTests

5. Robustness improvements to ProduceTests

    Not all tests were properly waiting on the `producedOperation` in all cases, and some variables were not properly protected from concurrent reads / writes.

6. Robustness improvements to GroupEventConcurrencyTests

    `test_group_finish_no_concurrent_events` and `test_group_cancel_no_concurrent_events` both checked for the DidFinish observer to be called, but didn't explicitly wait for it. (The testing harness function `wait(for: Procedure)` may return before DidFinish observers are called because it depends on Operation `isFinished` KVO which is signaled *prior* to DidFinish observers. It may happen that the DidFinish observers are called prior to `wait(for:)` returning, but ordering is not guaranteed.)

7. Robustness improvements to `test__did_finish_synchronized`

    `test__did_finish_synchronized` could occasionally fail due to a similar issue to 6 above, and is fixed by explicitly waiting for all DidFinish observers to be called.