### PR TITLE
Fix 'Integer' protocol is unavailable [Swift 4]

### DIFF
--- a/Sources/ProcedureKit/Support.swift
+++ b/Sources/ProcedureKit/Support.swift
@@ -154,7 +154,7 @@ public extension Protector where T: RangeReplaceableCollection {
     }
 }
 
-public extension Protector where T: Integer {
+public extension Protector where T: Strideable {
 
     func advance(by stride: T.Stride) {
         write { (ward: inout T) in


### PR DESCRIPTION
This particular use really ought to be `Strideable` anyway.