### PR TITLE
Resolve ProcedureObserver errors on Xcode 9 beta 3

### DIFF
--- a/Sources/ProcedureKit/AnyObserver.swift
+++ b/Sources/ProcedureKit/AnyObserver.swift
@@ -113,47 +113,47 @@ internal class TransformObserver<O: ProcedureProtocol, R: ProcedureProtocol>: Pr
         return typedProcedure
     }
 
-    public func didAttach(to procedure: Procedure) {
+    func didAttach(to procedure: Procedure) {
         guard let baseProcedure = typedProcedure(procedure, event: .didAttach, logError: true) else { return }
         wrapped.didAttach(to: baseProcedure)
     }
 
-    public func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) {
+    func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) {
         guard let baseProcedure = typedProcedure(procedure, event: .willExecute) else { return }
         wrapped.will(execute: baseProcedure, pendingExecute: pendingExecute)
     }
 
-    public func did(execute procedure: Procedure) {
+    func did(execute procedure: Procedure) {
         guard let baseProcedure = typedProcedure(procedure, event: .didExecute) else { return }
         wrapped.did(execute: baseProcedure)
     }
 
-    public func did(cancel procedure: Procedure, withErrors errors: [Error]) {
+    func did(cancel procedure: Procedure, withErrors errors: [Error]) {
         guard let baseProcedure = typedProcedure(procedure, event: .didCancel) else { return }
         wrapped.did(cancel: baseProcedure, withErrors: errors)
     }
 
-    public func procedure(_ procedure: Procedure, willAdd newOperation: Operation) {
+    func procedure(_ procedure: Procedure, willAdd newOperation: Operation) {
         guard let baseProcedure = typedProcedure(procedure, event: .willAdd) else { return }
         wrapped.procedure(baseProcedure, willAdd: newOperation)
     }
 
-    public func procedure(_ procedure: Procedure, didAdd newOperation: Operation) {
+    func procedure(_ procedure: Procedure, didAdd newOperation: Operation) {
         guard let baseProcedure = typedProcedure(procedure, event: .didAdd) else { return }
         wrapped.procedure(baseProcedure, didAdd: newOperation)
     }
 
-    public func will(finish procedure: Procedure, withErrors errors: [Error], pendingFinish: PendingFinishEvent) {
+    func will(finish procedure: Procedure, withErrors errors: [Error], pendingFinish: PendingFinishEvent) {
         guard let baseProcedure = typedProcedure(procedure, event: .willFinish) else { return }
         wrapped.will(finish: baseProcedure, withErrors: errors, pendingFinish: pendingFinish)
     }
 
-    public func did(finish procedure: Procedure, withErrors errors: [Error]) {
+    func did(finish procedure: Procedure, withErrors errors: [Error]) {
         guard let baseProcedure = typedProcedure(procedure, event: .didFinish) else { return }
         wrapped.did(finish: baseProcedure, withErrors: errors)
     }
 
-    public var eventQueue: DispatchQueueProtocol? {
+    var eventQueue: DispatchQueueProtocol? {
         return wrapped.eventQueue
     }
 }

--- a/Sources/ProcedureKit/AnyObserver.swift
+++ b/Sources/ProcedureKit/AnyObserver.swift
@@ -105,7 +105,7 @@ internal class TransformObserver<O: ProcedureProtocol, R: ProcedureProtocol>: Pr
         }
     }
 
-    private func typedProcedure(_ procedure: R, event: Event, logError: Bool = false) -> O? {
+    private func typedProcedure(_ procedure: R, event: Event) -> O? {
         guard let typedProcedure = procedureTransformBlock(procedure) else {
             procedure.log.warning(message: ("Observer will not receive event (\(event.string)). Unable to convert \(procedure) to the expected type \"\(String(describing: O.self))\""))
             return nil
@@ -114,7 +114,7 @@ internal class TransformObserver<O: ProcedureProtocol, R: ProcedureProtocol>: Pr
     }
 
     func didAttach(to procedure: Procedure) {
-        guard let baseProcedure = typedProcedure(procedure, event: .didAttach, logError: true) else { return }
+        guard let baseProcedure = typedProcedure(procedure, event: .didAttach) else { return }
         wrapped.didAttach(to: baseProcedure)
     }
 

--- a/Sources/ProcedureKit/Procedure.swift
+++ b/Sources/ProcedureKit/Procedure.swift
@@ -1141,7 +1141,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
      - parameter observer: type conforming to protocol `ProcedureObserver`.
      */
-    public func add<Observer>(observer: Observer) where Observer: ProcedureObserver, Observer.Procedure: Procedure {
+    open func add<Observer>(observer: Observer) where Observer: ProcedureObserver, Observer.Procedure: Procedure {
         assert(self as? Observer.Procedure != nil, "add(observer:) passed an Observer with an invalid expected Procedure type. The Observer will not receive any events from this Procedure. (Observer expects a Procedure of type \"\(String(describing: Observer.Procedure.self))\", but `self` is a \"\(typeDescription)\" and cannot be converted.)")
 
         add(anyObserver: AnyObserver(base: TransformObserver<Observer.Procedure, Procedure>(base: observer)))


### PR DESCRIPTION
This is an alternative WIP to #753 that should maintain essentially all backwards-compatibility with existing code. 

**New functionality:**
- Catches incompatible Observers at run-time and provides helpful debug / logging output.

(So it theoretically could go into a ProcedureKit v4 point release, while the more significant / breaking changes in #753 are further-discussed.)

Thoughts and feedback appreciated.