### PR TITLE
Simplify GroupProcedure child error handling behavior & customization

### DIFF
--- a/Sources/ProcedureKit/Group.swift
+++ b/Sources/ProcedureKit/Group.swift
@@ -15,34 +15,16 @@ import Dispatch
  related operations together, thereby creating higher
  levels of abstractions.
  */
-open class GroupProcedure: Procedure, ProcedureQueueDelegate {
-
-    internal struct GroupErrors {
-        typealias ByOperation = Dictionary<Operation, Array<Error>>
-        var fatal = [Error]()
-        var attemptedRecovery: ByOperation = [:]
-
-        var attemptedRecoveryErrors: [Error] {
-            return Array(attemptedRecovery.values.flatMap { $0 })
-        }
-
-        var all: [Error] {
-            get {
-                var tmp: [Error] = fatal
-                tmp.append(contentsOf: attemptedRecoveryErrors)
-                return tmp
-            }
-        }
-    }
+open class GroupProcedure: Procedure {
 
     internal let queue = ProcedureQueue()
+    internal var queueDelegate: GroupQueueDelegate!
 
     fileprivate let initialChildren: [Operation]
     fileprivate var groupCanFinish: CanFinishGroup!
     fileprivate var groupStateLock = PThreadMutex()
 
     // Protected private properties
-    fileprivate var _groupErrors = GroupErrors() // swiftlint:disable:this variable_name
     fileprivate var _groupChildren: [Operation] // swiftlint:disable:this variable_name
     fileprivate var _groupIsFinishing = false // swiftlint:disable:this variable_name
     fileprivate var _groupIsSuspended = false // swiftlint:disable:this variable_name
@@ -77,16 +59,6 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
             let (operations, procedures) = children.operationsAndProcedures
             operations.forEach { $0.setQualityOfService(fromUserIntent: userIntent) }
             procedures.forEach { $0.userIntent = userIntent }
-        }
-    }
-
-    /// Override of errors
-    public override var errors: [Error] {
-        get { return groupStateLock.withCriticalScope { _groupErrors.fatal } }
-        set {
-            groupStateLock.withCriticalScope {
-                _groupErrors.fatal = newValue
-            }
         }
     }
 
@@ -142,7 +114,8 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
 
         queue.isSuspended = true
         queue.underlyingQueue = underlyingQueue
-        queue.delegate = self
+        queueDelegate = GroupQueueDelegate(self)
+        queue.delegate = queueDelegate
         userIntent = operations.userIntent
         groupCanFinish = CanFinishGroup(group: self)
     }
