### PR TITLE
Fix closure input parameters [Swift 4]

### DIFF
--- a/Sources/TestingProcedureKit/RepeatTestCase.swift
+++ b/Sources/TestingProcedureKit/RepeatTestCase.swift
@@ -50,7 +50,7 @@ open class RetryTestCase: ProcedureKitTestCase {
                 guard info.numberOfFailures == failureThreshold else { throw ProcedureKitError.conditionFailed() }
                 return true
             })
-            procedure.addWillFinishBlockObserver { _ in
+            procedure.addWillFinishBlockObserver { _, _, _ in
                 info.numberOfExecuctions += 1
                 info.numberOfFailures += 1
             }
@@ -66,7 +66,7 @@ open class RetryTestCase: ProcedureKitTestCase {
                 guard info.numberOfFailures == failureThreshold else { throw ProcedureKitError.conditionFailed() }
                 return true
             })
-            procedure.addWillFinishBlockObserver { _ in
+            procedure.addWillFinishBlockObserver { _, _, _ in
                 info.numberOfExecuctions += 1
                 info.numberOfFailures += 1
             }

--- a/Tests/ProcedureKitCloudTests/CKFetchRecordChangesOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKFetchRecordChangesOperationTests.swift
@@ -192,7 +192,7 @@ class CloudKitProcedureFetchRecordChangesOperationTests: CKProcedureTestCase {
 
     func test__success_with_completion_block_set() {
         var didExecuteBlock = false
-        cloudkit.setFetchRecordChangesCompletionBlock { _ in
+        cloudkit.setFetchRecordChangesCompletionBlock { _, _ in
             didExecuteBlock = true
         }
         wait(for: cloudkit)
@@ -218,7 +218,7 @@ class CloudKitProcedureFetchRecordChangesOperationTests: CKProcedureTestCase {
         }
 
         var didExecuteBlock = false
-        cloudkit.setFetchRecordChangesCompletionBlock { _ in
+        cloudkit.setFetchRecordChangesCompletionBlock { _, _ in
             didExecuteBlock = true
         }
 
@@ -239,7 +239,7 @@ class CloudKitProcedureFetchRecordChangesOperationTests: CKProcedureTestCase {
             return op
         }
         var didExecuteBlock = false
-        cloudkit.setFetchRecordChangesCompletionBlock { _ in didExecuteBlock = true }
+        cloudkit.setFetchRecordChangesCompletionBlock { _, _ in didExecuteBlock = true }
         wait(for: cloudkit)
         XCTAssertProcedureFinishedWithoutErrors(cloudkit)
         XCTAssertTrue(didExecuteBlock)
@@ -262,7 +262,7 @@ class CloudKitProcedureFetchRecordChangesOperationTests: CKProcedureTestCase {
         }
 
         var didExecuteBlock = false
-        cloudkit.setFetchRecordChangesCompletionBlock { _ in didExecuteBlock = true }
+        cloudkit.setFetchRecordChangesCompletionBlock { _, _ in didExecuteBlock = true }
         wait(for: cloudkit)
         XCTAssertProcedureFinishedWithoutErrors(cloudkit)
         XCTAssertTrue(didExecuteBlock)

--- a/Tests/ProcedureKitNetworkTests/NetworkDataProcedureTests.swift
+++ b/Tests/ProcedureKitNetworkTests/NetworkDataProcedureTests.swift
@@ -56,7 +56,7 @@ class NetworkDataProcedureTests: ProcedureKitTestCase {
     func test__download_cancels_data_task_is_cancelled() {
         session.delay = 2.0
         let delay = DelayProcedure(by: 0.1)
-        delay.addDidFinishBlockObserver { _ in
+        delay.addDidFinishBlockObserver { _, _ in
             self.download.cancel()
         }
         wait(for: download, delay)

--- a/Tests/ProcedureKitNetworkTests/NetworkDownloadProcedureTests.swift
+++ b/Tests/ProcedureKitNetworkTests/NetworkDownloadProcedureTests.swift
@@ -55,7 +55,7 @@ class NetworkDownloadProcedureTests: ProcedureKitTestCase {
     func test__download_cancels_data_download_is_cancelled() {
         session.delay = 2.0
         let delay = DelayProcedure(by: 0.1)
-        delay.addDidFinishBlockObserver { _ in
+        delay.addDidFinishBlockObserver { _, _ in
             self.download.cancel()
         }
         wait(for: download, delay)

--- a/Tests/ProcedureKitNetworkTests/NetworkUploadProcedureTests.swift
+++ b/Tests/ProcedureKitNetworkTests/NetworkUploadProcedureTests.swift
@@ -59,7 +59,7 @@ class NetworkUploadProcedureTests: ProcedureKitTestCase {
     func test__upload_cancels_data_task_is_cancelled() {
         session.delay = 2.0
         let delay = DelayProcedure(by: 0.1)
-        delay.addDidFinishBlockObserver { _ in
+        delay.addDidFinishBlockObserver { _, _ in
             self.upload.cancel()
         }
         wait(for: upload, delay)

--- a/Tests/ProcedureKitTests/BlockObserverTests.swift
+++ b/Tests/ProcedureKitTests/BlockObserverTests.swift
@@ -20,7 +20,9 @@ class BlockObserverTests: ProcedureKitTestCase {
 
     func test__will_execute_is_called() {
         let willExecuteCalled = Protector<Procedure?>(nil)
-        procedure.add(observer: BlockObserver(willExecute: { willExecuteCalled.overwrite(with: $0.0) }))
+        procedure.add(observer: BlockObserver(willExecute: { procedure, _ in
+            willExecuteCalled.overwrite(with: procedure)
+        }))
         wait(for: procedure)
         XCTAssertEqual(willExecuteCalled.access, procedure)
     }
@@ -67,7 +69,9 @@ class BlockObserverTests: ProcedureKitTestCase {
 
     func test__will_finish_is_called() {
         let willFinishCalled = Protector<(Procedure, [Error])?>(nil)
-        procedure.add(observer: BlockObserver(willFinish: { willFinishCalled.overwrite(with: ($0.0, $0.1)) }))
+        procedure.add(observer: BlockObserver(willFinish: { procedure, errors, _ in
+            willFinishCalled.overwrite(with: (procedure, errors))
+        }))
         wait(for: procedure)
         XCTAssertEqual(willFinishCalled.access?.0, procedure)
     }
@@ -162,7 +166,9 @@ class BlockObserverSynchronizationTests: ProcedureKitTestCase {
             procedure.addWillExecuteBlockObserver(synchronizedWith: syncObject) { procedure, _ in
                 willExecuteCalled_addBlock.overwrite(with: (procedure, isSynced()))
             }
-            procedure.add(observer: BlockObserver(synchronizedWith: syncObject, willExecute: { willExecuteCalled_BlockObserver.overwrite(with: ($0.0, isSynced())) }))
+            procedure.add(observer: BlockObserver(synchronizedWith: syncObject, willExecute: { procedure, _ in
+                willExecuteCalled_BlockObserver.overwrite(with: (procedure, isSynced()))
+            }))
             wait(for: procedure)
             XCTAssertEqual(willExecuteCalled_addBlock.access?.0, procedure)
             XCTAssertTrue(willExecuteCalled_addBlock.access?.1 ?? false, "Was not synchronized on \(syncObject).") // was synchronized
@@ -277,7 +283,9 @@ class BlockObserverSynchronizationTests: ProcedureKitTestCase {
             procedure.addWillFinishBlockObserver(synchronizedWith: syncObject) { procedure, errors, _ in
                 willFinishCalled_addBlock.overwrite(with: (procedure, errors, isSynced()))
             }
-            procedure.add(observer: BlockObserver(synchronizedWith: syncObject, willFinish: { willFinishCalled_BlockObserver.overwrite(with: ($0.0, $0.1, isSynced())) }))
+            procedure.add(observer: BlockObserver(synchronizedWith: syncObject, willFinish: { procedure, errors, _ in
+                willFinishCalled_BlockObserver.overwrite(with: (procedure, errors, isSynced()))
+            }))
             wait(for: procedure)
             XCTAssertEqual(willFinishCalled_addBlock.access?.0, procedure)
             XCTAssertTrue(willFinishCalled_addBlock.access?.2 ?? false, "Was not synchronized on \(syncObject).") // was synchronized

--- a/Tests/ProcedureKitTests/FinishingTests.swift
+++ b/Tests/ProcedureKitTests/FinishingTests.swift
@@ -25,7 +25,7 @@ class FinishingTests: ProcedureKitTestCase {
         class TestOperation_CancelsAndManuallyFinishesOnWillExecute: Procedure {
             override init() {
                 super.init(disableAutomaticFinishing: true) // <-- disableAutomaticFinishing
-                addWillExecuteBlockObserver { [weak self] _ in
+                addWillExecuteBlockObserver { [weak self] _, _ in
                     guard let strongSelf = self else { return }
                     strongSelf.cancel()
                     strongSelf.finish() // manually finishes after cancelling

--- a/Tests/ProcedureKitTests/GroupTests.swift
+++ b/Tests/ProcedureKitTests/GroupTests.swift
@@ -104,7 +104,7 @@ class GroupTests: GroupTestCase {
 
         let childWillExecuteDispatchGroup = DispatchGroup()
         childWillExecuteDispatchGroup.enter()
-        child.addWillExecuteBlockObserver { _ in
+        child.addWillExecuteBlockObserver { _, _ in
             childWillExecuteDispatchGroup.leave()
         }
 


### PR DESCRIPTION
The Swift 4 compiler is stricter about how closure input parameters are specified.