### PR TITLE
Remove associatedtype from ProcedureObserver

### DIFF
--- a/Sources/ProcedureKit/AnyObserver.swift
+++ b/Sources/ProcedureKit/AnyObserver.swift
@@ -5,7 +5,7 @@
 //
 
 import Foundation
-
+/*
 class AnyObserverBox_<Procedure: ProcedureProtocol>: ProcedureObserver {
     func didAttach(to procedure: Procedure) { _abstractMethod() }
     func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) { _abstractMethod() }
@@ -107,3 +107,4 @@ public struct AnyObserver<Procedure: ProcedureProtocol>: ProcedureObserver {
         return box.eventQueue
     }
 }
+*/

--- a/Sources/ProcedureKit/BlockObservers.swift
+++ b/Sources/ProcedureKit/BlockObservers.swift
@@ -26,7 +26,7 @@ public struct Observer<Procedure: ProcedureProtocol> {
 
 public func typedProcedure<ProcedureType: ProcedureProtocol>(_ procedure: ProcedureProtocol) -> ProcedureType? {
     guard let typedProcedure = procedure as? ProcedureType else {
-        procedure.log.warning(message: "Unable to convert to the expected type \"\(String(describing: ProcedureType))\"")
+        procedure.log.warning(message: "Unable to convert to the expected type \"\(String(describing: ProcedureType.self))\"")
         return nil
     }
     return typedProcedure
@@ -95,43 +95,59 @@ public struct BlockObserver<Procedure: ProcedureProtocol>: ProcedureObserver {
     }
 
     public func didAttach(to procedure: ProcedureProtocol) {
+        guard let didAttach = didAttach else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didAttach?(typedProcedure)
+        didAttach(typedProcedure)
     }
 
     public func will(execute procedure: ProcedureProtocol, pendingExecute: PendingExecuteEvent) {
+        guard let willExecute = willExecute else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        willExecute?(typedProcedure, pendingExecute)
+        willExecute(typedProcedure, pendingExecute)
     }
 
     public func did(execute procedure: ProcedureProtocol) {
+        guard let didExecute = didExecute else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didExecute?(typedProcedure)
+        didExecute(typedProcedure)
     }
 
     public func did(cancel procedure: ProcedureProtocol, withErrors errors: [Error]) {
+        guard let didCancel = didCancel else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didCancel?(typedProcedure, errors)
+        didCancel(typedProcedure, errors)
     }
 
     public func procedure(_ procedure: ProcedureProtocol, willAdd newOperation: Operation) {
+        guard let willAdd = willAdd else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        willAdd?(typedProcedure, newOperation)
+        willAdd(typedProcedure, newOperation)
     }
 
     public func procedure(_ procedure: ProcedureProtocol, didAdd newOperation: Operation) {
+        guard let didAdd = didAdd else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didAdd?(typedProcedure, newOperation)
+        didAdd(typedProcedure, newOperation)
     }
 
     public func will(finish procedure: ProcedureProtocol, withErrors errors: [Error], pendingFinish: PendingFinishEvent) {
+        guard let willFinish = willFinish else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        willFinish?(typedProcedure, errors, pendingFinish)
+        willFinish(typedProcedure, errors, pendingFinish)
     }
 
     public func did(finish procedure: ProcedureProtocol, withErrors errors: [Error]) {
+        guard let didFinish = didFinish else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didFinish?(typedProcedure, errors)
+        didFinish(typedProcedure, errors)
+    }
+
+    private func typedProcedure(_ procedure: ProcedureProtocol) -> Procedure? {
+        guard let typedProcedure = procedure as? Procedure else {
+            procedure.log.warning(message: "BlockObserver<\(String(describing: Procedure.self))> will not receive event. Unable to convert input procedure \"\(procedure.procedureName)\" to the expected type `\(String(describing: Procedure.self))`")
+            return nil
+        }
+        return typedProcedure
     }
 }
 
@@ -159,8 +175,9 @@ public struct WillExecuteObserver<Procedure: ProcedureProtocol>: ProcedureObserv
     }
 
     public func didAttach(to procedure: ProcedureProtocol) {
+        guard let didAttachToProcedure = didAttachToProcedure else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didAttachToProcedure?(typedProcedure)
+        didAttachToProcedure(typedProcedure)
     }
 
     /// Conforms to `WillExecuteProcedureObserver`, executes the block
@@ -204,8 +221,9 @@ public struct DidExecuteObserver<Procedure: ProcedureProtocol>: ProcedureObserve
     }
 
     public func didAttach(to procedure: ProcedureProtocol) {
+        guard let didAttachToProcedure = didAttachToProcedure else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didAttachToProcedure?(typedProcedure)
+        didAttachToProcedure(typedProcedure)
     }
 
     /// Conforms to `DidExecuteProcedureObserver`, executes the block
@@ -237,8 +255,9 @@ public struct DidCancelObserver<Procedure: ProcedureProtocol>: ProcedureObserver
 
     /// - parameter to: the procedure which is attached
     public func didAttach(to procedure: ProcedureProtocol) {
+        guard let didAttachToProcedure = didAttachToProcedure else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didAttachToProcedure?(typedProcedure)
+        didAttachToProcedure(typedProcedure)
     }
 
     /// Observes when the attached procedure did cancel.
