### PR TITLE
Logger fix for `closure tuple parameter does not support destructuring` [Swift 4]

### DIFF
--- a/Sources/ProcedureKit/Logging.swift
+++ b/Sources/ProcedureKit/Logging.swift
@@ -165,7 +165,8 @@ public class LogManager: LogManagerProtocol {
     init() {
         _enabled = true
         _severity = .warning
-        _logger = { message, severity, file, function, line in
+        _logger = { (info) in
+            let (message, _, file, function, line) = info
             print("\(LogManager.metadata(for: file, function: function, line: line))\(message)")
         }
     }
@@ -256,7 +257,7 @@ public extension LoggerProtocol {
         guard enabled && severity >= self.severity else { return }
         let _message = messageWithOperationName(message())
         LogManager.queue.async { [logger = self.logger] in
-            logger(message: _message, severity: severity, file: file, function: function, line: line)
+            logger(LoggerInfo(message: _message, severity: severity, file: file, function: function, line: line))
         }
     }
 

--- a/Tests/ProcedureKitTests/LoggerTests.swift
+++ b/Tests/ProcedureKitTests/LoggerTests.swift
@@ -85,7 +85,8 @@ class LogManagerTests: LoggingTests {
     func test__custom_logger() {
         var receivedMessage: String? = nil
         var receivedSeverity: LogSeverity? = nil
-        LogManager.logger = { message, severity, _, _, _ in
+        LogManager.logger = { (info) in
+            let (message, severity, _, _, _) = info
             receivedMessage = message
             receivedSeverity = severity
         }
@@ -105,7 +106,8 @@ class RunAllTheLoggersTests: XCTestCase {
     }
 
     func test__verbose() {
-        log = Logger(severity: .verbose) { message, severity, _, _, _ in
+        log = Logger(severity: .verbose) { (info) in
+            let (message, severity, _, _, _) = info
             XCTAssertEqual(severity, LogSeverity.verbose)
             XCTAssertEqual(message, "Hello World")
         }
@@ -113,7 +115,8 @@ class RunAllTheLoggersTests: XCTestCase {
     }
 
     func test__notice() {
-        log = Logger(severity: .verbose) { message, severity, _, _, _ in
+        log = Logger(severity: .verbose) { (info) in
+            let (message, severity, _, _, _) = info
             XCTAssertEqual(severity, LogSeverity.notice)
             XCTAssertEqual(message, "Hello World")
         }
@@ -121,7 +124,8 @@ class RunAllTheLoggersTests: XCTestCase {
     }
 
     func test__info() {
-        log = Logger(severity: .verbose) { message, severity, _, _, _ in
+        log = Logger(severity: .verbose) { (info) in
+            let (message, severity, _, _, _) = info
             XCTAssertEqual(severity, LogSeverity.info)
             XCTAssertEqual(message, "Hello World")
         }
@@ -129,7 +133,8 @@ class RunAllTheLoggersTests: XCTestCase {
     }
 
     func test__warning() {
-        log = Logger(severity: .verbose) { message, severity, _, _, _ in
+        log = Logger(severity: .verbose) { (info) in
+            let (message, severity, _, _, _) = info
             XCTAssertEqual(severity, LogSeverity.warning)
             XCTAssertEqual(message, "Hello World")
         }
@@ -137,7 +142,8 @@ class RunAllTheLoggersTests: XCTestCase {
     }
 
     func test__fatal() {
-        log = Logger(severity: .verbose) { message, severity, _, _, _ in
+        log = Logger(severity: .verbose) { (info) in
+            let (message, severity, _, _, _) = info
             XCTAssertEqual(severity, LogSeverity.fatal)
             XCTAssertEqual(message, "Hello World")
         }


### PR DESCRIPTION
`Logging.swift:168:21: Closure tuple parameter '(message: String, severity: LogSeverity, file: String, function: String, line: Int)' does not support destructuring`

This was apparently [never really intended to work](https://bugs.swift.org/browse/SR-4738), but there was special-case behavior for a single tuple argument. The Swift 4 compiler is now stricter about rejecting it.