### PR TITLE
Resolve redundant conformance constraints [Swift 4]

### DIFF
--- a/Sources/ProcedureKit/Collection+ProcedureKit.swift
+++ b/Sources/ProcedureKit/Collection+ProcedureKit.swift
@@ -90,7 +90,7 @@ extension Collection where Iterator.Element: Operation {
 
 // MARK: - OutputProcedure & Gathering
 
-extension Collection where Iterator.Element: ProcedureProtocol, Iterator.Element: OutputProcedure {
+extension Collection where Iterator.Element: OutputProcedure {
 
     /// Creates a new procedure which will flatmap the non-nil results of the receiver's procedures into a
     /// new array. This new array is available as the result of the returned procedure.

--- a/Sources/ProcedureKit/Condition.swift
+++ b/Sources/ProcedureKit/Condition.swift
@@ -852,7 +852,7 @@ public func || (lhs: Condition, rhs: Condition) -> OrCondition {
     return OrCondition([lhs, rhs])
 }
 
-public prefix func !<T: Condition>(rhs: T) -> NegatedCondition<T> {
+public prefix func !<T>(rhs: T) -> NegatedCondition<T> {
     return NegatedCondition(rhs)
 }
 

--- a/Sources/ProcedureKitCloud/CKAcceptSharesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKAcceptSharesOperation.swift
@@ -58,7 +58,7 @@ extension CKProcedure where T: CKAcceptSharesOperationProtocol, T: AssociatedErr
     }
 }
 
-extension CloudKitProcedure where T: CKAcceptSharesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKAcceptSharesOperationProtocol {
 
     /// A typealias for the block type used by CloudKitOperation<CKAcceptSharesOperationType>
     public typealias AcceptSharesPerShareCompletionBlock = (T.ShareMetadata, T.Share?, Error?) -> Void

--- a/Sources/ProcedureKitCloud/CKDiscoverAllContactsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKDiscoverAllContactsOperation.swift
@@ -49,7 +49,7 @@ extension CKProcedure where T: CKDiscoverAllContactsOperationProtocol, T: Associ
     }
 }
 
-extension CloudKitProcedure where T: CKDiscoverAllContactsOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKDiscoverAllContactsOperationProtocol {
 
     /// A typealias for the block type used by CloudKitOperation<CKDiscoverAllContactsOperation>
     public typealias DiscoverAllContactsCompletionBlock = ([T.DiscoveredUserInfo]?) -> Void

--- a/Sources/ProcedureKitCloud/CKDiscoverAllUserIdentitiesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKDiscoverAllUserIdentitiesOperation.swift
@@ -49,7 +49,7 @@ extension CKProcedure where T: CKDiscoverAllUserIdentitiesOperationProtocol, T: 
     }
 }
 
-extension CloudKitProcedure where T: CKDiscoverAllUserIdentitiesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKDiscoverAllUserIdentitiesOperationProtocol {
 
     /// A typealias for the block type used by CloudKitOperation<CKDiscoverAllUserIdentitiesOperationType>
     public typealias DiscoverAllUserIdentitiesUserIdentityDiscoveredBlock = (T.UserIdentity) -> Void

--- a/Sources/ProcedureKitCloud/CKDiscoverUserIdentitiesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKDiscoverUserIdentitiesOperation.swift
@@ -55,7 +55,7 @@ extension CKProcedure where T: CKDiscoverUserIdentitiesOperationProtocol, T: Ass
     }
 }
 
-extension CloudKitProcedure where T: CKDiscoverUserIdentitiesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKDiscoverUserIdentitiesOperationProtocol {
 
     /// A typealias for the block type used by CloudKitOperation<CKDiscoverUserIdentitiesOperationType>
     public typealias DiscoverUserIdentitiesUserIdentityDiscoveredBlock = (T.UserIdentity, T.UserIdentityLookupInfo) -> Void

--- a/Sources/ProcedureKitCloud/CKDiscoverUserInfosOperation.swift
+++ b/Sources/ProcedureKitCloud/CKDiscoverUserInfosOperation.swift
@@ -64,7 +64,7 @@ extension CKProcedure where T: CKDiscoverUserInfosOperationProtocol, T: Associat
     }
 }
 