@@ -272,8 +291,9 @@ public struct WillAddOperationObserver<Procedure: ProcedureProtocol>: ProcedureO
 
     /// - parameter to: the procedure which is attached
     public func didAttach(to procedure: ProcedureProtocol) {
+        guard let didAttachToProcedure = didAttachToProcedure else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didAttachToProcedure?(typedProcedure)
+        didAttachToProcedure(typedProcedure)
     }
 
     /// Observes when the attached procedure will add another Operation.
@@ -307,8 +327,9 @@ public struct DidAddOperationObserver<Procedure: ProcedureProtocol>: ProcedureOb
 
     /// - parameter to: the procedure which is attached
     public func didAttach(to procedure: ProcedureProtocol) {
+        guard let didAttachToProcedure = didAttachToProcedure else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didAttachToProcedure?(typedProcedure)
+        didAttachToProcedure(typedProcedure)
     }
 
     /// Observes when the attached procedure did add another Operation.
@@ -342,8 +363,9 @@ public struct WillFinishObserver<Procedure: ProcedureProtocol>: ProcedureObserve
 
     /// - parameter to: the procedure which is attached
     public func didAttach(to procedure: ProcedureProtocol) {
+        guard let didAttachToProcedure = didAttachToProcedure else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didAttachToProcedure?(typedProcedure)
+        didAttachToProcedure(typedProcedure)
     }
 
     /// Observes when the attached procedure will finish.
@@ -379,8 +401,9 @@ public struct DidFinishObserver<Procedure: ProcedureProtocol>: ProcedureObserver
 
     /// - parameter to: the procedure which is attached
     public func didAttach(to procedure: ProcedureProtocol) {
+        guard let didAttachToProcedure = didAttachToProcedure else { return }
         guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
-        didAttachToProcedure?(typedProcedure)
+        didAttachToProcedure(typedProcedure)
     }
 
     /// Observes when the attached procedure did finish.

--- a/Sources/ProcedureKit/BlockObservers.swift
+++ b/Sources/ProcedureKit/BlockObservers.swift
@@ -24,6 +24,14 @@ public struct Observer<Procedure: ProcedureProtocol> {
     private init() { }
 }
 
+public func typedProcedure<ProcedureType: ProcedureProtocol>(_ procedure: ProcedureProtocol) -> ProcedureType? {
+    guard let typedProcedure = procedure as? ProcedureType else {
+        procedure.log.warning(message: "Unable to convert \(procedure) to the expected type \(String(describing: type(of: ProcedureType.self)))")
+        return nil
+    }
+    return typedProcedure
+}
+
 public struct BlockObserver<Procedure: ProcedureProtocol>: ProcedureObserver {
 
     /// - returns: the block which is called when the observer is attached to a procedure
@@ -86,36 +94,44 @@ public struct BlockObserver<Procedure: ProcedureProtocol>: ProcedureObserver {
             self.didFinish = didFinish
     }
 
-    public func didAttach(to procedure: Procedure) {
-        didAttach?(procedure)
+    public func didAttach(to procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didAttach?(typedProcedure)
     }
 
-    public func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) {
-        willExecute?(procedure, pendingExecute)
+    public func will(execute procedure: ProcedureProtocol, pendingExecute: PendingExecuteEvent) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        willExecute?(typedProcedure, pendingExecute)
     }
 
-    public func did(execute procedure: Procedure) {
-        didExecute?(procedure)
+    public func did(execute procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didExecute?(typedProcedure)
     }
 
-    public func did(cancel procedure: Procedure, withErrors errors: [Error]) {
-        didCancel?(procedure, errors)
+    public func did(cancel procedure: ProcedureProtocol, withErrors errors: [Error]) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didCancel?(typedProcedure, errors)
     }
 
-    public func procedure(_ procedure: Procedure, willAdd newOperation: Operation) {
-        willAdd?(procedure, newOperation)
+    public func procedure(_ procedure: ProcedureProtocol, willAdd newOperation: Operation) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        willAdd?(typedProcedure, newOperation)
     }
 
-    public func procedure(_ procedure: Procedure, didAdd newOperation: Operation) {
-        didAdd?(procedure, newOperation)
+    public func procedure(_ procedure: ProcedureProtocol, didAdd newOperation: Operation) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didAdd?(typedProcedure, newOperation)
     }
 
-    public func will(finish procedure: Procedure, withErrors errors: [Error], pendingFinish: PendingFinishEvent) {
-        willFinish?(procedure, errors, pendingFinish)
+    public func will(finish procedure: ProcedureProtocol, withErrors errors: [Error], pendingFinish: PendingFinishEvent) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        willFinish?(typedProcedure, errors, pendingFinish)
     }
 
-    public func did(finish procedure: Procedure, withErrors errors: [Error]) {
-        didFinish?(procedure, errors)
+    public func did(finish procedure: ProcedureProtocol, withErrors errors: [Error]) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didFinish?(typedProcedure, errors)
     }
 }
 
@@ -142,13 +158,15 @@ public struct WillExecuteObserver<Procedure: ProcedureProtocol>: ProcedureObserv
         self.eventQueue = queueProvider?.providedQueue
     }
 
-    public func didAttach(to procedure: Procedure) {
-        didAttachToProcedure?(procedure)
+    public func didAttach(to procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didAttachToProcedure?(typedProcedure)
     }
 
     /// Conforms to `WillExecuteProcedureObserver`, executes the block
-    public func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) {
-        block(procedure, pendingExecute)
+    public func will(execute procedure: ProcedureProtocol, pendingExecute: PendingExecuteEvent) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        block(typedProcedure, pendingExecute)
     }
 }
 
