### PR TITLE
Support for InputProcedure in RepeatProcedure etc

### DIFF
--- a/Sources/ProcedureKit/Repeat.swift
+++ b/Sources/ProcedureKit/Repeat.swift
@@ -370,6 +370,33 @@ extension RepeatProcedure where T: InputProcedure {
             appendConfigureBlock { $0.input = newValue }
         }
     }
+
+    /// MARK: Result Injection APIs
+
+    @discardableResult func injectResult<Dependency: OutputProcedure>(from dependency: Dependency, via block: @escaping (Dependency.Output) throws -> T.Input) -> Self {
+
+        return injectResult(from: dependency) { (procedure, output) in
+            do {
+                procedure.input = .ready(try block(output))
+            }
+            catch {
+                procedure.cancel(withError: ProcedureKitError.dependency(finishedWithErrors: [error]))
+            }
+        }
+    }
+
+    @discardableResult func injectResult<Dependency: OutputProcedure>(from dependency: Dependency) -> Self where Dependency.Output == T.Input {
+        return injectResult(from: dependency, via: { $0 })
+    }
+
+    @discardableResult func injectResult<Dependency: OutputProcedure>(from dependency: Dependency) -> Self where Dependency.Output == Optional<T.Input> {
+        return injectResult(from: dependency) { output in
+            guard let output = output else {
+                throw ProcedureKitError.requirementNotSatisfied()
+            }
+            return output
+        }
+    }
 }
 
 extension RepeatProcedure where T: OutputProcedure {

--- a/Sources/TestingProcedureKit/TestProcedure.swift
+++ b/Sources/TestingProcedureKit/TestProcedure.swift
@@ -29,7 +29,7 @@ open class TestProcedure: Procedure, InputProcedure, OutputProcedure {
     public let delay: TimeInterval
     public let error: Error?
     public let producedOperation: Operation?
-    public var input: Pending<Void> = pendingVoid
+    public var input: Pending<String> = .pending
     public var output: Pending<ProcedureResult<String>> = .ready(.success("Hello World"))
     public private(set) var executedAt: CFAbsoluteTime {
         get { return protected.read { $0.executedAt } }
@@ -71,6 +71,10 @@ open class TestProcedure: Procedure, InputProcedure, OutputProcedure {
     open override func execute() {
 
         executedAt = CFAbsoluteTimeGetCurrent()
+
+        if let input = input.value {
+            output = .ready(.success("Hello \(input)"))
+        }
 
         if let operation = producedOperation {
             let producedOperationGroup = DispatchGroup()

--- a/Tests/ProcedureKitTests/RepeatProcedureTests.swift
+++ b/Tests/ProcedureKitTests/RepeatProcedureTests.swift
@@ -102,14 +102,14 @@ class RepeatProcedureTests: RepeatTestCase {
         XCTAssertEqual(didExecuteConfigureBlock, 2)
     }
 
-    func test__repeat_with_input_procedure_payload() {
+    func test__with_input_procedure_payload() {
 
         let outputProcedure = TestProcedure()
         outputProcedure.output = .ready(.success("ProcedureKit"))
         repeatProcedure = RepeatProcedure(max: 3, iterator: createIterator())
 
         var textOutput: [String] = []
-        repeatProcedure.addWillAddOperationBlockObserver { (repeatProcedure, operation) in
+        repeatProcedure.addWillAddOperationBlockObserver { (_, operation) in
             if let procedure = operation as? TestProcedure {
                 procedure.addDidFinishBlockObserver { (testProcedure, _) in
                     if let output = testProcedure.output.value?.value {

--- a/Tests/ProcedureKitTests/RepeatProcedureTests.swift
+++ b/Tests/ProcedureKitTests/RepeatProcedureTests.swift
@@ -101,6 +101,31 @@ class RepeatProcedureTests: RepeatTestCase {
         XCTAssertEqual(repeatProcedure.count, 3)
         XCTAssertEqual(didExecuteConfigureBlock, 2)
     }
+
+    func test__repeat_with_input_procedure_payload() {
+
+        let outputProcedure = TestProcedure()
+        outputProcedure.output = .ready(.success("ProcedureKit"))
+        repeatProcedure = RepeatProcedure(max: 3, iterator: createIterator())
+
+        var textOutput: [String] = []
+        repeatProcedure.addWillAddOperationBlockObserver { (repeatProcedure, operation) in
+            if let procedure = operation as? TestProcedure {
+                procedure.addDidFinishBlockObserver { (testProcedure, _) in
+                    if let output = testProcedure.output.value?.value {
+                        textOutput.append(output)
+                    }
+                }
+            }
+        }
+
+        repeatProcedure.injectResult(from: outputProcedure)
+
+        wait(for: repeatProcedure, outputProcedure)
+        XCTAssertProcedureFinishedWithoutErrors(repeatProcedure)
+
+        XCTAssertEqual(textOutput, ["Hello ProcedureKit", "Hello ProcedureKit", "Hello ProcedureKit"])
+    }
 }
 
 class RepeatableTestProcedure: TestProcedure, Repeatable {

--- a/Tests/ProcedureKitTests/RetryProcedureTests.swift
+++ b/Tests/ProcedureKitTests/RetryProcedureTests.swift
@@ -38,6 +38,33 @@ class RetryProcedureTests: RetryTestCase {
         XCTAssertEqual(retry.count, 3)
     }
 
+    func test__with_input_procedure_payload() {
+
+        let outputProcedure = TestProcedure()
+        outputProcedure.output = .ready(.success("ProcedureKit"))
+        retry = Retry(iterator: createPayloadIterator(succeedsAfterFailureCount: 2), retry: { $1 })
+
+        var textOutput: [String] = []
+        retry.addWillAddOperationBlockObserver { (_, operation) in
+            if let procedure = operation as? TestProcedure {
+                procedure.addDidFinishBlockObserver { (testProcedure, _) in
+                    if let output = testProcedure.output.value?.value {
+                        textOutput.append(output)
+                    }
+                }
+            }
+        }
+
+        retry.injectResult(from: outputProcedure)
+
+        wait(for: retry, outputProcedure)
+        XCTAssertProcedureFinishedWithoutErrors(retry)
+
+        // The first two attemps fail due to a failed condition - so the output isn't
+        // set using the input.
+        XCTAssertEqual(textOutput, ["Hello World", "Hello World", "Hello ProcedureKit"])
+    }
+
     func test__retry_deinits_after_finished() {
         // Catches reference cycles.
 

--- a/Tests/ProcedureKitTests/RetryProcedureTests.swift
+++ b/Tests/ProcedureKitTests/RetryProcedureTests.swift
@@ -47,7 +47,8 @@ class RetryProcedureTests: RetryTestCase {
         var textOutput: [String] = []
         retry.addWillAddOperationBlockObserver { (_, operation) in
             if let procedure = operation as? TestProcedure {
-                procedure.addDidFinishBlockObserver { (testProcedure, _) in
+                procedure.addDidFinishBlockObserver { (testProcedure, errors) in
+                    guard errors.count == 0 else { return }
                     if let output = testProcedure.output.value?.value {
                         textOutput.append(output)
                     }
@@ -60,9 +61,7 @@ class RetryProcedureTests: RetryTestCase {
         wait(for: retry, outputProcedure)
         XCTAssertProcedureFinishedWithoutErrors(retry)
 
-        // The first two attemps fail due to a failed condition - so the output isn't
-        // set using the input.
-        XCTAssertEqual(textOutput, ["Hello World", "Hello World", "Hello ProcedureKit"])
+        XCTAssertEqual(textOutput, ["Hello ProcedureKit"])
     }
 
     func test__retry_deinits_after_finished() {


### PR DESCRIPTION
This PR adds full support for using _result injection_ techniques with `RepeatProcedure` (and it's subclasses, `RetryProcedure`) when the associated "Payload" Procedure type conforms to `InputProcedure`.