### PR TITLE
Improve ProcessProcedure

### DIFF
--- a/Sources/ProcedureKitMac/Process.swift
+++ b/Sources/ProcedureKitMac/Process.swift
@@ -11,33 +11,146 @@
 
 import Dispatch
 
-open class ProcessProcedure: Procedure {
+open class ProcessProcedure: Procedure, InputProcedure, OutputProcedure {
+
+    public struct LaunchRequest {
+        /// (Read-only) The path to the executable to be launched.
+        let launchPath: String
+
+        /// (Read-only) The command arguments that should be used to launch the executable.
+        let arguments: [String]?
+
+        /// (Read-only) The current directory to be used when launching the executable.
+        let currentDirectoryPath: String?
+
+        /// (Read-only) The environment to be used when launching the executable.
+        let environment: [String : String]?
+
+        /// (Read-only) The standard error (FileHandle or Pipe object).
+        let standardError: Any?
+
+        /// (Read-only) The standard input (FileHandle or Pipe object).
+        let standardInput: Any?
+
+        /// (Read-only) The standard output (FileHandle or Pipe object).
+        let standardOutput: Any?
+
+        /// Initialize a request to launch a Process.
+        ///
+        /// The minimum required parameter is a path to the executable to launch (`launchPath`).
+        ///
+        /// Other parameters are optional, and are described in full in the documentation
+        /// for NSTask/Process: https://developer.apple.com/reference/foundation/process
+        ///
+        /// By default, `Process` inherits the environment and some other parameters from the current process.
+        ///
+        /// - Parameters:
+        ///   - launchPath: the path to the executable to be launched.
+        ///   - arguments: (optional) the command arguments that should be used to launch the executable.
+        ///   - currentDirectoryPath: (optional) the current directory to be used when launching the executable.
+        ///   - environment: (optional) the environment to be used when launching the executable.
+        ///   - standardError: (optional) the standard error (FileHandle or Pipe object)
+        ///   - standardInput: (optional) the standard input (FileHandle or Pipe object)
+        ///   - standardOutput: (optional) the standard output (FileHandle or Pipe object)
+        init(launchPath: String, arguments: [String]? = nil, currentDirectoryPath: String? = nil, environment: [String : String]? = nil, standardError: Any? = nil, standardInput: Any? = nil, standardOutput: Any? = nil) {
+            self.launchPath = launchPath
+            self.arguments = arguments
+            self.currentDirectoryPath = currentDirectoryPath
+            self.environment = environment
+            self.standardError = standardError
+            self.standardInput = standardInput
+            self.standardOutput = standardOutput
+        }
+    }
+
+    public struct TerminationResult {
+        let status: Int32
+        let reason: Process.TerminationReason
+    }
 
     /// Error type for ProcessProcedure
     public enum Error: Swift.Error, Equatable {
-        case terminationReason(Process.TerminationReason)
+        case didNotExitCleanly(Int32, Process.TerminationReason)
 
         public static func == (lhs: ProcessProcedure.Error, rhs: ProcessProcedure.Error) -> Bool {
             switch (lhs, rhs) {
-            case let (.terminationReason(lhsReason), .terminationReason(rhsReason)):
-                return lhsReason == rhsReason
+            case let (.didNotExitCleanly(lhsStatus, lhsReason), .didNotExitCleanly(rhsStatus, rhsReason)):
+                return (lhsReason == rhsReason) && (lhsStatus == rhsStatus)
             }
         }
     }
 
-    /// Closure type for testing if the task did exit cleanly
-    public typealias ProcessDidExitCleanly = (Int) -> Bool
+    /// Closure type for processDidLaunch event
+    public typealias ProcessDidLaunch = (ProcessProcedure) -> Void
+
+    /// Closure type for determining whether the process exited cleanly
+    /// - Parameters:
+    ///   - Process.terminationStatus (In32)
+    ///   - Process.terminationReason (Process.TerminationReason)
+    /// - returns Bool: `true` if the Process exited cleanly, `false` otherwise
+    public typealias ProcessDidExitCleanly = (Int32, Process.TerminationReason) -> Bool
 
     /// The default closure for checking the exit status
-    public static let defaultProcessDidExitCleanly: ProcessDidExitCleanly = { status in
-        switch status {
-        case 0: return true
-        default: return false
+    public static let defaultProcessDidExitCleanly: ProcessDidExitCleanly = { status, reason in
+        switch reason {
+        case .uncaughtSignal: return false
+        case .exit:
+            switch status {
+            case 0: return true
+            default: return false
+            }
         }
     }
 
-    // - returns process: the Process
-    fileprivate let process: Process
+    /// The LaunchRequest used to launch a Process.
+    public var input: Pending<LaunchRequest> {
+        get { return stateLock.withCriticalScope { _input } }
+        set {
+            assert(!isExecuting, "Changing the input on a ProcessProcedure after it has started to execute will not have any effect.")
+            assert(!isFinished, "Changing the input on a ProcessProcedure after it has finished will not have any effect.")
+            stateLock.withCriticalScope {
+                _input = newValue
+            }
+        }
+    }
+
+    /// The ProcessProcedure result.
+    ///
+    /// On success (determined by the `processDidExitCleanly` handler), it will
+    /// be set to `.success(TerminationResult)`.
+    ///
+    /// If the `processDidExitCleanly` handler returns `false`, `output` will
+    /// bet set to `.failure(ProcessProcedure.Error.didNotExitCleanly)`.
+    ///
+    /// Both `TerminationResult` and `ProcessProcedure.Error.didNotExitCleanly`
+    /// provide the Process `terminationStatus` and `terminationReason`.
+    public var output: Pending<ProcedureResult<TerminationResult>> {
+        get { return stateLock.withCriticalScope { _output } }
+        set {
+            stateLock.withCriticalScope {
+                _output = newValue
+            }
+        }
+    }
+
+    // - returns process: the Process   // internal for testing
+    internal fileprivate(set) var process: Process? {
+        get { return stateLock.withCriticalScope { _process } }
+        set {
+            stateLock.withCriticalScope {
+                _process = newValue
+            }
+        }
+    }
+
+    fileprivate var _process: Process?
+    fileprivate var _processIdentifier: Int32 = 0
+    fileprivate var _input: Pending<LaunchRequest> = .pending
+    fileprivate var _output: Pending<ProcedureResult<TerminationResult>> = .pending
+    fileprivate let stateLock = PThreadMutex()
+
+    /// - the closure that is called once the Process has been launched
+    private let processDidLaunch: ProcessDidLaunch
 
     /// - returns processDidExitCleanly: the closure for exiting cleanly.
     private let processDidExitCleanly: ProcessDidExitCleanly
@@ -59,54 +172,67 @@ open class ProcessProcedure: Procedure {
     ///   - standardError: (optional) the standard error (FileHandle or Pipe object)
     ///   - standardInput: (optional) the standard input (FileHandle or Pipe object)
     ///   - standardOutput: (optional) the standard output (FileHandle or Pipe object)
-    ///   - processDidExitCleanly: a ProcessDidExitCleanly closure with a default.
-    public init(launchPath: String, arguments: [String]? = nil, currentDirectoryPath: String? = nil, environment: [String : String]? = nil, standardError: Any? = nil, standardInput: Any? = nil, standardOutput: Any? = nil, processDidExitCleanly: @escaping ProcessDidExitCleanly = ProcessProcedure.defaultProcessDidExitCleanly) {
+    ///   - processDidLaunch: a ProcessDidLaunch block that is called once the Process has been launched.
+    ///   - processDidExitCleanly: a ProcessDidExitCleanly block that is called once the Process has terminated, and is used to determine whether the ProcessProcedure finishes with an error.
+    public convenience init(launchPath: String, arguments: [String]? = nil, currentDirectoryPath: String? = nil, environment: [String : String]? = nil, standardError: Any? = nil, standardInput: Any? = nil, standardOutput: Any? = nil, processDidLaunch: @escaping ProcessDidLaunch = { _ in }, processDidExitCleanly: @escaping ProcessDidExitCleanly = ProcessProcedure.defaultProcessDidExitCleanly) {
 
-        let process = Process()
-        process.launchPath = launchPath
-        if let arguments = arguments {
-            process.arguments = arguments
-        }
-        if let currentDirectoryPath = currentDirectoryPath {
-            process.currentDirectoryPath = currentDirectoryPath
-        }
-        if let environment = environment {
-            process.environment = environment
-        }
-        if let standardError = standardError {
-            process.standardError = standardError
-        }
-        if let standardInput = standardInput {
-            process.standardInput = standardInput
-        }
-        if let standardOutput = standardOutput {
-            process.standardOutput = standardOutput
-        }
+        let launchRequest = LaunchRequest(launchPath: launchPath, arguments: arguments, currentDirectoryPath: currentDirectoryPath, environment: environment, standardError: standardError, standardInput: standardInput, standardOutput: standardOutput)
 
-        self.process = process
+        self.init(launchRequest: launchRequest, processDidLaunch: processDidLaunch, processDidExitCleanly: processDidExitCleanly)
+    }
+
+    /// Initialize a ProcessProcedure.
+    ///
+    /// A LaunchRequest must be provided before the ProcessProcedure executes.
+    /// It can be provided up-front, via this initializer, or later via result injection.
+    ///
+    /// Optionally, a `processDidLaunch` and/or `processDidExitCleanly` handler may be
+    /// provided.
+    ///
+    /// The `processDidLaunch` and `processDidExitCleanly` handlers are executed
+    /// on the ProcessProcedure's internal EventQueue.
+    ///
+    /// - Parameters:
+    ///   - launchRequest: a `LaunchRequest` containing the parameters used to launch a Process
+    ///   - processDidLaunch: a ProcessDidLaunch block that is called once the Process has been launched.
+    ///   - processDidExitCleanly: a ProcessDidExitCleanly block that is called once the Process has terminated, and is used to determine whether the ProcessProcedure finishes with an error.
+    public init(launchRequest: LaunchRequest? = nil, processDidLaunch: @escaping ProcessDidLaunch = { _ in }, processDidExitCleanly: @escaping ProcessDidExitCleanly = ProcessProcedure.defaultProcessDidExitCleanly) {
+
+        self.processDidLaunch = processDidLaunch
         self.processDidExitCleanly = processDidExitCleanly
         super.init()
+        self.input = launchRequest.flatMap { .ready($0) } ?? .pending
 
         addDidCancelBlockObserver { procedure, _ in
             DispatchQueue.main.async {
-                guard procedure.isExecuting && procedure.process.isRunning else { return }
-                procedure.process.terminate()
+                guard let process = procedure.process else { return }
+                guard procedure.isExecuting && process.isRunning else { return }
+                process.terminate()
                 // `finish()` is handled by the process termination handler
             }
         }
     }
 
     open override func execute() {
-        // NOTE: NSTask/Process is *not* thread-safe.
+
+        guard let request = input.value else {
+            finish(withResult: .failure(ProcedureKitError.requirementNotSatisfied()))
+            return
+        }
+
+        // NOTE: NSTask / Process is *not* thread-safe.
         // See: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/Multithreading/ThreadSafetySummary/ThreadSafetySummary.html#//apple_ref/doc/uid/10000057i-CH12-125664
         //
         // It's not a good idea to call `launch()` on a thread that may disappear before the
-        // NSTask/Process goes away. Thus, we use the main queue/thread.
+        // NSTask / Process goes away. Thus, we use the main queue/thread.
 
-        DispatchQueue.onMain { [weak self] in
+        DispatchQueue.main.async { [weak self] in
             guard let procedure = self else { return }
 
-            procedure.process.terminationHandler = { [weak procedure] task in
+            // create Process
+            let process = procedure.createProcess(withRequest: request)
+
+            process.terminationHandler = { [weak procedure] process in
                 guard let procedure = procedure else { return }
 
                 guard !procedure.isCancelled else {
@@ -116,19 +242,41 @@ open class ProcessProcedure: Procedure {
                     return
                 }
 
-                if procedure.processDidExitCleanly(Int(procedure.process.terminationStatus)) {
-                    procedure.finish()
-                }
-                else {
-                    procedure.finish(withError: Error.terminationReason(procedure.process.terminationReason))
+                let terminationStatus = process.terminationStatus
+                let terminationReason = process.terminationReason
+
+                // Dispatch the `processDidExitCleanly` closure on the EventQueue
+                procedure.eventQueue.dispatch {
+
+                    if procedure.processDidExitCleanly(terminationStatus, terminationReason) {
+                        procedure.finish(withResult: .success(TerminationResult(status: terminationStatus, reason: terminationReason)))
+                    }
+                    else {
+                        procedure.finish(withResult: .failure(Error.didNotExitCleanly(terminationStatus, terminationReason)))
+                    }
                 }
             }
 
+            // The ProcessProcedure can be cancelled concurrently with this block on the main queue.
+            // Check whether the Procedure has been cancelled.
             guard !procedure.isCancelled else {
                 procedure.finish()
                 return
             }
-            procedure.process.launch()
+
+            // Store the process
+            procedure.process = process
+
+            // Launch the Process
+            process.launch()
+
+            // Store the processIdentifier
+            procedure.processIdentifier = process.processIdentifier
+
+            // Dispatch the ProcessDidLaunch callback
+            procedure.eventQueue.dispatch {
+                procedure.processDidLaunch(procedure)
+            }
         }
     }
 }
@@ -142,10 +290,17 @@ public extension ProcessProcedure {
     /// This value is 0 until the ProcessProcedure executes and starts the Process.
     ///
     /// To retrieve the processIdentifier as soon as it is available,
-    /// access it inside a DidExecuteObserver (added to the ProcessProcedure).
-    var processIdentifier: Int32 {
-        get {
-            return DispatchQueue.onMain { process.processIdentifier }
+    /// access it inside the ProcessDidLaunch callback (added to the ProcessProcedure).
+    ///
+    /// The processIdentifier remains non-zero after the ProcessProcedure starts the
+    /// Process - even after the Process terminates. Do not assume based on a non-zero
+    /// processIdentifier that the expected associated Process is still running.
+    public fileprivate(set) var processIdentifier: Int32 {
+        get { return stateLock.withCriticalScope { _processIdentifier } }
+        set {
+            stateLock.withCriticalScope {
+                _processIdentifier = newValue
+            }
         }
     }
 }
@@ -156,37 +311,37 @@ public extension ProcessProcedure {
 
     /// (Read-only) The command arguments that should be used to launch the executable.
     var arguments: [String]? {
-        get { return DispatchQueue.onMain { process.arguments } }
+        get { return input.value?.arguments }
     }
 
     /// (Read-only) The current directory to be used when launching the executable.
-    var currentDirectoryPath: String {
-        get { return DispatchQueue.onMain { process.currentDirectoryPath } }
+    var currentDirectoryPath: String? {
+        get { return input.value?.currentDirectoryPath }
     }
 
     /// (Read-only) The environment to be used when launching the executable.
     var environment: [String : String]? {
-        get { return DispatchQueue.onMain { process.environment } }
+        get { return input.value?.environment }
     }
 
     /// (Read-only) The path to the executable to be launched.
-    var launchPath: String {
-        get { return DispatchQueue.onMain { process.launchPath! } }
+    var launchPath: String? {
+        get { return input.value?.launchPath }
     }
 
     /// (Read-only) The standard error (FileHandle or Pipe object).
     var standardError: Any? {
-        get { return DispatchQueue.onMain { process.standardError } }
+        get { return input.value?.standardError }
     }
 
     /// (Read-only) The standard input (FileHandle or Pipe object).
     var standardInput: Any? {
-        get { return DispatchQueue.onMain { process.standardInput } }
+        get { return input.value?.standardInput }
     }
 
     /// (Read-only) The standard output (FileHandle or Pipe object).
     var standardOutput: Any? {
-        get { return DispatchQueue.onMain { process.standardOutput } }
+        get { return input.value?.standardOutput }
     }
 }
 
@@ -214,7 +369,7 @@ public extension ProcessProcedure {
                 completion(false)
                 return
             }
-            let result = procedure.process.resume()
+            let result = procedure.process?.resume() ?? false
             completion(result)
         }
     }
@@ -238,8 +393,36 @@ public extension ProcessProcedure {
                 completion(false)
                 return
             }
-            let result = procedure.process.suspend()
+            let result = procedure.process?.suspend() ?? false
             completion(result)
         }
+    }
+}
+
+fileprivate extension ProcessProcedure {
+
+    fileprivate func createProcess(withRequest request: LaunchRequest) -> Process {
+        let process = Process()
+
+        process.launchPath = request.launchPath
+        if let arguments = request.arguments {
+            process.arguments = arguments
+        }
+        if let currentDirectoryPath = request.currentDirectoryPath {
+            process.currentDirectoryPath = currentDirectoryPath
+        }
+        if let environment = request.environment {
+            process.environment = environment
+        }
+        if let standardError = request.standardError {
+            process.standardError = standardError
+        }
+        if let standardInput = request.standardInput {
+            process.standardInput = standardInput
+        }
+        if let standardOutput = request.standardOutput {
+            process.standardOutput = standardOutput
+        }
+        return process
     }
 }

--- a/Tests/ProcedureKitMacTests/ProcessProcedureTests.swift
+++ b/Tests/ProcedureKitMacTests/ProcessProcedureTests.swift
@@ -6,7 +6,6 @@
 
 
 import XCTest
-import ProcedureKit
 import TestingProcedureKit
 import Foundation
 @testable import ProcedureKitMac
@@ -18,6 +17,8 @@ class ProcessProcedureTests: ProcedureKitTestCase {
 
     var launchPath: String!
     var arguments: [String]!
+
+    let bashWaitIndefinitelyForInput = "read -n1 -r -p \"Wait indefinitely for input\" key"
 
     override func setUp() {
         super.setUp()
@@ -45,10 +46,10 @@ class ProcessProcedureTests: ProcedureKitTestCase {
     }
 
     func test__cancel_process_after_launched() {
-        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 2"])
-        checkAfterDidExecute(procedure: processProcedure, withTimeout: 1) { procedure in
-            procedure.cancel()
-        }
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", bashWaitIndefinitelyForInput], processDidLaunch: { processProcedure in
+                processProcedure.cancel()
+        })
+        wait(for: processProcedure, withTimeout: 1)
         XCTAssertProcedureCancelledWithoutErrors(processProcedure)
     }
 
@@ -57,16 +58,15 @@ class ProcessProcedureTests: ProcedureKitTestCase {
     }
 
     func test__processIdentifier_after_launched() {
-        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"])
         weak var didExecuteExpectation = expectation(description: "DidExecute: \(#function)")
         let processIdentifier = Protector<Int32>(-1)
-        processProcedure.addDidExecuteBlockObserver { procedure in
-            let retrievedProcessIdentifier = procedure.processIdentifier
-            processIdentifier.overwrite(with: retrievedProcessIdentifier)
-            DispatchQueue.main.async {
-                didExecuteExpectation?.fulfill()
-            }
-        }
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"], processDidLaunch: { processProcedure in
+                let retrievedProcessIdentifier = processProcedure.processIdentifier
+                processIdentifier.overwrite(with: retrievedProcessIdentifier)
+                DispatchQueue.main.async {
+                    didExecuteExpectation?.fulfill()
+                }
+        })
         wait(for: processProcedure)
         XCTAssertGreaterThan(processIdentifier.access, 0)
     }
@@ -132,18 +132,17 @@ class ProcessProcedureTests: ProcedureKitTestCase {
         let didFinishGroup = DispatchGroup()
         weak var didSuspendExpectation = expectation(description: "Did Suspend: \(#function)")
         weak var delayPassed = expectation(description: "Delay Passed: \(#function)")
-        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"])
-        processProcedure.addDidExecuteBlockObserver { procedure in
-            procedure.suspend { (success) in
-                DispatchQueue.main.async {
-                    XCTAssertTrue(success)
-                    didSuspendExpectation?.fulfill()
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "sleep 1"], processDidLaunch: { processProcedure in
+                processProcedure.suspend { (success) in
+                    DispatchQueue.main.async {
+                        XCTAssertTrue(success)
+                        didSuspendExpectation?.fulfill()
+                    }
                 }
-            }
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
-                delayPassed?.fulfill()
-            }
-        }
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5) {
+                    delayPassed?.fulfill()
+                }
+        })
         didFinishGroup.enter()
         processProcedure.addDidFinishBlockObserver { procedure, _ in
             didFinishGroup.leave()
@@ -166,6 +165,56 @@ class ProcessProcedureTests: ProcedureKitTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
         XCTAssertTrue(processProcedure.isFinished)
+    }
+
+    // MARK: - ProcessDidExitCleanly closure
+
+    func test__process_did_exit_cleanly_closure_receives_expected_exit_status_input() {
+        let exitStatus: Int32 = 5
+        let receivedStatus = Protector<Int32?>(nil)
+        let receivedReason = Protector<Process.TerminationReason?>(nil)
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "exit \(exitStatus)"], processDidExitCleanly: { status, reason in
+            receivedStatus.overwrite(with: status)
+            receivedReason.overwrite(with: reason)
+            return false
+        })
+        wait(for: processProcedure)
+
+        guard let status = receivedStatus.access, let reason = receivedReason.access else {
+            XCTFail("processDidExitCleanly closure was not called. status and/or reason are nil.")
+            return
+        }
+        XCTAssertEqual(status, exitStatus, "processDidExitCleanly closure did not receive expected status (\(exitStatus)); instead, received: \(status))")
+        XCTAssertEqual(reason, .exit, "processDidExitCleanly closure did not receive expected reason (.exit); instead, received: \(reason))")
+        XCTAssertProcedureFinishedWithErrors(processProcedure, count: 1)
+        XCTAssertEqual(processProcedure.errors.first as? ProcessProcedure.Error, ProcessProcedure.Error.didNotExitCleanly(exitStatus, .exit))
+    }
+
+    func test__process_did_exit_cleanly_closure_receives_expected_uncaught_signal_input() {
+        let receivedStatus = Protector<Int32?>(nil)
+        let receivedReason = Protector<Process.TerminationReason?>(nil)
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", bashWaitIndefinitelyForInput], processDidLaunch: { processProcedure in
+            guard let process = processProcedure.process else { assertionFailure("ProcessProcedure.process does not exist"); return }
+            DispatchQueue.main.async {
+                // Send SIGTERM to the ProcessProcedure's internal Process
+                // NOTE: This is only for testing. User code should use `ProcessProcedure.cancel()`.
+                process.terminate()
+            }
+        }, processDidExitCleanly: { status, reason in
+            receivedStatus.overwrite(with: status)
+            receivedReason.overwrite(with: reason)
+            return false
+        })
+        wait(for: processProcedure)
+
+        guard let status = receivedStatus.access, let reason = receivedReason.access else {
+            XCTFail("processDidExitCleanly closure was not called. status and/or reason are nil.")
+            return
+        }
+        XCTAssertEqual(status, SIGTERM, "processDidExitCleanly closure did not receive expected status (\(SIGTERM)); instead, received: \(status))")
+        XCTAssertEqual(reason, .uncaughtSignal, "processDidExitCleanly closure did not receive expected reason (.uncaughtSignal); instead, received: \(reason))")
+        XCTAssertProcedureFinishedWithErrors(processProcedure, count: 1)
+        XCTAssertEqual(processProcedure.errors.first as? ProcessProcedure.Error, ProcessProcedure.Error.didNotExitCleanly(SIGTERM, .uncaughtSignal))
     }
 
     // MARK: - Configuration Properties (Read-only)
