### PR TITLE
Add trigger to build ProcedureKit documentation

### DIFF
--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -24,13 +24,12 @@ YAML
 fi
 
 cat <<-YAML
-  - block: ":aws: Generate Documentation"
-    branches: "master development release/*"
+  - block: ":aws: Update Documentation"
 
-  - name: ":aws: Generate Documentation"
+  - name: ":aws: Generate Docs"
     trigger: "procedurekit-documentation"
     build:
-      message: "Generating documentation for ProcedureKit"
+      message: "Generating docs for ProcedureKit"
       commit: "HEAD"
       branch: "setup"
       env:

--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -24,12 +24,15 @@ YAML
 fi
 
 cat <<-YAML
-  - block: ":aws: Generate Documentation"
+
+  - wait
+
+  - block: ":aws: Docs"
     branches: "!features/*"
 
-  - name: ":aws: Generate Documentation"
-    branches: "!features/*"  
+  - label: ":aws:"
     trigger: "procedurekit-documentation"
+    branches: "!features/*"  
     build:
       message: "Generating documentation for ProcedureKit"
       commit: "HEAD"

--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -24,14 +24,16 @@ YAML
 fi
 
 cat <<-YAML
-#  - block: ":aws: Update Documentation"
+  - block: ":aws: Generate Documentation"
+    branches: "!features/*"
 
-  - name: ":aws: Generate Docs"
+  - name: ":aws: Generate Documentation"
+    branches: "!features/*"  
     trigger: "procedurekit-documentation"
     build:
-      message: "Generating docs for ProcedureKit"
+      message: "Generating documentation for ProcedureKit"
       commit: "HEAD"
-      branch: "setup"
+      branch: "master"
       env:
         PROCEDUREKIT_HASH: "$COMMIT"
         PROCEDUREKIT_BRANCH: "$BRANCH"

--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -22,3 +22,19 @@ cat <<-YAML
         PROCEDUREKIT_HASH: "$COMMIT"
 YAML
 fi
+
+cat <<-YAML
+  - block: ":aws: Generate Documentation"
+    branches: "master development release/*"
+
+  - name: ":aws: Generate Documentation"
+    trigger: "procedurekit-documentation"
+    build:
+      message: "Generating documentation for ProcedureKit"
+      commit: "HEAD"
+      branch: "setup"
+      env:
+        PROCEDUREKIT_HASH: "$COMMIT"
+        PROCEDUREKIT_BRANCH: "$BRANCH"        
+
+YAML

--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -24,7 +24,7 @@ YAML
 fi
 
 cat <<-YAML
-  - block: ":aws: Update Documentation"
+#  - block: ":aws: Update Documentation"
 
   - name: ":aws: Generate Docs"
     trigger: "procedurekit-documentation"
@@ -34,6 +34,5 @@ cat <<-YAML
       branch: "setup"
       env:
         PROCEDUREKIT_HASH: "$COMMIT"
-        PROCEDUREKIT_BRANCH: "$BRANCH"        
-
+        PROCEDUREKIT_BRANCH: "$BRANCH"
 YAML

--- a/.ci/buildkite/upload
+++ b/.ci/buildkite/upload
@@ -4,4 +4,4 @@ set -eu
 
 # Makes sure all the steps run on this same agent
 #sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/" .ci/buildkite/pipeline.template.yml
-sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/;s/\$BRANCH/$BUILDKITE_BRANCH/" .ci/buildkite/pipeline.sh | sh
+sed "s~\$XCODE~$BUILDKITE_AGENT_META_DATA_XCODE~;s~\$COMMIT~$BUILDKITE_COMMIT~;s~\$BRANCH~$BUILDKITE_BRANCH~" .ci/buildkite/pipeline.sh | sh

--- a/.ci/buildkite/upload
+++ b/.ci/buildkite/upload
@@ -4,4 +4,4 @@ set -eu
 
 # Makes sure all the steps run on this same agent
 #sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/" .ci/buildkite/pipeline.template.yml
-sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/;s/\$BRANCH/$BRANCH_COMMIT/" .ci/buildkite/pipeline.sh | sh
+sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/;s/\$BRANCH/$BUILDKITE_BRANCH/" .ci/buildkite/pipeline.sh | sh

--- a/.ci/buildkite/upload
+++ b/.ci/buildkite/upload
@@ -4,4 +4,4 @@ set -eu
 
 # Makes sure all the steps run on this same agent
 #sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/" .ci/buildkite/pipeline.template.yml
-sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/" .ci/buildkite/pipeline.sh | sh
+sed "s/\$XCODE/$BUILDKITE_AGENT_META_DATA_XCODE/;s/\$COMMIT/$BUILDKITE_COMMIT/;s/\$BRANCH/$BRANCH_COMMIT/" .ci/buildkite/pipeline.sh | sh


### PR DESCRIPTION
Docs are generated with [ProcedureKit/Documentation](https://github.com/ProcedureKit/Documentation) project, on [procedure.kit.run](http://procedure.kit.run/development).