-extension CloudKitProcedure where T: CKDiscoverUserInfosOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKDiscoverUserInfosOperationProtocol {
 
     /// A typealias for the block type used by CloudKitOperation<CKDiscoverUserInfosOperation>
     public typealias DiscoverUserInfosCompletionBlock = ([String: T.DiscoveredUserInfo]?, [T.RecordID: T.DiscoveredUserInfo]?) -> Void

--- a/Sources/ProcedureKitCloud/CKFetchDatabaseChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchDatabaseChangesOperation.swift
@@ -96,7 +96,7 @@ extension CKProcedure where T: CKFetchDatabaseChangesOperationProtocol, T: Assoc
     }
 }
 
-extension CloudKitProcedure where T: CKFetchDatabaseChangesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKFetchDatabaseChangesOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKFetchDatabaseChangesOperationType>
     public typealias FetchDatabaseChangesRecordZoneWithIDChangedBlock = (T.RecordZoneID) -> Void

--- a/Sources/ProcedureKitCloud/CKFetchNotificationChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchNotificationChangesOperation.swift
@@ -52,7 +52,7 @@ extension CKProcedure where T: CKFetchNotificationChangesOperationProtocol, T: A
     }
 }
 
-extension CloudKitProcedure where T: CKFetchNotificationChangesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKFetchNotificationChangesOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKFetchNotificationChangesOperation>
     public typealias FetchNotificationChangesChangedBlock = (T.Notification) -> Void

--- a/Sources/ProcedureKitCloud/CKFetchRecordChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchRecordChangesOperation.swift
@@ -76,7 +76,7 @@ extension CKProcedure where T: CKFetchRecordChangesOperationProtocol, T: Associa
     }
 }
 
-extension CloudKitProcedure where T: CKFetchRecordChangesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKFetchRecordChangesOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKFetchRecordChangesOperation>
     public typealias FetchRecordChangesRecordChangedBlock = (T.Record) -> Void

--- a/Sources/ProcedureKitCloud/CKFetchRecordZoneChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchRecordZoneChangesOperation.swift
@@ -103,7 +103,7 @@ extension CKProcedure where T: CKFetchRecordZoneChangesOperationProtocol, T: Ass
     }
 }
 
-extension CloudKitProcedure where T: CKFetchRecordZoneChangesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKFetchRecordZoneChangesOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKFetchRecordZoneChangesOperationType>
     public typealias FetchRecordZoneChangesRecordChangedBlock = (T.Record) -> Void

--- a/Sources/ProcedureKitCloud/CKFetchRecordZonesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchRecordZonesOperation.swift
@@ -52,7 +52,7 @@ extension CKProcedure where T: CKFetchRecordZonesOperationProtocol, T: Associate
     }
 }
 
-extension CloudKitProcedure where T: CKFetchRecordZonesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKFetchRecordZonesOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKFetchRecordZonesOperation>
     public typealias FetchRecordZonesCompletionBlock = ([T.RecordZoneID: T.RecordZone]?) -> Void

--- a/Sources/ProcedureKitCloud/CKFetchRecordsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchRecordsOperation.swift
@@ -68,7 +68,7 @@ extension CKProcedure where T: CKFetchRecordsOperationProtocol, T: AssociatedErr
     }
 }
 
-extension CloudKitProcedure where T: CKFetchRecordsOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKFetchRecordsOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKFetchRecordsOperation>
     public typealias FetchRecordsPerRecordProgressBlock = (T.RecordID, Double) -> Void

--- a/Sources/ProcedureKitCloud/CKFetchShareMetadataOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchShareMetadataOperation.swift
@@ -74,7 +74,7 @@ extension CKProcedure where T: CKFetchShareMetadataOperationProtocol, T: Associa
     }
 }
 
-extension CloudKitProcedure where T: CKFetchShareMetadataOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKFetchShareMetadataOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKFetchShareMetadataOperationType>
     public typealias FetchShareMetadataPerShareMetadataBlock = (URL, T.ShareMetadata?, Error?) -> Void