@@ -232,5 +281,67 @@ class ProcessProcedureTests: ProcedureKitTestCase {
             return
         }
         XCTAssertEqual(readValueAsPipe, pipe)
+    }
+
+    // MARK: - Finishing
+
+    func test__no_requirement__finishes_with_error() {
+        processProcedure = ProcessProcedure()
+        wait(for: processProcedure)
+        XCTAssertProcedureFinishedWithErrors(processProcedure, count: 1)
+        XCTAssertEqual(processProcedure.errors.first as? ProcedureKitError, ProcedureKitError.requirementNotSatisfied())
+    }
+
+    func test__process_exit_status_1__finishes_with_error() {
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "exit 1"])
+        wait(for: processProcedure)
+        XCTAssertProcedureFinishedWithErrors(processProcedure, count: 1)
+        XCTAssertEqual(processProcedure.errors.first as? ProcessProcedure.Error, ProcessProcedure.Error.didNotExitCleanly(1, .exit))
+    }
+
+    func test__process_terminated_with_uncaught_signal__finishes_with_error() {
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", bashWaitIndefinitelyForInput], processDidLaunch: { processProcedure in
+            guard let process = processProcedure.process else { assertionFailure("ProcessProcedure.process does not exist"); return }
+            DispatchQueue.main.async {
+                // Send SIGTERM to the ProcessProcedure's internal Process
+                // NOTE: This is only for testing. User code should use `ProcessProcedure.cancel()`.
+                process.terminate()
+            }
+        })
+        wait(for: processProcedure)
+        XCTAssertProcedureFinishedWithErrors(processProcedure, count: 1)
+        XCTAssertEqual(processProcedure.errors.first as? ProcessProcedure.Error, ProcessProcedure.Error.didNotExitCleanly(SIGTERM, .uncaughtSignal))
+    }
+
+    func test__process_did_exit_cleanly_closure_false__finishes_with_error() {
+        let didCallClosure = Protector(false)
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "exit 0"], processDidExitCleanly: { _, _ in
+            didCallClosure.overwrite(with: true)
+            return false
+        })
+        wait(for: processProcedure)
+        XCTAssertTrue(didCallClosure.access, "processDidExitCleanly closure was not called.")
+        XCTAssertProcedureFinishedWithErrors(processProcedure, count: 1)
+        XCTAssertEqual(processProcedure.errors.first as? ProcessProcedure.Error, ProcessProcedure.Error.didNotExitCleanly(0, .exit))
+    }
+
+    func test__process_did_exit_cleanly_closure_true__finishes_without_error() {
+        let didCallClosure = Protector(false)
+        processProcedure = ProcessProcedure(launchPath: "/bin/bash/", arguments: ["-c", "exit 1"], processDidExitCleanly: { _, _ in
+            didCallClosure.overwrite(with: true)
+            return true
+        })
+        wait(for: processProcedure)
+        XCTAssertTrue(didCallClosure.access, "processDidExitCleanly closure was not called.")
+        XCTAssertProcedureFinishedWithoutErrors(processProcedure)
+    }
+}
+
+extension Process.TerminationReason: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .exit: return ".exit"
+        case .uncaughtSignal: return ".uncaughtSignal"
+        }
     }
 }


