### PR TITLE
Fix: In Swift 4, CKOperation `longLived` -> `isLongLived`

### DIFF
--- a/Sources/ProcedureKitCloud/CKOperation.swift
+++ b/Sources/ProcedureKitCloud/CKOperation.swift
@@ -204,6 +204,10 @@ extension CKProcedure {
             get { return operation.isLongLived }
             set { operation.isLongLived = newValue }
         }
+
+        // Renamed in Swift 4
+        @available(*, unavailable, renamed: "isLongLived")
+        public var longLived: Bool { return isLongLived }
     #else // Swift 3.x
         @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
         public var longLived: Bool {
@@ -267,6 +271,10 @@ extension CloudKitProcedure {
                 appendConfigureBlock { $0.isLongLived = newValue }
             }
         }
+
+        // Renamed in Swift 4
+        @available(*, unavailable, renamed: "isLongLived")
+        public var longLived: Bool { return isLongLived }
     #else // Swift 3.x
         /// - returns whether the operation is long-lived
         @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)

--- a/Sources/ProcedureKitCloud/CKOperation.swift
+++ b/Sources/ProcedureKitCloud/CKOperation.swift
@@ -84,9 +84,15 @@ public protocol CKOperationProtocol: class {
     @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
     var operationID: String { get }
 
-    /// - returns whether the operation is long-lived
-    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
-    var longLived: Bool { get set }
+    #if swift(>=4.0)
+        /// - returns whether the operation is long-lived
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        var isLongLived: Bool { get set }
+    #else // Swift 3.x
+        /// - returns whether the operation is long-lived
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        var longLived: Bool { get set }
+    #endif
 
     /// - returns the block to execute when the server starts storing callbacks for this long-lived CKOperation
     @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
@@ -192,11 +198,19 @@ extension CKProcedure {
         get { return operation.operationID }
     }
 
-    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
-    public var longLived: Bool {
-        get { return operation.longLived }
-        set { operation.longLived = newValue }
-    }
+    #if swift(>=4.0)
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        public var isLongLived: Bool {
+            get { return operation.isLongLived }
+            set { operation.isLongLived = newValue }
+        }
+    #else // Swift 3.x
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        public var longLived: Bool {
+            get { return operation.longLived }
+            set { operation.longLived = newValue }
+        }
+    #endif
 
     @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
     public var longLivedOperationWasPersistedBlock: T.LongLivedOperationWasPersistedBlockType {
@@ -243,15 +257,27 @@ extension CloudKitProcedure {
         get { return current.operationID }
     }
 
-    /// - returns whether the operation is long-lived
-    @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
-    public var longLived: Bool {
-        get { return current.longLived }
-        set {
-            current.longLived = newValue
-            appendConfigureBlock { $0.longLived = newValue }
+    #if swift(>=4.0)
+        /// - returns whether the operation is long-lived
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        public var isLongLived: Bool {
+            get { return current.isLongLived }
+            set {
+                current.isLongLived = newValue
+                appendConfigureBlock { $0.isLongLived = newValue }
+            }
         }
-    }
+    #else // Swift 3.x
+        /// - returns whether the operation is long-lived
+        @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
+        public var longLived: Bool {
+            get { return current.longLived }
+            set {
+                current.longLived = newValue
+                appendConfigureBlock { $0.longLived = newValue }
+            }
+        }
+    #endif
 
     /// - returns the block to execute when the server starts storing callbacks for this long-lived CKOperation
     @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)

--- a/Tests/ProcedureKitCloudTests/CKOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKOperationTests.swift
@@ -35,7 +35,11 @@ class TestCKOperation: Operation, CKOperationProtocol {
 
     //@available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
     var operationID: String = ""
-    var longLived: Bool = false
+    #if swift(>=4.0)
+        var isLongLived: Bool = false
+    #else // Swift 3.x
+        var longLived: Bool = false
+    #endif
 
     var longLivedOperationWasPersistedBlock: () -> Void = { }
 
@@ -85,9 +89,15 @@ class CKOperationTests: CKProcedureTestCase {
     @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
     func test__set_get__longLived() {
         let longLived = true
-        operation.longLived = longLived
-        XCTAssertEqual(operation.longLived, longLived)
-        XCTAssertEqual(target.longLived, longLived)
+        #if swift(>=4.0)
+            operation.isLongLived = longLived
+            XCTAssertEqual(operation.isLongLived, longLived)
+            XCTAssertEqual(target.isLongLived, longLived)
+        #else // Swift 3.x
+            operation.longLived = longLived
+            XCTAssertEqual(operation.longLived, longLived)
+            XCTAssertEqual(target.longLived, longLived)
+        #endif
     }
 
     @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)


### PR DESCRIPTION
In Swift 4, `CKOperation.longLived` becomes `CKOperation.isLongLived`.

Match this in ProcedureKitCloud on Swift 4.