### PR TITLE
Improve .then { } API

### DIFF
--- a/Sources/ProcedureKit/Collection+ProcedureKit.swift
+++ b/Sources/ProcedureKit/Collection+ProcedureKit.swift
@@ -43,27 +43,24 @@ extension Collection where Iterator.Element: Operation {
     }
 
     /**
-     Add the last operation of the receiver as a dependency of each element
-     of the argument sequence. An Array of the receiver extended by the argument is
-     returned.
-     - parameter operation: the Iterator.Element instance to add
-         the receiver as a dependency.
+     Add the operations of the receiver as dependencies of each element of the argument sequence.
+     An Array of the receiver extended by the argument is returned.
+     - parameter operation: the Iterator.Element instance to add the receiver as a dependency.
      - returns: an array of all operations operations.
      */
     public func then<S: Sequence>(do sequence: S) -> [Iterator.Element] where S.Iterator.Element == Iterator.Element {
         var operations = Array(self)
-        if let last = operations.last {
-            assert(!last.isFinished, "Cannot add a finished operation as a dependency.")
-            sequence.forEach { $0.add(dependency: last) }
+        for operation in self {
+            assert(!operation.isFinished, "Cannot add a finished operation as a dependency.")
+            sequence.forEach { $0.add(dependency: operation) }
         }
         operations += sequence
         return operations
     }
 
     /**
-     Add the last operation of the receiver as a dependency of each element
-     of the argument. An Array of the receiver extended by the argument is
-     returned.
+     Add the operations of the receiver as dependencies of each element of the argument.
+     An Array of the receiver extended by the argument is returned.
      - parameter operations: a variable argument of Iterator.Element instance(s) to
          add the receiver as a dependency.
      - returns: an array of all operations.


### PR DESCRIPTION
### Overview:

When the `.then` API is used with a Collection of Operations, **_all_** the operations in the receiver (collection) should be added as dependencies of the argument.

### Details:

Originally, the `.then { }` API was created to solve a particular use case (#176), in which single operation after single operation would be joined into a chain of dependencies, all using the `.then { }` API.

The initial implementation:

- Took the last Operation in a chain (collection), and added it as a dependency to the argument.

So, if it is used as the initial example use-case suggested, it would succeed as expected:

```swift
static func sequenceOfOperations(completionHandler: () -> ()) {
    sharedManager.addOperations(InterruptibleNetworkOperation<HTTPBinResponse>(request: APIRouter.GET)
        .then { InterruptibleNetworkOperation<HTTPBinResponse>(request: APIRouter.GET) }
        .then { InterruptibleNetworkOperation<HTTPBinResponse>(request: APIRouter.GET) }
        .then { BlockOperation(mainQueueBlock: completionHandler) }, waitUntilFinished: false)
}
```

However, this initial implementation does not function as intended in other use-cases. For example:

```swift
let procedure1 = BlockProcedure { ... }
let procedure2 = BlockProcedure { ... }
let procedure3 = BlockProcedure { ... }
let all = [procedure1, procedure2].then(do: procedure3)
```

It seems fairly clear from looking at this code that the *intent* is that `procedure3` should occur after *both* `procedure1` **and** `procedure2`.

But the initial implementation will only add `procedure2` (the last item in the collection) as a dependency to `procedure3`. `procedure3` very well could end up executing concurrently with or before `procedure1`.

This was caught because `test__operation_added_to_array_using_then` would occasionally fail. The original implementation of the test could rarely catch the fact that `another` was not guaranteed to execute after `one` or `two` (only `procedure`).

This PR changes the implementation of the `.then` API to resolve this issue, and increases the robustness of the test.