@@ -185,13 +203,15 @@ public struct DidExecuteObserver<Procedure: ProcedureProtocol>: ProcedureObserve
         self.eventQueue = queueProvider?.providedQueue
     }
 
-    public func didAttach(to procedure: Procedure) {
-        didAttachToProcedure?(procedure)
+    public func didAttach(to procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didAttachToProcedure?(typedProcedure)
     }
 
     /// Conforms to `DidExecuteProcedureObserver`, executes the block
-    public func did(execute procedure: Procedure) {
-        block(procedure)
+    public func did(execute procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        block(typedProcedure)
     }
 }
 
@@ -216,15 +236,17 @@ public struct DidCancelObserver<Procedure: ProcedureProtocol>: ProcedureObserver
     }
 
     /// - parameter to: the procedure which is attached
-    public func didAttach(to procedure: Procedure) {
-        didAttachToProcedure?(procedure)
+    public func didAttach(to procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didAttachToProcedure?(typedProcedure)
     }
 
     /// Observes when the attached procedure did cancel.
     /// - parameter cancel: the procedure which is cancelled.
     /// - parameter errors: the errors the procedure was cancelled with.
-    public func did(cancel procedure: Procedure, withErrors errors: [Error]) {
-        block(procedure, errors)
+    public func did(cancel procedure: ProcedureProtocol, withErrors errors: [Error]) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        block(typedProcedure, errors)
     }
 }
 
@@ -249,15 +271,17 @@ public struct WillAddOperationObserver<Procedure: ProcedureProtocol>: ProcedureO
     }
 
     /// - parameter to: the procedure which is attached
-    public func didAttach(to procedure: Procedure) {
-        didAttachToProcedure?(procedure)
+    public func didAttach(to procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didAttachToProcedure?(typedProcedure)
     }
 
     /// Observes when the attached procedure will add another Operation.
     /// - parameter procedure: the procedure which will add another Operation.
     /// - parameter newOperation: the new Operation instance which will be added.
-    public func procedure(_ procedure: Procedure, willAdd newOperation: Operation) {
-        block(procedure, newOperation)
+    public func procedure(_ procedure: ProcedureProtocol, willAdd newOperation: Operation) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        block(typedProcedure, newOperation)
     }
 }
 
@@ -282,15 +306,17 @@ public struct DidAddOperationObserver<Procedure: ProcedureProtocol>: ProcedureOb
     }
 
     /// - parameter to: the procedure which is attached
-    public func didAttach(to procedure: Procedure) {
-        didAttachToProcedure?(procedure)
+    public func didAttach(to procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didAttachToProcedure?(typedProcedure)
     }
 
     /// Observes when the attached procedure did add another Operation.
     /// - parameter procedure: the procedure which did add another Operation.
     /// - parameter newOperation: the new Operation instance which was added.
-    public func procedure(_ procedure: Procedure, didAdd newOperation: Operation) {
-        block(procedure, newOperation)
+    public func procedure(_ procedure: ProcedureProtocol, didAdd newOperation: Operation) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        block(typedProcedure, newOperation)
     }
 }
 
@@ -315,15 +341,17 @@ public struct WillFinishObserver<Procedure: ProcedureProtocol>: ProcedureObserve
     }
 
     /// - parameter to: the procedure which is attached
-    public func didAttach(to procedure: Procedure) {
-        didAttachToProcedure?(procedure)
+    public func didAttach(to procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didAttachToProcedure?(typedProcedure)
     }
 
     /// Observes when the attached procedure will finish.
     /// - parameter procedure: the procedure which will finish.
     /// - parameter errors: the errors the procedure will finish with
-    public func will(finish procedure: Procedure, withErrors errors: [Error], pendingFinish: PendingFinishEvent) {
-        block(procedure, errors, pendingFinish)
+    public func will(finish procedure: ProcedureProtocol, withErrors errors: [Error], pendingFinish: PendingFinishEvent) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        block(typedProcedure, errors, pendingFinish)
     }
 }
 
@@ -350,15 +378,17 @@ public struct DidFinishObserver<Procedure: ProcedureProtocol>: ProcedureObserver
     }
 
     /// - parameter to: the procedure which is attached
-    public func didAttach(to procedure: Procedure) {
-        didAttachToProcedure?(procedure)
+    public func didAttach(to procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        didAttachToProcedure?(typedProcedure)
     }
 
     /// Observes when the attached procedure did finish.
     /// - parameter procedure: the procedure which will finish.
     /// - parameter errors: the errors the procedure will finish with
-    public func did(finish procedure: Procedure, withErrors errors: [Error]) {
-        block(procedure, errors)
+    public func did(finish procedure: ProcedureProtocol, withErrors errors: [Error]) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
+        block(typedProcedure, errors)
     }
 }
 

