### PR TITLE
Update CI to fix issue with anon users & triggers in Buildkite 

### DIFF
--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 cat <<-YAML
 steps:
   -

--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -7,20 +7,3 @@ steps:
     agents:
       xcode: "$XCODE"
 YAML
-
-if [[ "$BUILDKITE_BUILD_CREATOR" == "Daniel Thorpe" ]]; then
-  cat <<-YAML
-
-  - wait
-
-  -
-    name: "Test CocoaPods Integration"
-    trigger: "tryprocedurekit"
-    build:
-      message: "Testing ProcedureKit Integration via Cocoapods"
-      commit: "HEAD"
-      branch: "cocoapods"
-      env:
-        PROCEDUREKIT_HASH: "$COMMIT"
-YAML
-fi

--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -11,7 +11,9 @@ YAML
 
 if [[ "$BUILDKITE_BUILD_CREATOR" == "Daniel Thorpe" ]]; then
   cat <<-YAML
+
   - wait
+
   -
     name: "Test CocoaPods Integration"
     trigger: "tryprocedurekit"

--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -8,7 +8,7 @@ steps:
 YAML
 
 if [[ "$BUILDKITE_BUILD_CREATOR" == "Daniel Thorpe" ]]; then
-  cat <<-YAML
+cat <<-YAML
 
   - wait
 

--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
 cat <<-YAML
 steps:
-  -
-    name: "ProcedureKit"
+  - name: "ProcedureKit"
     command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane mac test"
     agents:
       xcode: "$XCODE"
 YAML
+
+if [[ "$BUILDKITE_BUILD_CREATOR" == "Daniel Thorpe" ]]; then
+  cat <<-YAML
+
+  - wait
+
+  - name: "Test CocoaPods Integration"
+    trigger: "tryprocedurekit"
+    build:
+      message: "Testing ProcedureKit Integration via Cocoapods"
+      commit: "HEAD"
+      branch: "cocoapods"
+      env:
+        PROCEDUREKIT_HASH: "$COMMIT"
+YAML
+fi

--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+cat <<-YAML
+steps:
+  -
+    name: "ProcedureKit"
+    command: "source /usr/local/opt/chruby/share/chruby/chruby.sh && chruby ruby && bundle install --quiet && bundle exec fastlane mac test"
+    agents:
+      xcode: "$XCODE"
+YAML
+
+if [[ "$BUILDKITE_BUILD_CREATOR" == "Daniel Thorpe" ]]; then
+  cat <<-YAML
+  - wait
+  -
+    name: "Test CocoaPods Integration"
+    trigger: "tryprocedurekit"
+    build:
+      message: "Testing ProcedureKit Integration via Cocoapods"
+      commit: "HEAD"
+      branch: "cocoapods"
+      env:
+        PROCEDUREKIT_HASH: "$COMMIT"
+YAML
+fi

--- a/.ci/buildkite/pipeline.template.yml
+++ b/.ci/buildkite/pipeline.template.yml
@@ -95,6 +95,7 @@ steps:
   
   -
     name: "Test CocoaPods Integration"
+    branches: "master release/*"      
     trigger: "tryprocedurekit"
     build:
       message: "Testing ProcedureKit Integration via Cocoapods"

--- a/.ci/buildkite/upload
+++ b/.ci/buildkite/upload
@@ -4,4 +4,4 @@ set -eu
 
 # Makes sure all the steps run on this same agent
 #sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/" .ci/buildkite/pipeline.template.yml
-sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/" .ci/buildkite/pipeline.sh
+sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/" .ci/buildkite/pipeline.sh | sh

--- a/.ci/buildkite/upload
+++ b/.ci/buildkite/upload
@@ -3,4 +3,5 @@
 set -eu
 
 # Makes sure all the steps run on this same agent
-sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/" .ci/buildkite/pipeline.template.yml
+#sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/" .ci/buildkite/pipeline.template.yml
+sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/" .ci/buildkite/pipeline.sh


### PR DESCRIPTION
Turns out that there is a bug in Buildkite where anonymous users are not supported when a build pipeline contains "triggers", such as the one we use to trigger CI in the sister project [TryProcedureKit](https://github.com/ProcedureKit/TryProcedureKit) to perform CocoaPods integration testing.

The solution to this is to either add some more scripting (which I don't want to do). Instead, we'll add a block step, and then a pipeline upload to trigger the job. This will mean that only logged in users (me, and the open source user, can trigger integration testing). I might also limit this to `release/*` branches.  