### PR TITLE
Fix a (rare) data race in DelayProcedure

### DIFF
--- a/Sources/ProcedureKit/Delay.swift
+++ b/Sources/ProcedureKit/Delay.swift
@@ -121,7 +121,7 @@ public class DelayProcedure: Procedure {
         switch delay.interval {
         case (let interval) where interval > 0.0:
             guard !isCancelled else { return }
-            _timer = eventQueue.makeTimerSource(flags: [])
+            _timer = eventQueue.makeTimerSource()
             _timer?.setEventHandler { [weak self] in
                 guard let strongSelf = self else { return }
                 if !strongSelf.isCancelled { strongSelf.finish() }

--- a/Sources/ProcedureKit/Delay.swift
+++ b/Sources/ProcedureKit/Delay.swift
@@ -121,7 +121,7 @@ public class DelayProcedure: Procedure {
         switch delay.interval {
         case (let interval) where interval > 0.0:
             guard !isCancelled else { return }
-            _timer = DispatchSource.makeTimerSource(flags: [], queue: DispatchQueue.default)
+            _timer = eventQueue.makeTimerSource(flags: [])
             _timer?.setEventHandler { [weak self] in
                 guard let strongSelf = self else { return }
                 if !strongSelf.isCancelled { strongSelf.finish() }

--- a/Sources/ProcedureKit/ProcedureEventQueue.swift
+++ b/Sources/ProcedureKit/ProcedureEventQueue.swift
@@ -203,6 +203,10 @@ internal extension EventQueue {
             originalQueue.queue.resume()
         }
     }
+
+    func makeTimerSource(flags: DispatchSource.TimerFlags = []) -> DispatchSourceTimer {
+        return DispatchSource.makeTimerSource(flags: flags, queue: queue)
+    }
 }
 
 // MARK: - QueueProvider


### PR DESCRIPTION
Fix a (rare) data race in `DelayProcedure` (discovered via Thread Sanitizer) by ensuring that the `DispatchSourceTimer` is initialized to use the `DelayProcedure`’s internal EventQueue. (The race involved the release of the `DispatchSourceTimer`’s `eventHandler` block.)