### PR TITLE
Fix (rare) race conditions involving Conditions

### DIFF
--- a/Sources/ProcedureKit/ProcedureQueue.swift
+++ b/Sources/ProcedureKit/ProcedureQueue.swift
@@ -329,6 +329,8 @@ open class ProcedureQueue: OperationQueue {
 
         super.addOperation(procedure)
 
+        procedure.postQueueAdd()
+
         // DidAddProcedure delegate
         delegate?.procedureQueue(self, didAddProcedure: procedure, context: context)
 


### PR DESCRIPTION
In which Condition evaluation (or the Procedure which has the Conditions) could become stalled and never complete / execute.

The cause appears to be a race condition / bug / quirk in how `NSOperation(Queue)` handles dependencies (specifically, how it handles `isReady` changing while an Operation is being added to the queue).

For more, see #755 