@@ -170,7 +143,6 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
             children.forEach { $0.cancel() }
         }
         else {
-            append(fatalErrors: additionalErrors)
             let (operations, procedures) = children.operationsAndProcedures
             operations.forEach { $0.cancel() }
             procedures.forEach { $0.cancel(withError: ProcedureKitError.parent(cancelledWithErrors: additionalErrors)) }
@@ -204,183 +176,31 @@ open class GroupProcedure: Procedure, ProcedureQueueDelegate {
      */
     open func groupWillAdd(child: Operation) { /* no-op */ }
 
-    // MARK: - Error recovery and child finishing
+    // MARK: - Customizing the Group's Child Error Handling
 
     /**
-     This method is called when a child will finish with errors.
+     This method is called when a child Procedure will finish (with / without errors).
      (It is called on the Group's EventQueue.)
 
-     Often an operation will finish with errors become some of its pre-requisites were not
-     met. Errors of this nature should be recoverable. This can be done by re-trying the
-     original operation, but with another operation which fulfil the pre-requisites as a
-     dependency.
+     The default behavior is to append the child's errors, if any, to the Group's errors.
 
-     If the errors were recovered from, return true from this method, else return false.
+     When subclassing GroupProcedure, you can override this method to execute custom
+     code in response to child Procedures finishing, or to override the default
+     error-aggregating behavior.
 
-     Errors which are not handled will result in the GroupProcedure finishing with errors.
+     The child Procedure (and, thus, the Group) will not finish until this method returns.
 
-     - parameter child: the child operation which is finishing
-     - parameter errors: an [ErrorType], the errors of the child operation
-     - returns: a Boolean, return true if the errors were handled, else return false.
-     */
-    open func child(_ child: Operation, willAttemptRecoveryFromErrors errors: [Error]) -> Bool {
-        return false
-    }
+     - parameter child: the child Procedure which is finishing
+     - parameter errors: an [Error], the errors of the child Procedure
+    */
+    open func child(_ child: Procedure, willFinishWithErrors errors: [Error]) {
+        assert(!child.isFinished, "child(_:willFinishWithErrors:) called with a child that has already finished")
 
-    /**
-     This method is only called when a child finishes without any errors.
-     (It is called on the Group's EventQueue.)
+        // Default GroupProcedure error-handling behavior:
+        // - Aggregate errors from child Procedures
 
-     - parameter child: the Operation which will finish without errors
-     */
-    open func childWillFinishWithoutErrors(_ child: Operation) { /* no-op */ }
-
-    // MARK: - ProcedureQueueDelegate
-
-    /**
-     The group acts as its own queue's delegate. When an operation is added to the queue,
-     assuming that the group is not yet finishing or finished, then we add the operation
-     as a dependency to an internal "barrier" operation that separates executing from
-     finishing state.
-
-     The purpose of this is to keep the internal operation as a final child operation that executes
-     when there are no more operations in the group operation, safely handling the transition of
-     group operation state.
-     */
-
-    private func shouldAdd(operation: Operation) -> Bool {
-        return groupStateLock.withCriticalScope {
-            guard !_groupIsFinishing else {
-                assertionFailure("Cannot add new operations to a group after the group has started to finish.")
-                return false
-            }
-
-            // Add the new child as a dependency of the internal GroupCanFinish operation
-            groupCanFinish.addDependency(operation)
-
-            // Add the new child to the Group's internal children array
-            _groupChildren.append(operation)
-            return true
-        }
-    }
-
-    public func procedureQueue(_ queue: ProcedureQueue, willAddOperation operation: Operation, context: Any?) -> ProcedureFuture? {
-
-        return willAdd(operation: operation, context: context)
-    }
-
-    public func procedureQueue(_ queue: ProcedureQueue, willAddProcedure procedure: Procedure, context: Any?) -> ProcedureFuture? {
-        guard queue === self.queue else { return nil }
-
-        return willAdd(operation: procedure, context: context)
-    }
-
-    /**
-     - returns: a ProcedureFuture that is signaled once the Group has fully prepared for the operation to be added
-                to its internal queue (including notifying all WillAdd observers)
-     */
-    private func willAdd(operation: Operation, context: Any?) -> ProcedureFuture? {
-
-        if let context = context as? ProcedureQueueContext, context === queueAddContext {
-            // The Procedure adding the operation to the Group's private queue is the Group itself
-            //
-            // which means it could only have come from:
-            //      - self.add(child:)  (and convenience overloads)
-            //
-            // which will handle the setup-work for this operation in the context of the Group
-            // (asynchronously) so there is nothing to do here - exit early
-
-            return nil
-        }
-
-        // The Procedure adding the operation to the Group's private queue is *not* the Group.
-        //
-        // It could have come from:
-        //      - a child.produce(operation:)
-        //      - an Operation (NSOperation) subclass calling OperationQueue.current.addOperation()
-        //        (which is not at all recommended, but is possible from an Operation subclass)
-        //
-        // In either case, the operation has not yet been handled in the context of the Group
-        // (i.e. adding it as a child, adding it as a dependency on finishing, notifying Group
-        // Will/DidAddOperation observers) thus it must be handled here:
-        //
-
-        assert(!isFinished, "Cannot add new operations to a group after the group has completed.")
-
-        guard shouldAdd(operation: operation) else { return nil }
-
-        let promise = ProcedurePromise()
-
-        // If the Group is already cancelled, ensure that the new child is cancelled.
-        if isCancelled && !operation.isCancelled {
-            operation.cancel()
-        }
-
-        // Dispatch the next step (observers, etc) asynchronously on the Procedure EventQueue
-        dispatchEvent {
-            self.willAdd_step2(operation: operation, promise: promise)
-        }
-
-        return promise.future
-    }
-
-    private func willAdd_step2(operation: Operation, promise: ProcedurePromise) {
-        eventQueue.debugAssertIsOnQueue()
-
-        // groupWillAdd(child:) override
-        groupWillAdd(child: operation)
-
-        // WillAddOperation observers
-        let willAddObserversGroup = dispatchObservers(pendingEvent: PendingEvent.addOperation) { observer, _ in
-            observer.procedure(self, willAdd: operation)
-        }
-
-        optimizedDispatchEventNotify(group: willAddObserversGroup) {
-
-            // Complete the promise
-            promise.complete()
-
-            // DidAddOperation observers
-            _ = self.dispatchObservers(pendingEvent: PendingEvent.postDidAdd) { observer, _ in
-                    observer.procedure(self, didAdd: operation)
-            }
-
-            // Note: no need to wait on DidAddOperation observers - nothing left to do.
-        }
-    }
-
-    /**
-     The group acts as it's own queue's delegate. When a Procedure finishes, the group is
-     notified that a child Procedure has finished.
-     */
-    public func procedureQueue(_ queue: ProcedureQueue, willFinishProcedure procedure: Procedure, withErrors errors: [Error]) -> ProcedureFuture? {
-        guard queue === self.queue else { return nil }
-
-        /// If the group is cancelled, exit early
-        guard !isCancelled else { return nil }
-
-        let promise = ProcedurePromise()
-        dispatchEvent {
-            if !errors.isEmpty {
-                if self.child(procedure, willAttemptRecoveryFromErrors: errors) {
-                    self.child(procedure, didAttemptRecoveryFromErrors: errors)
-                }
-                else {
-                    self.child(procedure, didEncounterFatalErrors: errors)
-                }
-            }
-            else {
-                self.childWillFinishWithoutErrors(procedure)
-            }
-            promise.complete()
-        }
-        return promise.future
-    }
-
-    public func child(_ child: Operation, didAttemptRecoveryFromErrors errors: [Error]) {
-        groupStateLock.withCriticalScope {
-            _groupErrors.attemptedRecovery[child] = errors
-        }
+        guard !errors.isEmpty else { return }
+        append(errors: errors, fromChild: child)
     }
 }
 
@@ -570,53 +390,180 @@ public extension GroupProcedure {
     }
 }
 
-// MARK: - Error Handling & Recovery
+// MARK: - Aggregating Errors
 
 public extension GroupProcedure {
 
-    internal var attemptedRecoveryErrors: [Error] {
-        return groupStateLock.withCriticalScope { _groupErrors.attemptedRecoveryErrors }
+    /// Append an error to the Group's errors
+    ///
+    /// - Parameter error: an Error
+    final public func append(error: Error, fromChild child: Operation? = nil) {
+        if let child = child {
+            log.warning(message: "\(child.operationName) did encounter error: \(error).")
+        } else {
+            log.warning(message: "Appending error: \(error).")
+        }
+        append(errors: [error])
     }
 
-    final public func append(fatalError error: Error) {
-        append(fatalErrors: [error])
+    /// Append errors to the Group's errors
+    ///
+    /// - Parameter errors: an [Error]
+    /// - Parameter child: a child Operation
+    final public func append(errors: [Error], fromChild child: Operation? = nil) {
+        if let child = child {
+            log.warning(message: "\(child.operationName) did encounter \(errors.count) errors.")
+        } else {
+            log.warning(message: "Appending \(errors.count) errors.")
+        }
+        append(errors: errors)
     }
+}
 
-    final public func child(_ child: Operation, didEncounterFatalError error: Error) {
-        log.warning(message: "\(child.operationName) did encounter fatal error: \(error).")
-        append(fatalError: error)
-    }
+// MARK: - GroupProcedure Private Queue Delegate
 
-    final public func append(fatalErrors errors: [Error]) {
-        groupStateLock.withCriticalScope {
-            _groupErrors.fatal.append(contentsOf: errors)
+internal extension GroupProcedure {
+
+    /**
+     The group utilizes a GroupQueueDelegate to effectively act as its own delegate for its own
+     internal queue, while keeping this implementation detail private.
+
+     When an operation is added to the queue, assuming that the group is not yet finishing or 
+     finished, then we add the operation as a dependency to an internal "barrier" operation that
+     separates executing from finishing state.
+
+     This serves to keep the internal operation as a final child operation that executes when
+     there are no more operations in the group operation, safely handling the transition
+     of group operation state.
+     */
+
+    internal class GroupQueueDelegate: ProcedureQueueDelegate {
+
+        private weak var group: GroupProcedure?
+
+        init(_ group: GroupProcedure) {
+            self.group = group
+        }
+
+        func procedureQueue(_ queue: ProcedureQueue, willAddOperation operation: Operation, context: Any?) -> ProcedureFuture? {
+            guard let strongGroup = group else { return nil }
+            guard queue === strongGroup.queue else { return nil }
+
+            return strongGroup.willAdd(operation: operation, context: context)
+        }
+
+        func procedureQueue(_ queue: ProcedureQueue, willAddProcedure procedure: Procedure, context: Any?) -> ProcedureFuture? {
+            guard let strongGroup = group else { return nil }
+            guard queue === strongGroup.queue else { return nil }
+
+            return strongGroup.willAdd(operation: procedure, context: context)
+        }
+
+        public func procedureQueue(_ queue: ProcedureQueue, willFinishProcedure procedure: Procedure, withErrors errors: [Error]) -> ProcedureFuture? {
+            guard let strongGroup = group else { return nil }
+            guard queue === strongGroup.queue else { return nil }
+
+            /// If the group is cancelled, exit early
+            guard !strongGroup.isCancelled else { return nil }
+
+            let promise = ProcedurePromise()
+            strongGroup.dispatchEvent {
+                defer { promise.complete() }
+
+                // handle child errors
+                strongGroup.child(procedure, willFinishWithErrors: errors)
+            }
+            return promise.future
         }
     }
 
-    final public func child(_ child: Operation, didEncounterFatalErrors errors: [Error]) {
-        log.warning(message: "\(child.operationName) did encounter \(errors.count) fatal errors.")
-        append(fatalErrors: errors)
-    }
-
-    fileprivate var attemptedRecovery: GroupErrors.ByOperation {
-        return groupStateLock.withCriticalScope { _groupErrors.attemptedRecovery }
-    }
-
-    final public func childDidRecoverFromErrors(_ child: Operation) {
-        if attemptedRecovery[child] != nil {
-            log.notice(message: "successfully recovered from errors in \(child)")
-            groupStateLock.withCriticalScope { () -> Void in
-                _groupErrors.attemptedRecovery.removeValue(forKey: child)
+    private func shouldAdd(operation: Operation) -> Bool {
+        return groupStateLock.withCriticalScope {
+            guard !_groupIsFinishing else {
+                assertionFailure("Cannot add new operations to a group after the group has started to finish.")
+                return false
             }
+
+            // Add the new child as a dependency of the internal GroupCanFinish operation
+            groupCanFinish.addDependency(operation)
+
+            // Add the new child to the Group's internal children array
+            _groupChildren.append(operation)
+            return true
         }
     }
 
-    final public func childDidNotRecoverFromErrors(_ child: Operation) {
-        log.notice(message: "failed to recover from errors in \(child)")
-        groupStateLock.withCriticalScope {
-            if let errors = _groupErrors.attemptedRecovery.removeValue(forKey: child) {
-                _groupErrors.fatal.append(contentsOf: errors)
+    /**
+     - returns: a ProcedureFuture that is signaled once the Group has fully prepared for the operation to be added
+                to its internal queue (including notifying all WillAdd observers)
+     */
+    private func willAdd(operation: Operation, context: Any?) -> ProcedureFuture? {
+
+        if let context = context as? ProcedureQueueContext, context === queueAddContext {
+            // The Procedure adding the operation to the Group's private queue is the Group itself
+            //
+            // which means it could only have come from:
+            //      - self.add(child:)  (and convenience overloads)
+            //
+            // which will handle the setup-work for this operation in the context of the Group
+            // (asynchronously) so there is nothing to do here - exit early
+
+            return nil
+        }
+
+        // The Procedure adding the operation to the Group's private queue is *not* the Group.
+        //
+        // It could have come from:
+        //      - a child.produce(operation:)
+        //      - an Operation (NSOperation) subclass calling OperationQueue.current.addOperation()
+        //        (which is not at all recommended, but is possible from an Operation subclass)
+        //
+        // In either case, the operation has not yet been handled in the context of the Group
+        // (i.e. adding it as a child, adding it as a dependency on finishing, notifying Group
+        // Will/DidAddOperation observers) thus it must be handled here:
+        //
+
+        assert(!isFinished, "Cannot add new operations to a group after the group has completed.")
+
+        guard shouldAdd(operation: operation) else { return nil }
+
+        let promise = ProcedurePromise()
+
+        // If the Group is already cancelled, ensure that the new child is cancelled.
+        if isCancelled && !operation.isCancelled {
+            operation.cancel()
+        }
+
+        // Dispatch the next step (observers, etc) asynchronously on the Procedure EventQueue
+        dispatchEvent {
+            self.willAdd_step2(operation: operation, promise: promise)
+        }
+
+        return promise.future
+    }
+
+    private func willAdd_step2(operation: Operation, promise: ProcedurePromise) {
+        eventQueue.debugAssertIsOnQueue()
+
+        // groupWillAdd(child:) override
+        groupWillAdd(child: operation)
+
+        // WillAddOperation observers
+        let willAddObserversGroup = dispatchObservers(pendingEvent: PendingEvent.addOperation) { observer, _ in
+            observer.procedure(self, willAdd: operation)
+        }
+
+        optimizedDispatchEventNotify(group: willAddObserversGroup) {
+
+            // Complete the promise
+            promise.complete()
+
+            // DidAddOperation observers
+            _ = self.dispatchObservers(pendingEvent: PendingEvent.postDidAdd) { observer, _ in
+                    observer.procedure(self, didAdd: operation)
             }
+
+            // Note: no need to wait on DidAddOperation observers - nothing left to do.
         }
     }
 }
@@ -756,7 +703,9 @@ fileprivate extension GroupProcedure {
 
 fileprivate extension GroupProcedure {
     fileprivate func _finishGroup() {
-        super.finish(withErrors: errors)
+        // Because errors have been added throughout to the (superclass) Procedure's `errors`,
+        // there is no need to pass any additional errors to the call to finish().
+        super.finish()
         queue.isSuspended = true
     }
 }
@@ -790,4 +739,15 @@ public extension GroupProcedure {
     @available(*, unavailable, renamed: "add(children:)")
     func addOperations(additional: [Operation]) { }
 
+    @available(*, unavailable, message: "GroupProcedure child error handling customization has been re-worked. Consider overriding child(_:willFinishWithErrors:).")
+    final public func childDidRecoverFromErrors(_ child: Operation) { }
+
+    @available(*, unavailable, message: "GroupProcedure child error handling customization has been re-worked. Consider overriding child(_:willFinishWithErrors:).")
+    final public func childDidNotRecoverFromErrors(_ child: Operation) { }
+
+    @available(*, unavailable, renamed: "append(error:)")
+    final public func append(fatalError error: Error) { }
+
+    @available(*, unavailable, renamed: "append(errors:)")
+    final public func append(fatalErrors errors: [Error]) { }
 }

--- a/Sources/ProcedureKit/Repeat.swift
+++ b/Sources/ProcedureKit/Repeat.swift
@@ -180,15 +180,18 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
         super.execute()
     }
 
-    open override func childWillFinishWithoutErrors(_ child: Operation) {
+    /// Handle child willFinish event
+    ///
+    /// This is used by RepeatProcedure to trigger adding the next Procedure,
+    /// and calls `super.child(_:willFinishWithErrors:)` to get the default
+    /// GroupProcedure error-handling behavior.
+    ///
+    /// If subclassing RepeatProcedure and overriding this method, consider
+    /// carefully whether / when / how you should call super.
+    open override func child(_ child: Procedure, willFinishWithErrors errors: [Error]) {
         eventQueue.debugAssertIsOnQueue()
         _addNextOperation(child === self.current)
-    }
-
-    open override func child(_ child: Operation, willAttemptRecoveryFromErrors errors: [Error]) -> Bool {
-        eventQueue.debugAssertIsOnQueue()
-        _addNextOperation(child === self.current)
-        return super.child(child, willAttemptRecoveryFromErrors: errors)
+        super.child(child, willFinishWithErrors: errors) // default GroupProcedure error-handling
     }
 
     /// Adds the next payload from the iterator to the queue.

--- a/Sources/ProcedureKit/Repeat.swift
+++ b/Sources/ProcedureKit/Repeat.swift
@@ -9,10 +9,10 @@ import Dispatch
 
 /// Struct to hold the values necessary for each
 /// iteration of a RepeatProcedure. It is generic
-/// over the Procedure type (i.e. the type being
+/// over the Operation type (i.e. the type being
 /// iterated). However, it also holds an optional
 /// Delay property, and an optional ConfigureBlock.
-public struct RepeatProcedurePayload<T: Procedure> {
+public struct RepeatProcedurePayload<T: Operation> {
     public typealias ConfigureBlock = (T) -> Void
 
     /// - returns: the operation value
@@ -25,7 +25,7 @@ public struct RepeatProcedurePayload<T: Procedure> {
     /// Initializes a payload struct.
     ///
     /// - Parameters:
-    ///   - operation: an instance of a Procedure subclass T
+    ///   - operation: an instance of an Operation subclass T
     ///   - delay: an optional Delay value, which defaults to nil
     ///   - configure: an optional closure which receives the operation, and which defaults to nil
     public init(operation: T, delay: Delay? = nil, configure: ConfigureBlock? = nil) {
@@ -45,21 +45,21 @@ public struct RepeatProcedurePayload<T: Procedure> {
 
 /// RepeatProcedure is a GroupProcedure subclass which can be used to create
 /// polling or repeating procedures. Each child procedure is a new instance
-/// of the same Procedure subclass T. For example `RepeatProcedure<MyProcedure>`
-/// will create and execute instances of MyProcedure repeatedly, and we say
+/// of the same Operation subclass T. For example `RepeatProcedure<MyOperation>`
+/// will create and execute instances of MyOperation repeatedly, and we say
 /// that the RepeatProcedure is generic over T, which in this case is
-/// MyProcedure.
+/// MyOperation.
 ///
 /// While RepeatProcedure can be initialized in a variety of ways, it helps
 /// to understand that it works by using an Iterator. The iterator's payload
-/// is a structure which holds an instance of the Procedure subclass (`T`),
-/// an optional Delay value, and an optional configuration block. The block
+/// is a structure which holds an instance of the Operation subclass (`T`),
+/// and optional Delay value, and an optional configuration block. The block
 /// receives the instance, and can be used to prepare the operation before
 /// it is executed.
 ///
 /// All of the initializers available will ultimately create the underlying
 /// iterator.
-open class RepeatProcedure<T: Procedure>: GroupProcedure {
+open class RepeatProcedure<T: Operation>: GroupProcedure {
 
     public typealias Payload = RepeatProcedurePayload<T>
 
@@ -121,7 +121,7 @@ open class RepeatProcedure<T: Procedure>: GroupProcedure {
     }
 
     /// Initialize RepeatProcedure with two iterators, the first one has `Delay` elements, the
-    /// second has `T` elements - i.e. the Procedure subclass to be repeated.
+    /// second has `T` elements - i.e. the Operation subclass to be repeated.
     /// Other arguments allow for specific dispatch queues, and a maximum count of iteratations.
     ///
     /// - Parameters:
@@ -129,13 +129,13 @@ open class RepeatProcedure<T: Procedure>: GroupProcedure {
     ///   - max: an optional Int, which defaults to nil.
     ///   - delay: a generic IteratorProtocol type, with a Delay Element type
     ///   - iterator: a generic IteratorProtocol type, with a T Element type
-    public init<ProcedureIterator, DelayIterator>(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, delay: DelayIterator, iterator: ProcedureIterator) where ProcedureIterator: IteratorProtocol, DelayIterator: IteratorProtocol, ProcedureIterator.Element == T, DelayIterator.Element == Delay {
+    public init<OperationIterator, DelayIterator>(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, delay: DelayIterator, iterator: OperationIterator) where OperationIterator: IteratorProtocol, DelayIterator: IteratorProtocol, OperationIterator.Element == T, DelayIterator.Element == Delay {
         (_current, _iterator) = RepeatProcedure.create(withMax: max, andDelay: delay, andIterator: iterator)
         super.init(dispatchQueue: dispatchQueue, operations: [])
     }
 
     /// Initialize RepeatProcedure with a WaitStrategy and an iterator, which has `T` type
-    /// elements - i.e. the Procedure subclass to be repeated.
+    /// elements - i.e. the Operation subclass to be repeated.
     /// Other arguments allow for specific dispatch queues, and a maximum count of iteratations.
     ///
     /// - Parameters:
@@ -143,21 +143,21 @@ open class RepeatProcedure<T: Procedure>: GroupProcedure {
     ///   - max: an optional Int, which defaults to nil.
     ///   - wait: a WaitStrategy value, which defaults to .immediate
     ///   - iterator: a generic IteratorProtocol type, with a T Element type
-    public init<ProcedureIterator>(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, wait: WaitStrategy = .immediate, iterator: ProcedureIterator) where ProcedureIterator: IteratorProtocol, ProcedureIterator.Element == T {
+    public init<OperationIterator>(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, wait: WaitStrategy = .immediate, iterator: OperationIterator) where OperationIterator: IteratorProtocol, OperationIterator.Element == T {
         (_current, _iterator) = RepeatProcedure.create(withMax: max, andDelay: Delay.iterator(wait.iterator), andIterator: iterator)
         super.init(dispatchQueue: dispatchQueue, operations: [])
     }
 
     /// Initialize RepeatProcedure with a WaitStrategy and a closure. The closure returns
-    /// an optional instance of T, i.e. the Procedure subclass to be repeated.
+    /// an optional instance of T, i.e. the Operation subclass to be repeated.
     /// Other arguments allow for specific dispatch queues, and a maximum count of iteratations.
     ///
     /// This is the most convenient initializer, you can use it like this:
     /// ```
-    ///    let procedure = RepeatProcedure { MyProcedure() }
-    ///    let procedure = RepeatProcedure(dispatchQueue: target) { MyProcedure() }
-    ///    let procedure = RepeatProcedure(dispatchQueue: target, max: 5) { MyProcedure() }
-    ///    let procedure = RepeatProcedure(dispatchQueue: target, max: 5, wait: .constant(10)) { MyProcedure() }
+    ///    let procedure = RepeatProcedure { MyOperation() }
+    ///    let procedure = RepeatProcedure(dispatchQueue: target) { MyOperation() }
+    ///    let procedure = RepeatProcedure(dispatchQueue: target, max: 5) { MyOperation() }
+    ///    let procedure = RepeatProcedure(dispatchQueue: target, max: 5, wait: .constant(10)) { MyOperation() }
     /// ```
     ///
     /// - Parameters:

--- a/Sources/ProcedureKit/Repeat.swift
+++ b/Sources/ProcedureKit/Repeat.swift
@@ -9,10 +9,10 @@ import Dispatch
 
 /// Struct to hold the values necessary for each
 /// iteration of a RepeatProcedure. It is generic
-/// over the Operation type (i.e. the type being
+/// over the Procedure type (i.e. the type being
 /// iterated). However, it also holds an optional
 /// Delay property, and an optional ConfigureBlock.
-public struct RepeatProcedurePayload<T: Operation> {
+public struct RepeatProcedurePayload<T: Procedure> {
     public typealias ConfigureBlock = (T) -> Void
 
     /// - returns: the operation value
@@ -25,7 +25,7 @@ public struct RepeatProcedurePayload<T: Operation> {
     /// Initializes a payload struct.
     ///
     /// - Parameters:
-    ///   - operation: an instance of an Operation subclass T
+    ///   - operation: an instance of a Procedure subclass T
     ///   - delay: an optional Delay value, which defaults to nil
     ///   - configure: an optional closure which receives the operation, and which defaults to nil
     public init(operation: T, delay: Delay? = nil, configure: ConfigureBlock? = nil) {
@@ -45,21 +45,21 @@ public struct RepeatProcedurePayload<T: Operation> {
 
 /// RepeatProcedure is a GroupProcedure subclass which can be used to create
 /// polling or repeating procedures. Each child procedure is a new instance
-/// of the same Operation subclass T. For example `RepeatProcedure<MyOperation>`
-/// will create and execute instances of MyOperation repeatedly, and we say
+/// of the same Procedure subclass T. For example `RepeatProcedure<MyProcedure>`
+/// will create and execute instances of MyProcedure repeatedly, and we say
 /// that the RepeatProcedure is generic over T, which in this case is
-/// MyOperation.
+/// MyProcedure.
 ///
 /// While RepeatProcedure can be initialized in a variety of ways, it helps
 /// to understand that it works by using an Iterator. The iterator's payload
-/// is a structure which holds an instance of the Operation subclass (`T`),
-/// and optional Delay value, and an optional configuration block. The block
+/// is a structure which holds an instance of the Procedure subclass (`T`),
+/// an optional Delay value, and an optional configuration block. The block
 /// receives the instance, and can be used to prepare the operation before
 /// it is executed.
 ///
 /// All of the initializers available will ultimately create the underlying
 /// iterator.
-open class RepeatProcedure<T: Operation>: GroupProcedure {
+open class RepeatProcedure<T: Procedure>: GroupProcedure {
 
     public typealias Payload = RepeatProcedurePayload<T>
 
@@ -121,7 +121,7 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
     }
 
     /// Initialize RepeatProcedure with two iterators, the first one has `Delay` elements, the
-    /// second has `T` elements - i.e. the Operation subclass to be repeated.
+    /// second has `T` elements - i.e. the Procedure subclass to be repeated.
     /// Other arguments allow for specific dispatch queues, and a maximum count of iteratations.
     ///
     /// - Parameters:
@@ -129,13 +129,13 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
     ///   - max: an optional Int, which defaults to nil.
     ///   - delay: a generic IteratorProtocol type, with a Delay Element type
     ///   - iterator: a generic IteratorProtocol type, with a T Element type
-    public init<OperationIterator, DelayIterator>(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, delay: DelayIterator, iterator: OperationIterator) where OperationIterator: IteratorProtocol, DelayIterator: IteratorProtocol, OperationIterator.Element == T, DelayIterator.Element == Delay {
+    public init<ProcedureIterator, DelayIterator>(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, delay: DelayIterator, iterator: ProcedureIterator) where ProcedureIterator: IteratorProtocol, DelayIterator: IteratorProtocol, ProcedureIterator.Element == T, DelayIterator.Element == Delay {
         (_current, _iterator) = RepeatProcedure.create(withMax: max, andDelay: delay, andIterator: iterator)
         super.init(dispatchQueue: dispatchQueue, operations: [])
     }
 
     /// Initialize RepeatProcedure with a WaitStrategy and an iterator, which has `T` type
-    /// elements - i.e. the Operation subclass to be repeated.
+    /// elements - i.e. the Procedure subclass to be repeated.
     /// Other arguments allow for specific dispatch queues, and a maximum count of iteratations.
     ///
     /// - Parameters:
@@ -143,21 +143,21 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
     ///   - max: an optional Int, which defaults to nil.
     ///   - wait: a WaitStrategy value, which defaults to .immediate
     ///   - iterator: a generic IteratorProtocol type, with a T Element type
-    public init<OperationIterator>(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, wait: WaitStrategy = .immediate, iterator: OperationIterator) where OperationIterator: IteratorProtocol, OperationIterator.Element == T {
+    public init<ProcedureIterator>(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, wait: WaitStrategy = .immediate, iterator: ProcedureIterator) where ProcedureIterator: IteratorProtocol, ProcedureIterator.Element == T {
         (_current, _iterator) = RepeatProcedure.create(withMax: max, andDelay: Delay.iterator(wait.iterator), andIterator: iterator)
         super.init(dispatchQueue: dispatchQueue, operations: [])
     }
 
     /// Initialize RepeatProcedure with a WaitStrategy and a closure. The closure returns
-    /// an optional instance of T, i.e. the Operation subclass to be repeated.
+    /// an optional instance of T, i.e. the Procedure subclass to be repeated.
     /// Other arguments allow for specific dispatch queues, and a maximum count of iteratations.
     ///
     /// This is the most convenient initializer, you can use it like this:
     /// ```
-    ///    let procedure = RepeatProcedure { MyOperation() }
-    ///    let procedure = RepeatProcedure(dispatchQueue: target) { MyOperation() }
-    ///    let procedure = RepeatProcedure(dispatchQueue: target, max: 5) { MyOperation() }
-    ///    let procedure = RepeatProcedure(dispatchQueue: target, max: 5, wait: .constant(10)) { MyOperation() }
+    ///    let procedure = RepeatProcedure { MyProcedure() }
+    ///    let procedure = RepeatProcedure(dispatchQueue: target) { MyProcedure() }
+    ///    let procedure = RepeatProcedure(dispatchQueue: target, max: 5) { MyProcedure() }
+    ///    let procedure = RepeatProcedure(dispatchQueue: target, max: 5, wait: .constant(10)) { MyProcedure() }
     /// ```
     ///
     /// - Parameters:

--- a/Sources/ProcedureKit/Retry.swift
+++ b/Sources/ProcedureKit/Retry.swift
@@ -15,9 +15,6 @@ public struct RetryFailureInfo<T: Procedure> {
     /// - returns: the errors the operation finished with
     public let errors: [Error]
 
-    /// - returns: the previous errors of previous attempts
-    public let historicalErrors: [Error]
-
     /// - returns: the number of attempts made so far
     public let count: Int
 
@@ -112,45 +109,53 @@ open class RetryProcedure<T: Procedure>: RepeatProcedure<T> {
         super.init(dispatchQueue: dispatchQueue, max: max, iterator: retry)
     }
 
-    open override func childWillFinishWithoutErrors(_ child: Operation) {
-        // no-op
-        // To ensure that we do not retry/repeat successful procedures
-    }
-
-    open override func child(_ child: Operation, willAttemptRecoveryFromErrors errors: [Error]) -> Bool {
+    /// Handle child willFinish event
+    ///
+    /// This is used by RetryProcedure to trigger adding the next Procedure,
+    /// if the current Procedure fails with errors.
+    ///
+    /// If no further Procedure will be attempted (based on the Retry block / iterator),
+    /// it adds the current (last) Procedure's errors to the Group's errors.
+    ///
+    /// If subclassing RetryProcedure and overriding this method, consider
+    /// carefully whether / when / how you should call super.
+    open override func child(_ child: Procedure, willFinishWithErrors errors: [Error]) {
         eventQueue.debugAssertIsOnQueue()
-        guard child === current else { return false }
-        var returnValue = false
+        assert(!child.isFinished, "child(_:willFinishWithErrors:) called with a child that has already finished")
+        guard child === current else {
+            // There may be other Procedures that finish, such as DelayProcedures (between retried
+            // Procedures), and Procedures produced onto the Group's internal queue.
+            // 
+            // These other Procedures do not affect whether the RetryProcedure tries a next
+            // Procedure, and their errors (if any) are excluded from the RetryProcedure's
+            // errors.
+            return
+        }
+        guard !errors.isEmpty else {
+            // The RetryProcedure's current Procedure succeeded - stop retrying.
+            return
+        }
+
+        var willAttemptAnotherOperation = false
         defer {
-            let message = returnValue ? "will attempt" : "will not attempt"
-            log.notice(message: "\(message) recovery from errors: \(errors) in operation: \(child)")
+            log.notice(message: "\(willAttemptAnotherOperation ? "will attempt" : "will not attempt") recovery from errors: \(errors) in operation: \(child)")
         }
         retry.info = createFailureInfo(for: current, errors: errors)
-        returnValue = _addNextOperation()
+        willAttemptAnotherOperation = _addNextOperation()
         retry.info = .none
-        return returnValue
-    }
-
-    open override func child(_ child: Operation, didAttemptRecoveryFromErrors errors: [Error]) {
-        eventQueue.debugAssertIsOnQueue()
-        if let previous = previous, child === current {
-            childDidNotRecoverFromErrors(previous)
+        if !willAttemptAnotherOperation {
+            // If no further operation will be attempted, append the errors from this child
+            // to the Group's errors.
+            append(errors: errors, fromChild: child)
         }
-        super.child(child, didAttemptRecoveryFromErrors: errors)
-    }
-
-    open override func procedureQueue(_ queue: ProcedureQueue, willFinishProcedure procedure: Procedure, withErrors errors: [Error]) -> ProcedureFuture? {
-        if errors.isEmpty, let previous = previous, procedure === current {
-            childDidRecoverFromErrors(previous)
-        }
-        return super.procedureQueue(queue, willFinishProcedure: procedure, withErrors: errors)
+        // Do not call super.child(_:willFinishWithErrors:)
+        // To ensure that we do not retry/repeat successful procedures (via RepeatProcedure)
     }
 
     internal func createFailureInfo(for operation: T, errors: [Error]) -> FailureInfo {
         return FailureInfo(
             operation: operation,
             errors: errors,
-            historicalErrors: attemptedRecoveryErrors,
             count: count,
             addOperations: { self.add(children: $0, before: nil); return },
             log: log,

--- a/Sources/ProcedureKitCloud/CKAcceptSharesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKAcceptSharesOperation.swift
@@ -49,7 +49,7 @@ extension CKProcedure where T: CKAcceptSharesOperationProtocol, T: AssociatedErr
     func setAcceptSharesCompletionBlock(_ block: @escaping CloudKitProcedure<T>.AcceptSharesCompletionBlock) {
         operation.acceptSharesCompletionBlock = { [weak self] error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: PKCKError(underlyingError: error))
+                strongSelf.append(error: PKCKError(underlyingError: error))
             }
             else {
                 block()

--- a/Sources/ProcedureKitCloud/CKDiscoverAllContactsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKDiscoverAllContactsOperation.swift
@@ -40,7 +40,7 @@ extension CKProcedure where T: CKDiscoverAllContactsOperationProtocol, T: Associ
     func setDiscoverAllContactsCompletionBlock(_ block: @escaping CloudKitProcedure<T>.DiscoverAllContactsCompletionBlock) {
         operation.discoverAllContactsCompletionBlock = { [weak self] userInfos, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: DiscoverAllContactsError(underlyingError: error, userInfo: userInfos))
+                strongSelf.append(error: DiscoverAllContactsError(underlyingError: error, userInfo: userInfos))
             }
             else {
                 block(userInfos)

--- a/Sources/ProcedureKitCloud/CKDiscoverAllUserIdentitiesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKDiscoverAllUserIdentitiesOperation.swift
@@ -40,7 +40,7 @@ extension CKProcedure where T: CKDiscoverAllUserIdentitiesOperationProtocol, T: 
     func setDiscoverAllUserIdentitiesCompletionBlock(_ block: @escaping CloudKitProcedure<T>.DiscoverAllUserIdentitiesCompletionBlock) {
         operation.discoverAllUserIdentitiesCompletionBlock = { [weak self] error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: PKCKError(underlyingError: error))
+                strongSelf.append(error: PKCKError(underlyingError: error))
             }
             else {
                 block()

--- a/Sources/ProcedureKitCloud/CKDiscoverUserIdentitiesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKDiscoverUserIdentitiesOperation.swift
@@ -46,7 +46,7 @@ extension CKProcedure where T: CKDiscoverUserIdentitiesOperationProtocol, T: Ass
     func setDiscoverUserIdentitiesCompletionBlock(_ block: @escaping CloudKitProcedure<T>.DiscoverUserIdentitiesCompletionBlock) {
         operation.discoverUserIdentitiesCompletionBlock = { [weak self] error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: PKCKError(underlyingError: error))
+                strongSelf.append(error: PKCKError(underlyingError: error))
             }
             else {
                 block()

--- a/Sources/ProcedureKitCloud/CKDiscoverUserInfosOperation.swift
+++ b/Sources/ProcedureKitCloud/CKDiscoverUserInfosOperation.swift
@@ -55,7 +55,7 @@ extension CKProcedure where T: CKDiscoverUserInfosOperationProtocol, T: Associat
     func setDiscoverUserInfosCompletionBlock(_ block: @escaping CloudKitProcedure<T>.DiscoverUserInfosCompletionBlock) {
         operation.discoverUserInfosCompletionBlock = { [weak self] userInfoByEmail, userInfoByRecordID, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: DiscoverUserInfosError(underlyingError: error, userInfoByEmail: userInfoByEmail, userInfoByRecordID: userInfoByRecordID))
+                strongSelf.append(error: DiscoverUserInfosError(underlyingError: error, userInfoByEmail: userInfoByEmail, userInfoByRecordID: userInfoByRecordID))
             }
             else {
                 block(userInfoByEmail, userInfoByRecordID)

--- a/Sources/ProcedureKitCloud/CKFetchDatabaseChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchDatabaseChangesOperation.swift
@@ -87,7 +87,7 @@ extension CKProcedure where T: CKFetchDatabaseChangesOperationProtocol, T: Assoc
     func setFetchDatabaseChangesCompletionBlock(_ block: @escaping CloudKitProcedure<T>.FetchDatabaseChangesCompletionBlock) {
         operation.fetchDatabaseChangesCompletionBlock = { [weak self] (serverChangeToken, moreComing, error) in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: FetchDatabaseChangesError(underlyingError: error, token: serverChangeToken, moreComing: moreComing))
+                strongSelf.append(error: FetchDatabaseChangesError(underlyingError: error, token: serverChangeToken, moreComing: moreComing))
             }
             else {
                 block(serverChangeToken, moreComing)

--- a/Sources/ProcedureKitCloud/CKFetchNotificationChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchNotificationChangesOperation.swift
@@ -43,7 +43,7 @@ extension CKProcedure where T: CKFetchNotificationChangesOperationProtocol, T: A
 
         operation.fetchNotificationChangesCompletionBlock = { [weak self] token, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: FetchNotificationChangesError(underlyingError: error, token: token))
+                strongSelf.append(error: FetchNotificationChangesError(underlyingError: error, token: token))
             }
             else {
                 block(token)

--- a/Sources/ProcedureKitCloud/CKFetchRecordChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchRecordChangesOperation.swift
@@ -67,7 +67,7 @@ extension CKProcedure where T: CKFetchRecordChangesOperationProtocol, T: Associa
     func setFetchRecordChangesCompletionBlock(_ block: @escaping CloudKitProcedure<T>.FetchRecordChangesCompletionBlock) {
         operation.fetchRecordChangesCompletionBlock = { [weak self] token, data, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: FetchRecordChangesError(underlyingError: error, token: token, data: data))
+                strongSelf.append(error: FetchRecordChangesError(underlyingError: error, token: token, data: data))
             }
             else {
                 block(token, data)

--- a/Sources/ProcedureKitCloud/CKFetchRecordZoneChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchRecordZoneChangesOperation.swift
@@ -94,7 +94,7 @@ extension CKProcedure where T: CKFetchRecordZoneChangesOperationProtocol, T: Ass
     func setFetchRecordZoneChangesCompletionBlock(_ block: @escaping CloudKitProcedure<T>.FetchRecordZoneChangesCompletionBlock) {
         operation.fetchRecordZoneChangesCompletionBlock = { [weak self] error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: PKCKError(underlyingError: error))
+                strongSelf.append(error: PKCKError(underlyingError: error))
             }
             else {
                 block()

--- a/Sources/ProcedureKitCloud/CKFetchRecordZonesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchRecordZonesOperation.swift
@@ -43,7 +43,7 @@ extension CKProcedure where T: CKFetchRecordZonesOperationProtocol, T: Associate
     func setFetchRecordZonesCompletionBlock(_ block: @escaping CloudKitProcedure<T>.FetchRecordZonesCompletionBlock) {
         operation.fetchRecordZonesCompletionBlock = { [weak self] zonesByID, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: FetchRecordZonesError(underlyingError: error, zonesByID: zonesByID))
+                strongSelf.append(error: FetchRecordZonesError(underlyingError: error, zonesByID: zonesByID))
             }
             else {
                 block(zonesByID)

--- a/Sources/ProcedureKitCloud/CKFetchRecordsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchRecordsOperation.swift
@@ -59,7 +59,7 @@ extension CKProcedure where T: CKFetchRecordsOperationProtocol, T: AssociatedErr
     func setFetchRecordsCompletionBlock(_ block: @escaping CloudKitProcedure<T>.FetchRecordsCompletionBlock) {
         operation.fetchRecordsCompletionBlock = { [weak self] recordsByID, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: FetchRecordsError(underlyingError: error, recordsByID: recordsByID))
+                strongSelf.append(error: FetchRecordsError(underlyingError: error, recordsByID: recordsByID))
             }
             else {
                 block(recordsByID)

--- a/Sources/ProcedureKitCloud/CKFetchShareMetadataOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchShareMetadataOperation.swift
@@ -65,7 +65,7 @@ extension CKProcedure where T: CKFetchShareMetadataOperationProtocol, T: Associa
     func setFetchShareMetadataCompletionBlock(_ block: @escaping CloudKitProcedure<T>.FetchShareMetadataCompletionBlock) {
         operation.fetchShareMetadataCompletionBlock = { [weak self] error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: PKCKError(underlyingError: error))
+                strongSelf.append(error: PKCKError(underlyingError: error))
             }
             else {
                 block()

--- a/Sources/ProcedureKitCloud/CKFetchShareParticipantsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchShareParticipantsOperation.swift
@@ -49,7 +49,7 @@ extension CKProcedure where T: CKFetchShareParticipantsOperationProtocol, T: Ass
     func setFetchShareParticipantsCompletionBlock(_ block: @escaping CloudKitProcedure<T>.FetchShareParticipantsCompletionBlock) {
         operation.fetchShareParticipantsCompletionBlock = { [weak self] error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: PKCKError(underlyingError: error))
+                strongSelf.append(error: PKCKError(underlyingError: error))
             }
             else {
                 block()

--- a/Sources/ProcedureKitCloud/CKFetchSubscriptionsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchSubscriptionsOperation.swift
@@ -45,7 +45,7 @@ extension CKProcedure where T: CKFetchSubscriptionsOperationProtocol, T: Associa
     func setFetchSubscriptionCompletionBlock(_ block: @escaping CloudKitProcedure<T>.FetchSubscriptionCompletionBlock) {
         operation.fetchSubscriptionCompletionBlock = { [weak self] subscriptionsByID, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: FetchSubscriptionsError(underlyingError: error, subscriptionsByID: subscriptionsByID))
+                strongSelf.append(error: FetchSubscriptionsError(underlyingError: error, subscriptionsByID: subscriptionsByID))
             }
             else {
                 block(subscriptionsByID)

--- a/Sources/ProcedureKitCloud/CKMarkNotificationsReadOperation.swift
+++ b/Sources/ProcedureKitCloud/CKMarkNotificationsReadOperation.swift
@@ -46,7 +46,7 @@ extension CKProcedure where T: CKMarkNotificationsReadOperationProtocol, T: Asso
     func setMarkNotificationsReadCompletionBlock(_ block: @escaping CloudKitProcedure<T>.MarkNotificationsReadCompletionBlock) {
         operation.markNotificationsReadCompletionBlock = { [weak self] notificationIDs, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: MarkNotificationsReadError(underlyingError: error, marked: notificationIDs))
+                strongSelf.append(error: MarkNotificationsReadError(underlyingError: error, marked: notificationIDs))
             }
             else {
                 block(notificationIDs)

--- a/Sources/ProcedureKitCloud/CKModifyBadgeOperation.swift
+++ b/Sources/ProcedureKitCloud/CKModifyBadgeOperation.swift
@@ -37,7 +37,7 @@ extension CKProcedure where T: CKModifyBadgeOperationProtocol, T: AssociatedErro
     func setModifyBadgeCompletionBlock(_ block: @escaping CloudKitProcedure<T>.ModifyBadgeCompletionBlock) {
         operation.modifyBadgeCompletionBlock = { [weak self] error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: PKCKError(underlyingError: error))
+                strongSelf.append(error: PKCKError(underlyingError: error))
             }
             else {
                 block()

--- a/Sources/ProcedureKitCloud/CKModifyRecordZonesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKModifyRecordZonesOperation.swift
@@ -52,7 +52,7 @@ extension CKProcedure where T: CKModifyRecordZonesOperationProtocol, T: Associat
     func setModifyRecordZonesCompletionBlock(_ block: @escaping CloudKitProcedure<T>.ModifyRecordZonesCompletionBlock) {
         operation.modifyRecordZonesCompletionBlock = { [weak self] saved, deleted, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: ModifyRecordZonesError(underlyingError: error, saved: saved, deleted: deleted))
+                strongSelf.append(error: ModifyRecordZonesError(underlyingError: error, saved: saved, deleted: deleted))
             }
             else {
                 block(saved, deleted)

--- a/Sources/ProcedureKitCloud/CKModifyRecordsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKModifyRecordsOperation.swift
@@ -95,7 +95,7 @@ extension CKProcedure where T: CKModifyRecordsOperationProtocol, T: AssociatedEr
     func setModifyRecordsCompletionBlock(_ block: @escaping CloudKitProcedure<T>.ModifyRecordsCompletionBlock) {
         operation.modifyRecordsCompletionBlock = { [weak self] saved, deleted, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: ModifyRecordsError(underlyingError: error, saved: saved, deleted: deleted))
+                strongSelf.append(error: ModifyRecordsError(underlyingError: error, saved: saved, deleted: deleted))
             }
             else {
                 block(saved, deleted)

--- a/Sources/ProcedureKitCloud/CKModifySubscriptionsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKModifySubscriptionsOperation.swift
@@ -54,7 +54,7 @@ extension CKProcedure where T: CKModifySubscriptionsOperationProtocol, T: Associ
     func setModifySubscriptionsCompletionBlock(_ block: @escaping CloudKitProcedure<T>.ModifySubscriptionsCompletionBlock) {
         operation.modifySubscriptionsCompletionBlock = { [weak self] saved, deleted, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: ModifySubscriptionsError(underlyingError: error, saved: saved, deleted: deleted))
+                strongSelf.append(error: ModifySubscriptionsError(underlyingError: error, saved: saved, deleted: deleted))
             }
             else {
                 block(saved, deleted)

--- a/Sources/ProcedureKitCloud/CKQueryOperation.swift
+++ b/Sources/ProcedureKitCloud/CKQueryOperation.swift
@@ -67,7 +67,7 @@ extension CKProcedure where T: CKQueryOperationProtocol, T: AssociatedErrorProto
     func setQueryCompletionBlock(_ block: @escaping CloudKitProcedure<T>.QueryCompletionBlock) {
         operation.queryCompletionBlock = { [weak self] cursor, error in
             if let strongSelf = self, let error = error {
-                strongSelf.append(fatalError: QueryError(underlyingError: error, cursor: cursor))
+                strongSelf.append(error: QueryError(underlyingError: error, cursor: cursor))
             }
             else {
                 block(cursor)

--- a/Sources/TestingProcedureKit/ConcurrencyTestCase.swift
+++ b/Sources/TestingProcedureKit/ConcurrencyTestCase.swift
@@ -204,10 +204,7 @@ public class EventConcurrencyTrackingRegistrar {
 
         // GroupProcedure open functions
         case override_groupWillAdd_child(String)
-        case override_child_willAttemptRecoveryFromErrors(String)
-        case override_childWillFinishWithoutErrors(String)
-        // GroupProcedure non-final public functions
-        case override_child_didAttemptRecoveryFromErrors(String)
+        case override_child_willFinishWithErrors(String)
 
         public var description: String {
             switch self {
@@ -227,10 +224,7 @@ public class EventConcurrencyTrackingRegistrar {
             case .override_procedureDidFinish: return "procedureDidFinish()"
             // GroupProcedure open functions
             case .override_groupWillAdd_child(let child): return "groupWillAdd(child:) [\(child)]"
-            case .override_child_willAttemptRecoveryFromErrors(let child): return "child(_:willAttemptRecoveryFromErrors:) [\(child)]"
-            case .override_childWillFinishWithoutErrors(let child): return "childWillFinishWithoutErrors() [\(child)]"
-            // GroupProcedure public non-final functions
-            case .override_child_didAttemptRecoveryFromErrors(let child): return "child(_:didAttemptRecoveryFromErrors:) [\(child)]"
+            case .override_child_willFinishWithErrors(let child): return "child(_:willFinishWithErrors:) [\(child)]"
             }
         }
 
@@ -255,11 +249,7 @@ public class EventConcurrencyTrackingRegistrar {
                 return lhs_name == rhs_name
             case (.override_groupWillAdd_child(let lhs_child), .override_groupWillAdd_child(let rhs_child)):
                 return lhs_child == rhs_child
-            case (.override_child_willAttemptRecoveryFromErrors(let lhs_child), .override_child_willAttemptRecoveryFromErrors(let rhs_child)):
-                return lhs_child == rhs_child
-            case (.override_childWillFinishWithoutErrors(let lhs_child), .override_childWillFinishWithoutErrors(let rhs_child)):
-                return lhs_child == rhs_child
-            case (.override_child_didAttemptRecoveryFromErrors(let lhs_child), .override_child_didAttemptRecoveryFromErrors(let rhs_child)):
+            case (.override_child_willFinishWithErrors(let lhs_child), .override_child_willFinishWithErrors(let rhs_child)):
                 return lhs_child == rhs_child
             default:
                 return false
@@ -510,12 +500,8 @@ open class EventConcurrencyTrackingGroupProcedure: GroupProcedure, EventConcurre
         concurrencyRegistrar.doRun(.override_groupWillAdd_child(child.operationName))
         super.groupWillAdd(child: child)
     }
-    open override func child(_ child: Operation, willAttemptRecoveryFromErrors errors: [Error]) -> Bool {
-        concurrencyRegistrar.doRun(.override_child_willAttemptRecoveryFromErrors(child.operationName))
-        return super.child(child, willAttemptRecoveryFromErrors: errors)
-    }
-    open override func childWillFinishWithoutErrors(_ child: Operation) {
-        concurrencyRegistrar.doRun(.override_childWillFinishWithoutErrors(child.operationName))
-        super.childWillFinishWithoutErrors(child)
+    open override func child(_ child: Procedure, willFinishWithErrors errors: [Error]) {
+        concurrencyRegistrar.doRun(.override_child_willFinishWithErrors(child.operationName))
+        return super.child(child, willFinishWithErrors: errors)
     }
 }


### PR DESCRIPTION
Key changes:
- **`GroupProcedure`** child error handling is now centralized in a single **`child(_:willFinishWithErrors:)`** method, which is called for all finishing child Procedures (even if the errors array is empty). The default implementation in `GroupProcedure` appends the received child errors to the Group’s errors.
- **`GroupProcedure`** now uses an internal `GroupProcedureDelegate` object to forward delegate callbacks from its internal queue. Thus, `GroupProcedure` itself is no longer a `ProcedureQueueDelegate` (nor does it expose all the `ProcedureQueueDelegate` methods).
- **`RepeatProcedure`** and **`RetryProcedure`** now override the `child(_:willFinishWithErrors:)` method, providing a clearer execution flow (instead of jumping back-and-forth between multiple different overridden methods and GroupProcedure's internals and GroupProcedure's ProcedureQueueDelegate, etc).

Diff:

```diff
open class GroupProcedure: Procedure {
    ...
-   open func child(_ child: Operation, willAttemptRecoveryFromErrors errors: [Error]) -> Bool
-   open func childWillFinishWithoutErrors(_ child: Operation)
+   open func child(_ child: Procedure, willFinishWithErrors errors: [Error])
    ...
-   final public func append(fatalError error: Error)
+   final public func append(error: Error, fromChild child: Operation? = nil)
-   final public func append(fatalErrors errors: [Error])
+   final public func append(errors: [Error], fromChild child: Operation? = nil)
-   final public func child(_ child: Operation, didEncounterFatalError error: Error)
-   final public func child(_ child: Operation, didEncounterFatalErrors errors: [Error])
-   final public func childDidRecoverFromErrors(_ child: Operation)
-   final public func childDidNotRecoverFromErrors(_ child: Operation)
    ...
-   func procedureQueue(_ queue: ProcedureQueue, willAddOperation operation: Operation, context: Any?) -> ProcedureFuture?
-   func procedureQueue(_ queue: ProcedureQueue, didAddOperation operation: Operation, context: Any?)
-   func procedureQueue(_ queue: ProcedureQueue, didFinishOperation operation: Operation)
-   func procedureQueue(_ queue: ProcedureQueue, willAddProcedure procedure: Procedure, context: Any?) -> ProcedureFuture?
-   func procedureQueue(_ queue: ProcedureQueue, didAddProcedure procedure: Procedure, context: Any?)
-   func procedureQueue(_ queue: ProcedureQueue, willFinishProcedure procedure: Procedure, withErrors errors: [Error]) -> ProcedureFuture?
-   func procedureQueue(_ queue: ProcedureQueue, didFinishProcedure procedure: Procedure, withErrors errors: [Error])
}

public struct RetryFailureInfo<T: Procedure> {
-   public let historicalErrors: [Error]
}
```