--- a/Sources/ProcedureKitCloud/CKFetchShareParticipantsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchShareParticipantsOperation.swift
@@ -58,7 +58,7 @@ extension CKProcedure where T: CKFetchShareParticipantsOperationProtocol, T: Ass
     }
 }
 
-extension CloudKitProcedure where T: CKFetchShareParticipantsOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKFetchShareParticipantsOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKFetchShareMetadataOperationType>
     public typealias FetchShareParticipantsParticipantFetchedBlock = (T.ShareParticipant) -> Void

--- a/Sources/ProcedureKitCloud/CKFetchSubscriptionsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchSubscriptionsOperation.swift
@@ -54,7 +54,7 @@ extension CKProcedure where T: CKFetchSubscriptionsOperationProtocol, T: Associa
     }
 }
 
-extension CloudKitProcedure where T: CKFetchSubscriptionsOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKFetchSubscriptionsOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKFetchSubscriptionsOperation>
     public typealias FetchSubscriptionCompletionBlock = ([String: T.Subscription]?) -> Void

--- a/Sources/ProcedureKitCloud/CKMarkNotificationsReadOperation.swift
+++ b/Sources/ProcedureKitCloud/CKMarkNotificationsReadOperation.swift
@@ -55,7 +55,7 @@ extension CKProcedure where T: CKMarkNotificationsReadOperationProtocol, T: Asso
     }
 }
 
-extension CloudKitProcedure where T: CKMarkNotificationsReadOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKMarkNotificationsReadOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKMarkNotificationsReadOperation>
     public typealias MarkNotificationsReadCompletionBlock = ([T.NotificationID]?) -> Void

--- a/Sources/ProcedureKitCloud/CKModifyBadgeOperation.swift
+++ b/Sources/ProcedureKitCloud/CKModifyBadgeOperation.swift
@@ -46,7 +46,7 @@ extension CKProcedure where T: CKModifyBadgeOperationProtocol, T: AssociatedErro
     }
 }
 
-extension CloudKitProcedure where T: CKModifyBadgeOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKModifyBadgeOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKModifyBadgeOperation>
     public typealias ModifyBadgeCompletionBlock = () -> Void

--- a/Sources/ProcedureKitCloud/CKModifyRecordZonesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKModifyRecordZonesOperation.swift
@@ -61,7 +61,7 @@ extension CKProcedure where T: CKModifyRecordZonesOperationProtocol, T: Associat
     }
 }
 
-extension CloudKitProcedure where T: CKModifyRecordZonesOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKModifyRecordZonesOperationProtocol {
 
     internal typealias ModifyRecordZonesCompletion = ([T.RecordZone]?, [T.RecordZoneID]?)
 

--- a/Sources/ProcedureKitCloud/CKModifyRecordsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKModifyRecordsOperation.swift
@@ -104,7 +104,7 @@ extension CKProcedure where T: CKModifyRecordsOperationProtocol, T: AssociatedEr
     }
 }
 
-extension CloudKitProcedure where T: CKModifyRecordsOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKModifyRecordsOperationProtocol {
 
     internal typealias ModifyRecordsPerRecordProgress = (T.Record, Double)
     internal typealias ModifyRecordsPerRecordCompletion = (T.Record?, Error?)

--- a/Sources/ProcedureKitCloud/CKModifySubscriptionsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKModifySubscriptionsOperation.swift
@@ -63,7 +63,7 @@ extension CKProcedure where T: CKModifySubscriptionsOperationProtocol, T: Associ
     }
 }
 
-extension CloudKitProcedure where T: CKModifySubscriptionsOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKModifySubscriptionsOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKModifySubscriptionsOperation>
     public typealias ModifySubscriptionsCompletionBlock = ([T.Subscription]?, [String]?) -> Void

--- a/Sources/ProcedureKitCloud/CKOperation.swift
+++ b/Sources/ProcedureKitCloud/CKOperation.swift
@@ -175,7 +175,7 @@ extension CKOperation: CKOperationProtocol {
     public typealias ShareParticipant = CKShareParticipant
 }
 
