### PR TITLE
Fix KVONotificationTests compilation [Swift 4]

### DIFF
--- a/Tests/ProcedureKitTests/KVONotificationTests.swift
+++ b/Tests/ProcedureKitTests/KVONotificationTests.swift
@@ -372,7 +372,7 @@ class KVOTests: ProcedureKitTestCase {
 
 extension Collection where Indices.Iterator.Element == Index {
     // Returns the element at the specified index iff it is within bounds, otherwise nil.
-    func get(safe index: Index) -> Generator.Element? {
+    func get(safe index: Index) -> Iterator.Element? {
         return indices.contains(index) ? self[index] : nil
     }
 }


### PR DESCRIPTION
`Generator.Element` should be `Iterator.Element`