### PR DESCRIPTION
**New Features**:
- `ProcessProcedure` now conforms to **`InputProcedure`**, and the `LaunchRequest` can be provided via result injection.
- `ProcessProcedure` now conforms to **`OutputProcedure`**.
- `ProcessProcedure` explicitly handles termination due to uncaught signals by default.
- `ProcessProcedure` dispatches the `processDidExitCleanly` and `processDidLaunch ` handlers on its internal, serial EventQueue.
- **`processDidLaunch`** handler: execute code after the `ProcessProcedure` starts its Process

**Breaking Changes**:
- `ProcessProcedure` now provides the `Process.terminationStatus` **and** the `Process.terminationReason` to the **`processDidExitCleanly`** handler:
    ```diff
    - public typealias ProcessDidExitCleanly = (Int) -> Bool
    + public typealias ProcessDidExitCleanly = (Int32, Process.TerminationReason) -> Bool
    ```
- `DidExecute` observers are no longer guaranteed to execute after the Process has successfully started.
    - **Solution**: Use a **`processDidLaunch`** handler.
- `ProcessProcedure` is now stricter about what constitutes a valid `launchPath`, and checks that the `launchPath` is executable (at least at some point in time) before handing it off to `Process` internally. This enables `ProcessProcedure` to catch more common programmer errors, and provide a descriptive error to aide debugging (instead of just allowing Process / NSTask to throw an Objective-C exception that leads to a crash), but is not an exhaustive check of situations that can lead to Process / NSTask throwing an exception internally.

**Other Changes**:
- `ProcessProcedure` no longer uses `DispatchQueue.onMain` internally - instead, it async dispatches to the main queue.
- Lots of additional tests and improved tests.