-extension CKProcedure where T: CKOperationProtocol {
+extension CKProcedure {
 
     public var container: T.Container? {
         get { return operation.container }
@@ -217,7 +217,7 @@ extension CKProcedure where T: CKOperationProtocol {
     }
 }
 
-extension CloudKitProcedure where T: CKOperationProtocol {
+extension CloudKitProcedure {
 
     /// - returns: the CloudKit container
     public var container: T.Container? {

--- a/Sources/ProcedureKitCloud/CKQueryOperation.swift
+++ b/Sources/ProcedureKitCloud/CKQueryOperation.swift
@@ -76,7 +76,7 @@ extension CKProcedure where T: CKQueryOperationProtocol, T: AssociatedErrorProto
     }
 }
 
-extension CloudKitProcedure where T: CKQueryOperationProtocol, T: AssociatedErrorProtocol, T.AssociatedError: CloudKitError {
+extension CloudKitProcedure where T: CKQueryOperationProtocol {
 
     /// A typealias for the block types used by CloudKitOperation<CKQueryOperation>
     public typealias QueryRecordFetchedBlock = (T.Record) -> Void

--- a/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
+++ b/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
@@ -86,7 +86,7 @@ open class ProcedureKitTestCase: XCTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
-    public func checkAfterDidExecute<T: ProcedureProtocol>(procedure: T, withTimeout timeout: TimeInterval = 3, withExpectationDescription expectationDescription: String = #function, checkAfterDidExecuteBlock: @escaping (T) -> Void) where T: Procedure {
+    public func checkAfterDidExecute<T>(procedure: T, withTimeout timeout: TimeInterval = 3, withExpectationDescription expectationDescription: String = #function, checkAfterDidExecuteBlock: @escaping (T) -> Void) where T: Procedure {
         addCompletionBlockTo(procedure: procedure, withExpectationDescription: expectationDescription)
         procedure.addDidExecuteBlockObserver { (procedure) in
             checkAfterDidExecuteBlock(procedure)

--- a/Sources/TestingProcedureKit/XCTAsserts.swift
+++ b/Sources/TestingProcedureKit/XCTAsserts.swift
@@ -214,7 +214,7 @@ public extension ProcedureKitTestCase {
 
 public extension ProcedureKitTestCase {
 
-    func XCTAssertProcedureFinishedWithoutErrors<T: ProcedureProtocol>(_ exp: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where T: TestProcedure {
+    func XCTAssertProcedureFinishedWithoutErrors<T>(_ exp: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where T: TestProcedure {
         __XCTEvaluateAssertion(testCase: self, message, file: file, line: line) {
             let procedure = try exp()
             guard !procedure.failed else {
@@ -233,7 +233,7 @@ public extension ProcedureKitTestCase {
         }
     }
 
-    func XCTAssertProcedureCancelledWithoutErrors<T: ProcedureProtocol>(_ exp: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where T: TestProcedure {
+    func XCTAssertProcedureCancelledWithoutErrors<T>(_ exp: @autoclosure () throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where T: TestProcedure {
         __XCTEvaluateAssertion(testCase: self, message, file: file, line: line) {
             let procedure = try exp()
             guard !procedure.failed else {
@@ -285,7 +285,7 @@ public extension ProcedureKitTestCase {
 
 public extension ProcedureKitTestCase {
 
-    func XCTAssertProcedureNoConcurrentEvents<T: ProcedureProtocol & EventConcurrencyTrackingProcedureProtocol>(_ exp: @autoclosure () throws -> T, minimumConcurrentDetected: Int = 1, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where T: Procedure {
+    func XCTAssertProcedureNoConcurrentEvents<T: EventConcurrencyTrackingProcedureProtocol>(_ exp: @autoclosure () throws -> T, minimumConcurrentDetected: Int = 1, _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) where T: Procedure {
         __XCTEvaluateAssertion(testCase: self, message, file: file, line: line) {
             let procedure = try exp()
             let detectedConcurrentEvents = procedure.concurrencyRegistrar.detectedConcurrentEvents


### PR DESCRIPTION
The Swift 4 compiler is stricter, and warns about redundant conformance constraints.