--- a/Sources/ProcedureKit/BlockObservers.swift
+++ b/Sources/ProcedureKit/BlockObservers.swift
@@ -26,7 +26,7 @@ public struct Observer<Procedure: ProcedureProtocol> {
 
 public func typedProcedure<ProcedureType: ProcedureProtocol>(_ procedure: ProcedureProtocol) -> ProcedureType? {
     guard let typedProcedure = procedure as? ProcedureType else {
-        procedure.log.warning(message: "Unable to convert \(procedure) to the expected type \(String(describing: type(of: ProcedureType.self)))")
+        procedure.log.warning(message: "Unable to convert to the expected type \"\(String(describing: ProcedureType))\"")
         return nil
     }
     return typedProcedure

--- a/Sources/ProcedureKit/Group.swift
+++ b/Sources/ProcedureKit/Group.swift
@@ -30,7 +30,7 @@ open class GroupProcedure: Procedure {
     fileprivate var _groupChildren: [Operation] // swiftlint:disable:this variable_name
     fileprivate var _groupIsFinishing = false // swiftlint:disable:this variable_name
     fileprivate var _groupIsSuspended = false // swiftlint:disable:this variable_name
-    fileprivate var _groupTransformChildErrorsBlock: TransformChildErrorsBlockType? = nil
+    fileprivate var _groupTransformChildErrorsBlock: TransformChildErrorsBlockType?
 
     /// - returns: the operations which have been added to the queue
     final public var children: [Operation] {

--- a/Sources/ProcedureKit/NetworkObserver.swift
+++ b/Sources/ProcedureKit/NetworkObserver.swift
@@ -99,11 +99,11 @@ public class NetworkObserver: ProcedureObserver {
         networkActivityController = controller
     }
 
-    public func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) {
+    public func will(execute procedure: ProcedureProtocol, pendingExecute: PendingExecuteEvent) {
         networkActivityController.start()
     }
 
-    public func did(finish procedure: Procedure, withErrors errors: [Error]) {
+    public func did(finish procedure: ProcedureProtocol, withErrors errors: [Error]) {
         networkActivityController.stop()
     }
 }

--- a/Sources/ProcedureKit/Procedure.swift
+++ b/Sources/ProcedureKit/Procedure.swift
@@ -325,7 +325,7 @@ open class Procedure: Operation, ProcedureProtocol {
     fileprivate class ProtectedProperties {
         var log: LoggerProtocol = Logger()
         var errors = [Error]()
-        var observers = [AnyObserver<Procedure>]()
+        var observers = [ProcedureObserver]()
         var directDependencies = Set<Operation>()
         var conditions = Set<Condition>()
     }
@@ -401,7 +401,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
     // MARK: Observers
 
-    final internal var observers: [AnyObserver<Procedure>] {
+    final internal var observers: [ProcedureObserver] {
         get {
             return stateLock.withCriticalScope { protectedProperties.observers }
         }
@@ -1137,7 +1137,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
      - parameter observer: type conforming to protocol `ProcedureObserver`.
      */
-    open func add<Observer: ProcedureObserver>(observer: Observer) where Observer.Procedure == Procedure {
+    open func add(observer: ProcedureObserver) {
         assert(state < .pending, "Adding observers to a Procedure after it has been added to a queue is an inherent race condition, and risks missing events.")
 
         dispatchEvent {
@@ -1146,7 +1146,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
             // Add the observer to the internal observers array
             self.stateLock.withCriticalScope {
-                self.protectedProperties.observers.append(AnyObserver(base: observer))
+                self.protectedProperties.observers.append(observer)
             }
 
             // Dispatch the DidAttach event to the observer
@@ -1181,7 +1181,7 @@ open class Procedure: Operation, ProcedureProtocol {
     ///   - block: a block that will be called for every observer, on the appropriate queue/thread
     /// - Returns: a DispatchGroup that will be signaled (ready) when the PendingEvent is ready (i.e. when
     //             all of the observers have completed their work)
-    internal func dispatchObservers(pendingEvent: (Procedure) -> PendingEvent, block: @escaping (AnyObserver<Procedure>, PendingEvent) -> Void) -> DispatchGroup {
+    internal func dispatchObservers(pendingEvent: (Procedure) -> PendingEvent, block: @escaping (ProcedureObserver, PendingEvent) -> Void) -> DispatchGroup {
         debugAssertIsOnEventQueue() // This function should only be called if already on the EventQueue
 
         let iterator = observers.makeIterator()
@@ -1191,8 +1191,8 @@ open class Procedure: Operation, ProcedureProtocol {
         return pendingEvent.group
     }
 
-    typealias ObserverIterator = IndexingIterator<[AnyObserver<Procedure>]>
-    private func processObservers(iterator: ObserverIterator, futureEvent: PendingEvent, block: @escaping (AnyObserver<Procedure>, PendingEvent) -> Void) {
+    typealias ObserverIterator = IndexingIterator<[ProcedureObserver]>
+    private func processObservers(iterator: ObserverIterator, futureEvent: PendingEvent, block: @escaping (ProcedureObserver, PendingEvent) -> Void) {
         debugAssertIsOnEventQueue() // This function should only be called if already on the EventQueue
 
         var modifiableIterator = iterator

--- a/Sources/ProcedureKit/ProcedureObserver.swift
+++ b/Sources/ProcedureKit/ProcedureObserver.swift
@@ -12,21 +12,19 @@ import Foundation
  */
 public protocol ProcedureObserver {
 
-    associatedtype Procedure: ProcedureProtocol
-
     /**
      Observer gets notified when it is attached to a procedure.
 
      - parameter procedure: the observed procedure, P.
      */
-    func didAttach(to procedure: Procedure)
+    func didAttach<P: Procedure>(to procedure: P)
 
     /**
      The procedure will execute.
 
      - parameter procedure: the observed `Procedure`.
      */
-    func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent)
+    func will<P: Procedure>(execute procedure: P, pendingExecute: PendingExecuteEvent)
 
     /**
      The procedure did execute.
@@ -43,14 +41,14 @@ public protocol ProcedureObserver {
 
      - parameter procedure: the observed `Procedure`.
      */
-    func did(execute procedure: Procedure)
+    func did<P: Procedure>(execute procedure: P)
 
     /**
      The procedure did cancel.
 
      - parameter procedure: the observed `Procedure`.
      */
-    func did(cancel procedure: Procedure, withErrors: [Error])
+    func did<P: Procedure>(cancel procedure: P, withErrors: [Error])
 
     /**
      The procedure will add a new `Operation` instance to the
@@ -60,7 +58,7 @@ public protocol ProcedureObserver {
      - parameter procedure: the observed `Procedure`.
      - parameter newOperation: the `Operation` which will be added
      */
-    func procedure(_ procedure: Procedure, willAdd newOperation: Operation)
+    func procedure<P: Procedure>(_ procedure: P, willAdd newOperation: Operation)
 
     /**
      The procedure did add a new `Operation` instance to the
@@ -70,7 +68,7 @@ public protocol ProcedureObserver {
      - parameter procedure: the observed `Procedure`.
      - parameter newOperation: the `Operation` which has been added to the queue
      */
-    func procedure(_ procedure: Procedure, didAdd newOperation: Operation)
+    func procedure<P: Procedure>(_ procedure: P, didAdd newOperation: Operation)
 
     /**
      The procedure will finish. Any errors that were encountered are collected here.
@@ -78,7 +76,7 @@ public protocol ProcedureObserver {
      - parameter procedure: the observed `Procedure`.
      - parameter errors: an array of `Error`s.
      */
-    func will(finish procedure: Procedure, withErrors: [Error], pendingFinish: PendingFinishEvent)
+    func will<P: Procedure>(finish procedure: P, withErrors: [Error], pendingFinish: PendingFinishEvent)
 
     /**
      The procedure did finish. Any errors that were encountered are collected here.
@@ -86,7 +84,7 @@ public protocol ProcedureObserver {
      - parameter procedure: the observed `Procedure`.
      - parameter errors: an array of `ErrorType`s.
      */
-    func did(finish procedure: Procedure, withErrors: [Error])
+    func did<P: Procedure>(finish procedure: P, withErrors: [Error])
 
     /**
      Provide a queue onto which observer callbacks will be dispatched.
@@ -105,21 +103,21 @@ public extension ProcedureObserver {
 
 public extension ProcedureObserver {
 
-    func didAttach(to procedure: Procedure) { }
+    func didAttach<P: Procedure>(to procedure: P) { }
 
-    func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) { }
+    func will<P: Procedure>(execute procedure: P, pendingExecute: PendingExecuteEvent) { }
 
-    func did(execute procedure: Procedure) { }
+    func did<P: Procedure>(execute procedure: P) { }
 
-    func did(cancel procedure: Procedure, withErrors: [Error]) { }
+    func did<P: Procedure>(cancel procedure: P, withErrors: [Error]) { }
 
-    func procedure(_ procedure: Procedure, willAdd newOperation: Operation) { }
+    func procedure<P: Procedure>(_ procedure: P, willAdd newOperation: Operation) { }
 
-    func procedure(_ procedure: Procedure, didAdd newOperation: Operation) { }
+    func procedure<P: Procedure>(_ procedure: P, didAdd newOperation: Operation) { }
 
-    func will(finish procedure: Procedure, withErrors errors: [Error], pendingFinish: PendingFinishEvent) { }
+    func will<P: Procedure>(finish procedure: P, withErrors errors: [Error], pendingFinish: PendingFinishEvent) { }
 
-    func did(finish procedure: Procedure, withErrors errors: [Error]) { }
+    func did<P: Procedure>(finish procedure: P, withErrors errors: [Error]) { }
 
     var eventQueue: DispatchQueueProtocol? { return nil }
 }

--- a/Sources/ProcedureKit/ProcedureObserver.swift
+++ b/Sources/ProcedureKit/ProcedureObserver.swift
@@ -17,14 +17,14 @@ public protocol ProcedureObserver {
 
      - parameter procedure: the observed procedure, P.
      */
-    func didAttach<P: Procedure>(to procedure: P)
+    func didAttach(to procedure: ProcedureProtocol)
 
     /**
      The procedure will execute.
 
      - parameter procedure: the observed `Procedure`.
      */
-    func will<P: Procedure>(execute procedure: P, pendingExecute: PendingExecuteEvent)
+    func will(execute procedure: ProcedureProtocol, pendingExecute: PendingExecuteEvent)
 
     /**
      The procedure did execute.
@@ -41,14 +41,14 @@ public protocol ProcedureObserver {
 
      - parameter procedure: the observed `Procedure`.
      */
-    func did<P: Procedure>(execute procedure: P)
+    func did(execute procedure: ProcedureProtocol)
 
     /**
      The procedure did cancel.
 
      - parameter procedure: the observed `Procedure`.
      */
-    func did<P: Procedure>(cancel procedure: P, withErrors: [Error])
+    func did(cancel procedure: ProcedureProtocol, withErrors: [Error])
 
     /**
      The procedure will add a new `Operation` instance to the
@@ -58,7 +58,7 @@ public protocol ProcedureObserver {
      - parameter procedure: the observed `Procedure`.
      - parameter newOperation: the `Operation` which will be added
      */
-    func procedure<P: Procedure>(_ procedure: P, willAdd newOperation: Operation)
+    func procedure(_ procedure: ProcedureProtocol, willAdd newOperation: Operation)
 
     /**
      The procedure did add a new `Operation` instance to the
@@ -68,7 +68,7 @@ public protocol ProcedureObserver {
      - parameter procedure: the observed `Procedure`.
      - parameter newOperation: the `Operation` which has been added to the queue
      */
-    func procedure<P: Procedure>(_ procedure: P, didAdd newOperation: Operation)
+    func procedure(_ procedure: ProcedureProtocol, didAdd newOperation: Operation)
 
     /**
      The procedure will finish. Any errors that were encountered are collected here.
@@ -76,7 +76,7 @@ public protocol ProcedureObserver {
      - parameter procedure: the observed `Procedure`.
      - parameter errors: an array of `Error`s.
      */
-    func will<P: Procedure>(finish procedure: P, withErrors: [Error], pendingFinish: PendingFinishEvent)
+    func will(finish procedure: ProcedureProtocol, withErrors: [Error], pendingFinish: PendingFinishEvent)
 
     /**
      The procedure did finish. Any errors that were encountered are collected here.
@@ -84,7 +84,7 @@ public protocol ProcedureObserver {
      - parameter procedure: the observed `Procedure`.
      - parameter errors: an array of `ErrorType`s.
      */
-    func did<P: Procedure>(finish procedure: P, withErrors: [Error])
+    func did(finish procedure: ProcedureProtocol, withErrors: [Error])
 
     /**
      Provide a queue onto which observer callbacks will be dispatched.
@@ -95,29 +95,29 @@ public protocol ProcedureObserver {
 public extension ProcedureObserver {
     // MARK: - Unavailable/renamed observer callbacks
     @available(*, unavailable, renamed: "will(execute:pendingExecute:)")
-    func will(execute procedure: Procedure) { }
+    func will(execute procedure: ProcedureProtocol) { }
 
     @available(*, unavailable, renamed: "will(finish:withErrors:pendingFinish:)")
-    func will(finish procedure: Procedure, withErrors: [Error]) { }
+    func will(finish procedure: ProcedureProtocol, withErrors: [Error]) { }
 }
 
 public extension ProcedureObserver {
 
-    func didAttach<P: Procedure>(to procedure: P) { }
+    func didAttach(to procedure: ProcedureProtocol) { }
 
-    func will<P: Procedure>(execute procedure: P, pendingExecute: PendingExecuteEvent) { }
+    func will(execute procedure: ProcedureProtocol, pendingExecute: PendingExecuteEvent) { }
 
-    func did<P: Procedure>(execute procedure: P) { }
+    func did(execute procedure: ProcedureProtocol) { }
 
-    func did<P: Procedure>(cancel procedure: P, withErrors: [Error]) { }
+    func did(cancel procedure: ProcedureProtocol, withErrors: [Error]) { }
 
-    func procedure<P: Procedure>(_ procedure: P, willAdd newOperation: Operation) { }
+    func procedure(_ procedure: ProcedureProtocol, willAdd newOperation: Operation) { }
 
-    func procedure<P: Procedure>(_ procedure: P, didAdd newOperation: Operation) { }
+    func procedure(_ procedure: ProcedureProtocol, didAdd newOperation: Operation) { }
 
-    func will<P: Procedure>(finish procedure: P, withErrors errors: [Error], pendingFinish: PendingFinishEvent) { }
+    func will(finish procedure: ProcedureProtocol, withErrors errors: [Error], pendingFinish: PendingFinishEvent) { }
 
-    func did<P: Procedure>(finish procedure: P, withErrors errors: [Error]) { }
+    func did(finish procedure: ProcedureProtocol, withErrors errors: [Error]) { }
 
     var eventQueue: DispatchQueueProtocol? { return nil }
 }

--- a/Sources/ProcedureKit/ProcedureProcotol.swift
+++ b/Sources/ProcedureKit/ProcedureProcotol.swift
@@ -46,7 +46,7 @@ public protocol ProcedureProtocol: class {
 
     // Observers
 
-    func add<Observer: ProcedureObserver>(observer: Observer) where Observer.Procedure == Self
+    func add(observer: ProcedureObserver)
 
     // Dependencies
 

--- a/Sources/ProcedureKit/Profiler.swift
+++ b/Sources/ProcedureKit/Profiler.swift
@@ -193,26 +193,27 @@ extension ProcedureProfiler: ProcedureProfilerReporter {
 
 extension ProcedureProfiler: ProcedureObserver {
 
-    public func didAttach(to procedure: Procedure) {
+    public func didAttach(to procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { return }
         queue.sync { [unowned self] in
-            self.result = self.result.set(identity: procedure.identity)
+            self.result = self.result.set(identity: typedProcedure.identity)
         }
         addMetric(forEvent: .attached)
     }
 
-    public func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) {
+    public func will(execute procedure: ProcedureProtocol, pendingExecute: PendingExecuteEvent) {
         addMetric(forEvent: .started)
     }
 
-    public func did(cancel procedure: Procedure) {
+    public func did(cancel procedure: ProcedureProtocol) {
         addMetric(forEvent: .cancelled)
     }
 
-    public func did(finish procedure: Procedure, withErrors errors: [Error]) {
+    public func did(finish procedure: ProcedureProtocol, withErrors errors: [Error]) {
         addMetric(forEvent: .finished)
     }
 
-    public func procedure(_ procedure: Procedure, willAdd newOperation: Operation) {
+    public func procedure(_ procedure: ProcedureProtocol, willAdd newOperation: Operation) {
         addChild(operation: newOperation)
     }
 }

--- a/Sources/ProcedureKit/TimeoutObserver.swift
+++ b/Sources/ProcedureKit/TimeoutObserver.swift
@@ -40,17 +40,19 @@ public struct TimeoutObserver: ProcedureObserver {
         delay = .until(date)
     }
 
-    public func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) {
+    public func will(execute procedure: ProcedureProtocol, pendingExecute: PendingExecuteEvent) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { assertionFailure("TimeoutObserver only supports Procedure subclasses."); return }
         switch delay.interval {
         case (let interval) where interval > 0.0:
-            ProcedureTimeoutRegistrar.shared.createFinishTimeout(forProcedure: procedure, withDelay: delay)
+            ProcedureTimeoutRegistrar.shared.createFinishTimeout(forProcedure: typedProcedure, withDelay: delay)
             break
         default: break
         }
     }
 
-    public func did(finish procedure: Procedure, withErrors errors: [Error]) {
-        ProcedureTimeoutRegistrar.shared.registerFinished(procedure: procedure)
+    public func did(finish procedure: ProcedureProtocol, withErrors errors: [Error]) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { assertionFailure("TimeoutObserver only supports Procedure subclasses."); return }
+        ProcedureTimeoutRegistrar.shared.registerFinished(procedure: typedProcedure)
     }
 }
 

--- a/Sources/ProcedureKitMobile/BackgroundObserver.swift
+++ b/Sources/ProcedureKitMobile/BackgroundObserver.swift
@@ -79,13 +79,13 @@ public class BackgroundObserver: NSObject, ProcedureObserver {
         }
     }
 
-    public func didAttach(to procedure: Procedure) {
+    public func didAttach(to procedure: ProcedureProtocol) {
         stateLock.withCriticalScope {
             _log = procedure.log
         }
     }
 
-    public func did(finish procedure: Procedure, withErrors errors: [Error]) {
+    public func did(finish procedure: ProcedureProtocol, withErrors errors: [Error]) {
         removeNotificationCenterObservers()
         endBackgroundTask()
     }

--- a/Sources/TestingProcedureKit/ConcurrencyTestCase.swift
+++ b/Sources/TestingProcedureKit/ConcurrencyTestCase.swift
@@ -393,30 +393,55 @@ open class ConcurrencyTrackingObserver: ProcedureObserver {
         self.callbackBlock = callbackBlock
     }
 
-    public func didAttach(to procedure: Procedure) {
+    public func didAttach(to procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { fatalError("ConcurrencyTrackingObserver cannot convert input procedure to `Procedure`.") }
         if let eventTrackingProcedure = procedure as? EventConcurrencyTrackingProcedureProtocol {
             if registrar == nil {
                 registrar = eventTrackingProcedure.concurrencyRegistrar
             }
-            doRun(.observer_didAttach, block: { callback in callbackBlock(procedure, callback) })
+            doRun(.observer_didAttach, block: { callback in callbackBlock(typedProcedure, callback) })
         }
     }
 
-    public func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) { doRun(.observer_willExecute, block: { callback in callbackBlock(procedure, callback) }) }
+    public func will(execute procedure: ProcedureProtocol, pendingExecute: PendingExecuteEvent) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { fatalError("ConcurrencyTrackingObserver cannot convert input procedure to `Procedure`.") }
+        doRun(.observer_willExecute, block: { callback in callbackBlock(typedProcedure, callback) })
+    }
 
-    public func did(execute procedure: Procedure) { doRun(.observer_didExecute, block: { callback in callbackBlock(procedure, callback) }) }
+    public func did(execute procedure: ProcedureProtocol) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { fatalError("ConcurrencyTrackingObserver cannot convert input procedure to `Procedure`.") }
+        doRun(.observer_didExecute, block: { callback in callbackBlock(typedProcedure, callback) })
+    }
 
-    public func will(cancel procedure: Procedure, withErrors: [Error]) { doRun(.observer_willCancel, block: { callback in callbackBlock(procedure, callback) }) }
+    public func will(cancel procedure: ProcedureProtocol, withErrors: [Error]) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { fatalError("ConcurrencyTrackingObserver cannot convert input procedure to `Procedure`.") }
+        doRun(.observer_willCancel, block: { callback in callbackBlock(typedProcedure, callback) })
+    }
 
-    public func did(cancel procedure: Procedure, withErrors: [Error]) { doRun(.observer_didCancel, block: { callback in callbackBlock(procedure, callback) }) }
+    public func did(cancel procedure: ProcedureProtocol, withErrors: [Error]) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { fatalError("ConcurrencyTrackingObserver cannot convert input procedure to `Procedure`.") }
+        doRun(.observer_didCancel, block: { callback in callbackBlock(typedProcedure, callback) })
+    }
 
-    public func procedure(_ procedure: Procedure, willAdd newOperation: Operation) { doRun(.observer_procedureWillAdd(newOperation.operationName), block: { callback in callbackBlock(procedure, callback) }) }
+    public func procedure(_ procedure: ProcedureProtocol, willAdd newOperation: Operation) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { fatalError("ConcurrencyTrackingObserver cannot convert input procedure to `Procedure`.") }
+        doRun(.observer_procedureWillAdd(newOperation.operationName), block: { callback in callbackBlock(typedProcedure, callback) })
+    }
 
-    public func procedure(_ procedure: Procedure, didAdd newOperation: Operation) { doRun(.observer_procedureDidAdd(newOperation.operationName), block: { callback in callbackBlock(procedure, callback) }) }
+    public func procedure(_ procedure: ProcedureProtocol, didAdd newOperation: Operation) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { fatalError("ConcurrencyTrackingObserver cannot convert input procedure to `Procedure`.") }
+        doRun(.observer_procedureDidAdd(newOperation.operationName), block: { callback in callbackBlock(typedProcedure, callback) })
+    }
 
-    public func will(finish procedure: Procedure, withErrors errors: [Error], pendingFinish: PendingFinishEvent) { doRun(.observer_willFinish, block: { callback in callbackBlock(procedure, callback) }) }
+    public func will(finish procedure: ProcedureProtocol, withErrors errors: [Error], pendingFinish: PendingFinishEvent) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { fatalError("ConcurrencyTrackingObserver cannot convert input procedure to `Procedure`.") }
+        doRun(.observer_willFinish, block: { callback in callbackBlock(typedProcedure, callback) })
+    }
 
-    public func did(finish procedure: Procedure, withErrors errors: [Error]) { doRun(.observer_didFinish, block: { callback in callbackBlock(procedure, callback) }) }
+    public func did(finish procedure: ProcedureProtocol, withErrors errors: [Error]) {
+        guard let typedProcedure: Procedure = typedProcedure(procedure) else { fatalError("ConcurrencyTrackingObserver cannot convert input procedure to `Procedure`.") }
+        doRun(.observer_didFinish, block: { callback in callbackBlock(typedProcedure, callback) })
+    }
 
     public func doRun(_ callback: EventConcurrencyTrackingRegistrar.ProcedureEvent, withDelay delay: TimeInterval = 0.0001, block: (EventConcurrencyTrackingRegistrar.ProcedureEvent) -> Void = { _ in }) {
         registrar.doRun(callback, withDelay: delay, block: block)

--- a/Tests/ProcedureKitTests/AnyProcedureTests.swift
+++ b/Tests/ProcedureKitTests/AnyProcedureTests.swift
@@ -48,6 +48,7 @@ class Baz: Procedure, InputProcedure, OutputProcedure {
 }
 
 class BaseAnyProcedureTests: ProcedureKitTestCase {
+
     func test__any_procedure(_ anyProcedure: Procedure) {
         wait(for: anyProcedure)
         XCTAssertProcedureFinishedWithoutErrors(procedure)
@@ -119,7 +120,7 @@ class AnyInputProcedureTests: BaseAnyProcedureTests {
 
     func test__any_procedure() {
         let anyProcedure = AnyInputProcedure(procedure)
-        self.test__any_procedure(anyProcedure)
+        test__any_procedure(anyProcedure)
     }
 
     func test__setting_requirement() {
@@ -131,7 +132,7 @@ class AnyInputProcedureTests: BaseAnyProcedureTests {
     func test__not_setting_requirement() {
         let foo = Foo()
         let anyProcedure = AnyInputProcedure(foo)
-        self.test__not_setting_requirement(anyProcedure: anyProcedure, boxedProcedure: foo)
+        test__not_setting_requirement(anyProcedure: anyProcedure, boxedProcedure: foo)
     }
 }
 

--- a/Tests/ProcedureKitTests/BlockObserverTests.swift
+++ b/Tests/ProcedureKitTests/BlockObserverTests.swift
@@ -251,7 +251,7 @@ class BlockObserverSynchronizationTests: ProcedureKitTestCase {
                 didAddGroup.leave()
             }
             didAddGroup.enter()
-            producingProcedure.add(observer: BlockObserver(synchronizedWith: syncObject, didAdd: {
+            producingProcedure.add(observer: BlockObserver<TestProcedure>(synchronizedWith: syncObject, didAdd: {
                 didAddOperationCalled_BlockObserver.overwrite(with: ($0, $1, isSynced()))
                 didAddGroup.leave()
             }))
@@ -306,7 +306,7 @@ class BlockObserverSynchronizationTests: ProcedureKitTestCase {
                 didFinishGroup.leave()
             }
             didFinishGroup.enter()
-            procedure.add(observer: BlockObserver(synchronizedWith: syncObject, didFinish: { didFinishCalled_BlockObserver.overwrite(with: ($0, $1, isSynced()))
+            procedure.add(observer: BlockObserver<TestProcedure>(synchronizedWith: syncObject, didFinish: { didFinishCalled_BlockObserver.overwrite(with: ($0, $1, isSynced()))
                 didFinishGroup.leave()
             }))
             wait(for: procedure)

--- a/Tests/ProcedureKitTests/ProfilerTests.swift
+++ b/Tests/ProcedureKitTests/ProfilerTests.swift
@@ -71,7 +71,7 @@ class ProfilerTests: ProcedureKitTestCase {
 
     func test__profile_simple_operation_which_cancels() {
 
-        procedure.add(observer: WillExecuteObserver { op, _ in
+        procedure.add(observer: WillExecuteObserver<TestProcedure> { op, _ in
             op.cancel()
         })
         procedure.add(observer: profiler)


### PR DESCRIPTION
This is to work around the changes in Xcode 9 Beta 3 as raised by issue #752.