### PR TITLE
Resolve Group/RetryProcedure overridden extension declaration [Swift 4]

### DIFF
--- a/Sources/ProcedureKit/Group.swift
+++ b/Sources/ProcedureKit/Group.swift
@@ -376,6 +376,12 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
         }
         return promise.future
     }
+
+    public func child(_ child: Operation, didAttemptRecoveryFromErrors errors: [Error]) {
+        groupStateLock.withCriticalScope {
+            _groupErrors.attemptedRecovery[child] = errors
+        }
+    }
 }
 
 // MARK: - GroupProcedure API
@@ -590,12 +596,6 @@ public extension GroupProcedure {
     final public func child(_ child: Operation, didEncounterFatalErrors errors: [Error]) {
         log.warning(message: "\(child.operationName) did encounter \(errors.count) fatal errors.")
         append(fatalErrors: errors)
-    }
-
-    public func child(_ child: Operation, didAttemptRecoveryFromErrors errors: [Error]) {
-        groupStateLock.withCriticalScope {
-            _groupErrors.attemptedRecovery[child] = errors
-        }
     }
 
     fileprivate var attemptedRecovery: GroupErrors.ByOperation {


### PR DESCRIPTION
`Retry.swift:134:24: Declarations from extensions cannot be overridden yet` (The Swift 4 compiler catches a case that the Swift 3 compiler was happy to allow.)

Resolved by moving the declaration of `child(_:didAttemptRecoveryFromErrors:)` in Group.swift from an extension of GroupProcedure to the main `class GroupProcedure`.