### PR TITLE
Add `transformChildErrorsBlock` to GroupProcedure

### DIFF
--- a/Sources/TestingProcedureKit/ConcurrencyTestCase.swift
+++ b/Sources/TestingProcedureKit/ConcurrencyTestCase.swift
@@ -205,6 +205,8 @@ public class EventConcurrencyTrackingRegistrar {
         // GroupProcedure open functions
         case override_groupWillAdd_child(String)
         case override_child_willFinishWithErrors(String)
+        // GroupProcedure handlers
+        case group_transformChildErrorsBlock(String)
 
         public var description: String {
             switch self {
@@ -225,6 +227,7 @@ public class EventConcurrencyTrackingRegistrar {
             // GroupProcedure open functions
             case .override_groupWillAdd_child(let child): return "groupWillAdd(child:) [\(child)]"
             case .override_child_willFinishWithErrors(let child): return "child(_:willFinishWithErrors:) [\(child)]"
+            case .group_transformChildErrorsBlock(let child): return "group.transformChildErrorsBlock [\(child)]"
             }
         }
 
@@ -250,6 +253,8 @@ public class EventConcurrencyTrackingRegistrar {
             case (.override_groupWillAdd_child(let lhs_child), .override_groupWillAdd_child(let rhs_child)):
                 return lhs_child == rhs_child
             case (.override_child_willFinishWithErrors(let lhs_child), .override_child_willFinishWithErrors(let rhs_child)):
+                return lhs_child == rhs_child
+            case (.group_transformChildErrorsBlock(let lhs_child), .group_transformChildErrorsBlock(let rhs_child)):
                 return lhs_child == rhs_child
             default:
                 return false
@@ -473,6 +478,10 @@ open class EventConcurrencyTrackingGroupProcedure: GroupProcedure, EventConcurre
         self.name = name
         if let baseObserver = baseObserver {
             add(observer: baseObserver)
+        }
+        // GroupProcedure transformChildErrorsBlock
+        transformChildErrorsBlock = { [concurrencyRegistrar] (child, errors) in
+            concurrencyRegistrar.doRun(.group_transformChildErrorsBlock(child.operationName))
         }
     }
     open override func execute() {


### PR DESCRIPTION
Enables customization of the finishing errors of the GroupProcedure without subclassing.

```diff
open class GroupProcedure {
    ...
+   public typealias TransformChildErrorsBlockType = (Procedure, inout [Error]) -> Void
    ...
+   final public var transformChildErrorsBlock: TransformChildErrorsBlockType?
    ...
}
```

### Description:
The `transformChildErrorsBlock` is called before the `GroupProcedure` handles child errors.
(It is called on the Group's EventQueue.)

The block is passed two parameters:
- `Procedure`: the child Procedure that will finish
- `inout [Error]`: the errors that the Group attributes to the child (on input: the errors that the child Procedure will finish with)

The array of errors is an `inout` parameter, and may be modified directly.

This enables the customization of the errors that the GroupProcedure (or GroupProcedure subclass) attributes to the child and considers in its `child(_:willFinishWithErrors:)` function.

> **IMPORTANT:** This only affects the child errors that the GroupProcedure (or GroupProcedure subclass) utilizes. It does not directly impact the child Procedure itself, nor the child Procedure's errors (if obtained or read directly from the child).

### Example:

```swift
let child1 = ProcedureA()
let child2 = ProcedureB()
child2.add(dependency: child1)
child2.add(condition: NoFailedDependenciesCondition())
let group = GroupProcedure(operations: [child1, child2])
group.transformChildErrorsBlock = { (child, errors) in
    // to filter any errors from `child1` from the Group's final errors:
    if child === child1 {
        errors.removeAll()
    }
}
```

The above will filter any errors from `child1` from the Group's final errors.

However, if `child1` fails, `child2` will still fail because one of its dependencies (`child1`) finished with errors (and it has a `NoFailedDependenciesCondition`). The `transformChildErrorsBlock` only affects the child errors that the _Group_ considers.