### PR TITLE
UserIntent causes Data Race

### DIFF
--- a/Sources/ProcedureKit/Collection+ProcedureKit.swift
+++ b/Sources/ProcedureKit/Collection+ProcedureKit.swift
@@ -26,12 +26,10 @@ extension Collection where Iterator.Element: Operation {
     internal var conditions: [Condition] {
         return flatMap { $0 as? Condition }
     }
-
+    
+    @available(*, deprecated: 4.5.0, message: "Use underlying quality of service APIs instead.")
     internal var userIntent: UserIntent {
-        get {
-            let (_, procedures) = operationsAndProcedures
-            return procedures.map { $0.userIntent }.max { $0.rawValue < $1.rawValue } ?? .none
-        }
+        get { return .none }
     }
 
     internal func forEachProcedure(body: (Procedure) throws -> Void) rethrows {

--- a/Sources/ProcedureKit/Group.swift
+++ b/Sources/ProcedureKit/Group.swift
@@ -56,15 +56,6 @@ open class GroupProcedure: Procedure {
         }
     }
 
-    /// Override of Procedure.userIntent
-    final public override var userIntent: UserIntent {
-        didSet {
-            let (operations, procedures) = children.operationsAndProcedures
-            operations.forEach { $0.setQualityOfService(fromUserIntent: userIntent) }
-            procedures.forEach { $0.userIntent = userIntent }
-        }
-    }
-
     /**
      - WARNING: Do not call `finish()` on a GroupProcedure or a GroupProcedure subclass.
      A GroupProcedure finishes when all of its children finish.
@@ -119,7 +110,7 @@ open class GroupProcedure: Procedure {
         queue.underlyingQueue = underlyingQueue
         queueDelegate = GroupQueueDelegate(self)
         queue.delegate = queueDelegate
-        userIntent = operations.userIntent
+//        userIntent = operations.userIntent
         groupCanFinish = CanFinishGroup(group: self)
     }
 

--- a/Sources/ProcedureKit/Group.swift
+++ b/Sources/ProcedureKit/Group.swift
@@ -110,7 +110,6 @@ open class GroupProcedure: Procedure {
         queue.underlyingQueue = underlyingQueue
         queueDelegate = GroupQueueDelegate(self)
         queue.delegate = queueDelegate
-//        userIntent = operations.userIntent
         groupCanFinish = CanFinishGroup(group: self)
     }
 

--- a/Sources/ProcedureKit/Operation+ProcedureKit.swift
+++ b/Sources/ProcedureKit/Operation+ProcedureKit.swift
@@ -56,14 +56,6 @@ public extension Operation {
     }
 
     /**
-     Sets the quality of service of the Operation from `UserIntent`
-     - parameter userIntent: a UserIntent value
-     */
-    func setQualityOfService(fromUserIntent userIntent: UserIntent) {
-        qualityOfService = userIntent.qualityOfService
-    }
-
-    /**
      Add a dependency to the operation, using Swift 3 API style
      - parameter dependency: the Operation to add as a dependency
     */
@@ -128,4 +120,15 @@ public extension Operation {
         guard let operation = try block() else { return [self] }
         return then(do: operation)
     }
+}
+
+
+public extension Operation {
+    
+    /**
+     Sets the quality of service of the Operation from `UserIntent`
+     - parameter userIntent: a UserIntent value
+     */
+    @available(*, deprecated: 4.5.0, message: "Use underlying quality of service APIs instead.")
+    func setQualityOfService(fromUserIntent userIntent: UserIntent) { }
 }

--- a/Sources/ProcedureKit/Procedure.swift
+++ b/Sources/ProcedureKit/Procedure.swift
@@ -63,6 +63,7 @@ internal struct ProcedureKit {
 
  - see: https://developer.apple.com/library/ios/documentation/Performance/Conceptual/EnergyGuide-iOS/PrioritizeWorkWithQoS.html#//apple_ref/doc/uid/TP40015243-CH39
  */
+@available(*, deprecated: 4.5.0, message: "Use underlying quality of service APIs instead.")
 @objc public enum UserIntent: Int {
     case none = 0, sideEffect, initiated
 
@@ -185,11 +186,8 @@ open class Procedure: Operation, ProcedureProtocol {
      - requires: self must not have started yet. i.e. either hasn't been added
      to a queue, or is waiting on dependencies.
      */
-    public var userIntent: UserIntent = .none {
-        didSet {
-            setQualityOfService(fromUserIntent: userIntent)
-        }
-    }
+    @available(*, deprecated: 4.5.0, message: "Use underlying quality of service APIs instead.")
+    public var userIntent: UserIntent = .none
 
     @available(OSX 10.10, iOS 8.0, tvOS 8.0, watchOS 2.0, *)
     open override var qualityOfService: QualityOfService {

--- a/Tests/ProcedureKitTests/GroupTests.swift
+++ b/Tests/ProcedureKitTests/GroupTests.swift
@@ -10,28 +10,6 @@ import TestingProcedureKit
 
 class GroupTests: GroupTestCase {
 
-    // MARK: - Basic Group Tests
-
-    func test__group_has_user_intent_set_from_input_operations() {
-        let child = TestProcedure()
-        child.userIntent = .initiated
-        group = TestGroupProcedure(operations: [child, TestProcedure(), BlockOperation { }])
-        XCTAssertEqual(group.userIntent, .initiated)
-    }
-
-    func test__group_sets_user_intent_on_children() {
-        let child1 = TestProcedure()
-        child1.userIntent = .initiated
-        let child2 = TestProcedure()
-        let child3 = BlockOperation { }
-        group = TestGroupProcedure(operations: [child1, child2, child3])
-        group.userIntent = .sideEffect
-
-        XCTAssertEqual(child1.userIntent, .sideEffect)
-        XCTAssertEqual(child2.userIntent, .sideEffect)
-        XCTAssertEqual(child3.qualityOfService, .userInitiated)
-    }
-
     // MARK: - Execution
 
     func test__group_children_are_executed() {

--- a/Tests/ProcedureKitTests/ProcedureTests.swift
+++ b/Tests/ProcedureKitTests/ProcedureTests.swift
@@ -296,33 +296,6 @@ class ExecutionTests: ProcedureKitTestCase {
     }
 }
 
-class UserIntentTests: ProcedureKitTestCase {
-
-    func test__getting_user_intent_default_background() {
-        XCTAssertEqual(procedure.userIntent, .none)
-    }
-
-    func test__set_user_intent__initiated() {
-        procedure.userIntent = .initiated
-        XCTAssertEqual(procedure.qualityOfService, .userInitiated)
-    }
-
-    func test__set_user_intent__side_effect() {
-        procedure.userIntent = .sideEffect
-        XCTAssertEqual(procedure.qualityOfService, .userInitiated)
-    }
-
-    func test__set_user_intent__initiated_then_background() {
-        procedure.userIntent = .initiated
-        procedure.userIntent = .none
-        XCTAssertEqual(procedure.qualityOfService, .default)
-    }
-
-    func test__user_intent__equality() {
-        XCTAssertNotEqual(UserIntent.initiated, UserIntent.sideEffect)
-    }
-}
-
 import Dispatch
 
 class QualityOfServiceTests: ProcedureKitTestCase {


### PR DESCRIPTION
Will deprecate `userIntent` property, and remove it's usage. Particularly from `GroupOperation`.