### PR TITLE
Revise several #if swift conditions to >= 3.2

### DIFF
--- a/Sources/ProcedureKit/NetworkObserver.swift
+++ b/Sources/ProcedureKit/NetworkObserver.swift
@@ -8,9 +8,9 @@ import Foundation
 import Dispatch
 
 public protocol NetworkActivityIndicatorProtocol {
-    #if swift(>=4.0)
+    #if swift(>=3.2)
         var isNetworkActivityIndicatorVisible: Bool { get set }
-    #else // Swift 3.x
+    #else // Swift < 3.2 (Xcode 8.x)
         var networkActivityIndicatorVisible: Bool { get set }
     #endif
 }
@@ -77,11 +77,11 @@ public class NetworkActivityController {
         delayedHide = nil
         DispatchQueue.main.async {
             // only set the visibility if it has changed
-            #if swift(>=4.0)
+            #if swift(>=3.2)
                 if self.indicator.isNetworkActivityIndicatorVisible != visibility {
                     self.indicator.isNetworkActivityIndicatorVisible = visibility
                 }
-            #else // Swift 3.x
+            #else // Swift < 3.2 (Xcode 8.x)
                 if self.indicator.networkActivityIndicatorVisible != visibility {
                     self.indicator.networkActivityIndicatorVisible = visibility
                 }

--- a/Sources/ProcedureKit/ProcedureEventQueue.swift
+++ b/Sources/ProcedureKit/ProcedureEventQueue.swift
@@ -266,9 +266,9 @@ extension DispatchQueue: DispatchQueueProtocol {
     }
     #if DEBUG
     public func pk_setSpecific<T>(key: DispatchSpecificKey<T>, value: T?) {
-        #if swift(>=4.0)
+        #if swift(>=3.2)
             setSpecific(key: key, value: value)
-        #else // Swift 3.x
+        #else // Swift < 3.2 (Xcode 8.x)
             if let value = value {
                 setSpecific(key: key, value: value)
             }

--- a/Sources/ProcedureKitCloud/CKOperation.swift
+++ b/Sources/ProcedureKitCloud/CKOperation.swift
@@ -84,11 +84,11 @@ public protocol CKOperationProtocol: class {
     @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
     var operationID: String { get }
 
-    #if swift(>=4.0)
+    #if swift(>=3.2)
         /// - returns whether the operation is long-lived
         @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
         var isLongLived: Bool { get set }
-    #else // Swift 3.x
+    #else // Swift < 3.2 (Xcode 8.x)
         /// - returns whether the operation is long-lived
         @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
         var longLived: Bool { get set }
@@ -198,17 +198,17 @@ extension CKProcedure {
         get { return operation.operationID }
     }
 
-    #if swift(>=4.0)
+    #if swift(>=3.2)
         @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
         public var isLongLived: Bool {
             get { return operation.isLongLived }
             set { operation.isLongLived = newValue }
         }
 
-        // Renamed in Swift 4
+        // Renamed in Swift 3.2+
         @available(*, unavailable, renamed: "isLongLived")
         public var longLived: Bool { fatalError("Use isLongLived") }
-    #else // Swift 3.x
+    #else // Swift < 3.2 (Xcode 8.x)
         @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
         public var longLived: Bool {
             get { return operation.longLived }
@@ -261,7 +261,7 @@ extension CloudKitProcedure {
         get { return current.operationID }
     }
 
-    #if swift(>=4.0)
+    #if swift(>=3.2)
         /// - returns whether the operation is long-lived
         @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
         public var isLongLived: Bool {
@@ -275,7 +275,7 @@ extension CloudKitProcedure {
         // Renamed in Swift 4
         @available(*, unavailable, renamed: "isLongLived")
         public var longLived: Bool { fatalError("Use isLongLived") }
-    #else // Swift 3.x
+    #else // Swift < 3.2 (Xcode 8.x)
         /// - returns whether the operation is long-lived
         @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
         public var longLived: Bool {

--- a/Tests/ProcedureKitCloudTests/CKOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKOperationTests.swift
@@ -35,7 +35,7 @@ class TestCKOperation: Operation, CKOperationProtocol {
 
     //@available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
     var operationID: String = ""
-    #if swift(>=4.0)
+    #if swift(>=3.2)
         var isLongLived: Bool = false
     #else // Swift 3.x
         var longLived: Bool = false
@@ -89,11 +89,11 @@ class CKOperationTests: CKProcedureTestCase {
     @available(iOS 9.3, tvOS 9.3, OSX 10.12, watchOS 2.3, *)
     func test__set_get__longLived() {
         let longLived = true
-        #if swift(>=4.0)
+        #if swift(>=3.2)
             operation.isLongLived = longLived
             XCTAssertEqual(operation.isLongLived, longLived)
             XCTAssertEqual(target.isLongLived, longLived)
-        #else // Swift 3.x
+        #else // Swift < 3.2 (Xcode 8.x)
             operation.longLived = longLived
             XCTAssertEqual(operation.longLived, longLived)
             XCTAssertEqual(target.longLived, longLived)

--- a/Tests/ProcedureKitTests/NetworkObserverTests.swift
+++ b/Tests/ProcedureKitTests/NetworkObserverTests.swift
@@ -17,13 +17,13 @@ class TestableNetworkActivityIndicator: NetworkActivityIndicatorProtocol {
         visibilityDidChange = didChange
     }
 
-    #if swift(>=4.0)
+    #if swift(>=3.2)
         var isNetworkActivityIndicatorVisible = false {
             didSet {
                 visibilityDidChange(isNetworkActivityIndicatorVisible)
             }
         }
-    #else // Swift 3.x
+    #else // Swift < 3.2 (Xcode 8.x)
         var networkActivityIndicatorVisible = false {
             didSet {
                 visibilityDidChange(networkActivityIndicatorVisible)


### PR DESCRIPTION
Several conditions that were `#if swift(>=4.0)` should actually be `#if swift(>=3.2)`, as the changes apply even in Swift 3 mode ("Swift 3.2") in Xcode 9.