### PR TITLE
Fix a memory cycle in the testing framework helpers

### DIFF
--- a/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
+++ b/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
@@ -131,7 +131,8 @@ open class ProcedureKitTestCase: XCTestCase {
         // Adds a will add operation observer, which adds the produced operation as a dependency
         // of the finishing procedure. This way, we don't actually finish, until the
         // procedure, and any produced operations also finish.
-        procedure.addWillAddOperationBlockObserver { _, operation in
+        procedure.addWillAddOperationBlockObserver { [weak weakFinishing = finishing] _, operation in
+            guard let finishing = weakFinishing else { fatalError("Finishing procedure is finished + gone, but a WillAddOperation observer on a dependency was called. This should never happen.") }
             finishing.add(dependency: operation)
         }
         finishing.name = "FinishingBlockProcedure(for: \(procedure.operationName))"


### PR DESCRIPTION
`makeFinishingProcedure` previously created a memory cycle by:
1. Adding the target procedure as a dependency of the `finishingProcedure` (strong reference: `finishingProcedure` -> `target`)
2. Adding a ‘WillAddOperation’ observer to the target procedure that captured the `finishingProcedure` (strong reference: `target` ->`finishingProcedure`)