### PR TITLE
Fix: In Swift 4, `networkActivityIndicatorVisible` -> `isNetworkActivityIndicatorVisible`

### DIFF
--- a/Sources/ProcedureKit/NetworkObserver.swift
+++ b/Sources/ProcedureKit/NetworkObserver.swift
@@ -8,7 +8,11 @@ import Foundation
 import Dispatch
 
 public protocol NetworkActivityIndicatorProtocol {
-    var networkActivityIndicatorVisible: Bool { get set }
+    #if swift(>=4.0)
+        var isNetworkActivityIndicatorVisible: Bool { get set }
+    #else // Swift 3.x
+        var networkActivityIndicatorVisible: Bool { get set }
+    #endif
 }
 
 public class NetworkActivityController {
@@ -73,9 +77,15 @@ public class NetworkActivityController {
         delayedHide = nil
         DispatchQueue.main.async {
             // only set the visibility if it has changed
-            if self.indicator.networkActivityIndicatorVisible != visibility {
-                self.indicator.networkActivityIndicatorVisible = visibility
-            }
+            #if swift(>=4.0)
+                if self.indicator.isNetworkActivityIndicatorVisible != visibility {
+                    self.indicator.isNetworkActivityIndicatorVisible = visibility
+                }
+            #else // Swift 3.x
+                if self.indicator.networkActivityIndicatorVisible != visibility {
+                    self.indicator.networkActivityIndicatorVisible = visibility
+                }
+            #endif
         }
     }
 }

--- a/Tests/ProcedureKitTests/NetworkObserverTests.swift
+++ b/Tests/ProcedureKitTests/NetworkObserverTests.swift
@@ -17,11 +17,19 @@ class TestableNetworkActivityIndicator: NetworkActivityIndicatorProtocol {
         visibilityDidChange = didChange
     }
 
-    var networkActivityIndicatorVisible = false {
-        didSet {
-            visibilityDidChange(networkActivityIndicatorVisible)
+    #if swift(>=4.0)
+        var isNetworkActivityIndicatorVisible = false {
+            didSet {
+                visibilityDidChange(isNetworkActivityIndicatorVisible)
+            }
         }
-    }
+    #else // Swift 3.x
+        var networkActivityIndicatorVisible = false {
+            didSet {
+                visibilityDidChange(networkActivityIndicatorVisible)
+            }
+        }
+    #endif
 }
 
 class NetworkObserverTests: ProcedureKitTestCase {


### PR DESCRIPTION
In Swift 4, `UIApplication.networkActivityIndicatorVisible` becomes `UIApplication.isNetworkActivityIndicatorVisible`.

Match this in the NetworkActivityIndicatorProtocol on Swift 4.