### PR TITLE
Update for Swift 4.1 & Xcode 9.3

### DIFF
--- a/.fastlane/Fastfile
+++ b/.fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKit",
-      destination: "platform=iOS Simulator,OS=11.2,name=iPhone 8"
+      destination: "platform=iOS Simulator,OS=11.3,name=iPhone 8"
     )
   end
 
@@ -29,7 +29,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKit",
-      destination: "platform=tvOS Simulator,OS=11.2,name=Apple TV"
+      destination: "platform=tvOS Simulator,OS=11.3,name=Apple TV"
     )
   end
 
@@ -41,7 +41,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKitMobile",
-      destination: "platform=iOS Simulator,OS=11.2,name=iPhone 8"
+      destination: "platform=iOS Simulator,OS=11.3,name=iPhone 8"
     )
   end
 
@@ -51,7 +51,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKitMobile",
-      destination: "platform=tvOS Simulator,OS=11.2,name=Apple TV"
+      destination: "platform=tvOS Simulator,OS=11.3,name=Apple TV"
     )
   end
 
@@ -62,7 +62,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKitTV",
-      destination: "platform=tvOS Simulator,OS=11.2,name=Apple TV"
+      destination: "platform=tvOS Simulator,OS=11.3,name=Apple TV"
     )
   end
 
@@ -72,7 +72,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKitNetwork",
-      destination: "platform=iOS Simulator,OS=11.2,name=iPhone 8"
+      destination: "platform=iOS Simulator,OS=11.3,name=iPhone 8"
     )
   end
 
@@ -82,7 +82,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKitNetwork",
-      destination: "platform=tvOS Simulator,OS=11.2,name=Apple TV"
+      destination: "platform=tvOS Simulator,OS=11.3,name=Apple TV"
     )
   end
 
@@ -92,7 +92,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKitCloud",
-      destination: "platform=iOS Simulator,OS=11.2,name=iPhone 8"
+      destination: "platform=iOS Simulator,OS=11.3,name=iPhone 8"
     )
   end
 
@@ -102,7 +102,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKitCloud",
-      destination: "platform=tvOS Simulator,OS=11.2,name=Apple TV"
+      destination: "platform=tvOS Simulator,OS=11.3,name=Apple TV"
     )
   end
 
@@ -112,7 +112,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKitLocation",
-      destination: "platform=iOS Simulator,OS=11.2,name=iPhone 8"
+      destination: "platform=iOS Simulator,OS=11.3,name=iPhone 8"
     )
 
   end
@@ -123,7 +123,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKitLocation",
-      destination: "platform=tvOS Simulator,OS=11.2,name=Apple TV"
+      destination: "platform=tvOS Simulator,OS=11.3,name=Apple TV"
     )
   end
 
@@ -134,7 +134,7 @@ platform :ios do
     scan(
       project: "ProcedureKit.xcodeproj",
       scheme: "ProcedureKitCloud",
-      destination: "platform=tvOS Simulator,OS=11.2,name=Apple TV"
+      destination: "platform=tvOS Simulator,OS=11.3,name=Apple TV"
     )
   end
 

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -1672,7 +1672,7 @@
 			attributes = {
 				CLASSPREFIX = PCK;
 				LastSwiftUpdateCheck = 0800;
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = ProcedureKit;
 				TargetAttributes = {
 					653C9FC01D6097A40070B7A2 = {
@@ -3446,6 +3446,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 65CFC60E1D608AE200CAD875 /* ProcedureKit.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_IDENTITY = "";
 				ONLY_ACTIVE_ARCH = YES;
 			};
@@ -3455,6 +3457,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 65CFC60E1D608AE200CAD875 /* ProcedureKit.xcconfig */;
 			buildSettings = {
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CODE_SIGN_IDENTITY = "";
 			};
 			name = Release;

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -31,6 +31,27 @@
 		6594843E1DAAA5430028F83B /* TestingProcedureKit.framework in Copy Files (2 items) */ = {isa = PBXBuildFile; fileRef = 65CFC6161D60900000CAD875 /* TestingProcedureKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		65A72C2A1DA7F37C008597CA /* ProcedureKit.framework in Copy Dependencies */ = {isa = PBXBuildFile; fileRef = 65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		65A72C2B1DA7F37C008597CA /* TestingProcedureKit.framework in Copy Dependencies */ = {isa = PBXBuildFile; fileRef = 65CFC6161D60900000CAD875 /* TestingProcedureKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		65C7BBC22085CEF4009A6D6E /* CKAcceptSharesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367DF1E1844F800D03E86 /* CKAcceptSharesOperation.swift */; };
+		65C7BBC32085CF21009A6D6E /* CKDatabaseOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E01E1844F800D03E86 /* CKDatabaseOperation.swift */; };
+		65C7BBC42085CF26009A6D6E /* CKDiscoverAllContactsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E11E1844F800D03E86 /* CKDiscoverAllContactsOperation.swift */; };
+		65C7BBC52085CF46009A6D6E /* CKDiscoverAllUserIdentitiesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E21E1844F800D03E86 /* CKDiscoverAllUserIdentitiesOperation.swift */; };
+		65C7BBC62085D0D3009A6D6E /* CKDiscoverUserIdentitiesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E31E1844F800D03E86 /* CKDiscoverUserIdentitiesOperation.swift */; };
+		65C7BBC72085D10E009A6D6E /* CKDiscoverUserInfosOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E41E1844F800D03E86 /* CKDiscoverUserInfosOperation.swift */; };
+		65C7BBC82085D121009A6D6E /* CKFetchDatabaseChangesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E51E1844F800D03E86 /* CKFetchDatabaseChangesOperation.swift */; };
+		65C7BBC92085D17C009A6D6E /* CKFetchNotificationChangesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E61E1844F800D03E86 /* CKFetchNotificationChangesOperation.swift */; };
+		65C7BBCA2085D197009A6D6E /* CKFetchRecordChangesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E71E1844F800D03E86 /* CKFetchRecordChangesOperation.swift */; };
+		65C7BBCB2085D1B4009A6D6E /* CKFetchRecordsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E81E1844F800D03E86 /* CKFetchRecordsOperation.swift */; };
+		65C7BBCD2085D26F009A6D6E /* CKFetchRecordZoneChangesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E91E1844F800D03E86 /* CKFetchRecordZoneChangesOperation.swift */; };
+		65C7BBCE2085D294009A6D6E /* CKFetchRecordZonesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367EA1E1844F800D03E86 /* CKFetchRecordZonesOperation.swift */; };
+		65C7BBCF2085D2A3009A6D6E /* CKFetchShareMetadataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367EB1E1844F800D03E86 /* CKFetchShareMetadataOperation.swift */; };
+		65C7BBD02085D2B1009A6D6E /* CKFetchShareParticipantsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367EC1E1844F800D03E86 /* CKFetchShareParticipantsOperation.swift */; };
+		65C7BBD12085D2DC009A6D6E /* CKFetchSubscriptionsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367ED1E1844F800D03E86 /* CKFetchSubscriptionsOperation.swift */; };
+		65C7BBD22085D2E8009A6D6E /* CKMarkNotificationsReadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367EE1E1844F800D03E86 /* CKMarkNotificationsReadOperation.swift */; };
+		65C7BBD32085D2EE009A6D6E /* CKModifyBadgeOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367EF1E1844F800D03E86 /* CKModifyBadgeOperation.swift */; };
+		65C7BBD42085D2F3009A6D6E /* CKModifyRecordsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F01E1844F800D03E86 /* CKModifyRecordsOperation.swift */; };
+		65C7BBD52085D30C009A6D6E /* CKModifyRecordZonesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F11E1844F800D03E86 /* CKModifyRecordZonesOperation.swift */; };
+		65C7BBD62085D31F009A6D6E /* CKModifySubscriptionsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F21E1844F800D03E86 /* CKModifySubscriptionsOperation.swift */; };
+		65C7BBD72085D329009A6D6E /* CKQueryOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F41E1844F800D03E86 /* CKQueryOperation.swift */; };
 		65CFC5FA1D608A5500CAD875 /* ProcedureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */; };
 		65CFC60B1D608AA700CAD875 /* ProcedureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 65CFC60A1D608AA700CAD875 /* ProcedureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		65CFC61F1D60904700CAD875 /* TestingProcedureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 65CFC61E1D60904700CAD875 /* TestingProcedureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -131,28 +152,7 @@
 		65D367DB1E1844E500D03E86 /* TestCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367CF1E1844E500D03E86 /* TestCondition.swift */; };
 		65D367DC1E1844E500D03E86 /* TestProcedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367D01E1844E500D03E86 /* TestProcedure.swift */; };
 		65D367DD1E1844E500D03E86 /* XCTAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367D11E1844E500D03E86 /* XCTAsserts.swift */; };
-		65D367F91E1844F800D03E86 /* CKAcceptSharesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367DF1E1844F800D03E86 /* CKAcceptSharesOperation.swift */; };
-		65D367FA1E1844F800D03E86 /* CKDatabaseOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E01E1844F800D03E86 /* CKDatabaseOperation.swift */; };
-		65D367FB1E1844F800D03E86 /* CKDiscoverAllContactsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E11E1844F800D03E86 /* CKDiscoverAllContactsOperation.swift */; };
-		65D367FC1E1844F800D03E86 /* CKDiscoverAllUserIdentitiesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E21E1844F800D03E86 /* CKDiscoverAllUserIdentitiesOperation.swift */; };
-		65D367FD1E1844F800D03E86 /* CKDiscoverUserIdentitiesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E31E1844F800D03E86 /* CKDiscoverUserIdentitiesOperation.swift */; };
-		65D367FE1E1844F800D03E86 /* CKDiscoverUserInfosOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E41E1844F800D03E86 /* CKDiscoverUserInfosOperation.swift */; };
-		65D367FF1E1844F800D03E86 /* CKFetchDatabaseChangesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E51E1844F800D03E86 /* CKFetchDatabaseChangesOperation.swift */; };
-		65D368001E1844F800D03E86 /* CKFetchNotificationChangesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E61E1844F800D03E86 /* CKFetchNotificationChangesOperation.swift */; };
-		65D368011E1844F800D03E86 /* CKFetchRecordChangesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E71E1844F800D03E86 /* CKFetchRecordChangesOperation.swift */; };
-		65D368021E1844F800D03E86 /* CKFetchRecordsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E81E1844F800D03E86 /* CKFetchRecordsOperation.swift */; };
-		65D368031E1844F800D03E86 /* CKFetchRecordZoneChangesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E91E1844F800D03E86 /* CKFetchRecordZoneChangesOperation.swift */; };
-		65D368041E1844F800D03E86 /* CKFetchRecordZonesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367EA1E1844F800D03E86 /* CKFetchRecordZonesOperation.swift */; };
-		65D368051E1844F800D03E86 /* CKFetchShareMetadataOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367EB1E1844F800D03E86 /* CKFetchShareMetadataOperation.swift */; };
-		65D368061E1844F800D03E86 /* CKFetchShareParticipantsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367EC1E1844F800D03E86 /* CKFetchShareParticipantsOperation.swift */; };
-		65D368071E1844F800D03E86 /* CKFetchSubscriptionsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367ED1E1844F800D03E86 /* CKFetchSubscriptionsOperation.swift */; };
-		65D368081E1844F800D03E86 /* CKMarkNotificationsReadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367EE1E1844F800D03E86 /* CKMarkNotificationsReadOperation.swift */; };
-		65D368091E1844F800D03E86 /* CKModifyBadgeOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367EF1E1844F800D03E86 /* CKModifyBadgeOperation.swift */; };
-		65D3680A1E1844F800D03E86 /* CKModifyRecordsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F01E1844F800D03E86 /* CKModifyRecordsOperation.swift */; };
-		65D3680B1E1844F800D03E86 /* CKModifyRecordZonesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F11E1844F800D03E86 /* CKModifyRecordZonesOperation.swift */; };
-		65D3680C1E1844F800D03E86 /* CKModifySubscriptionsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F21E1844F800D03E86 /* CKModifySubscriptionsOperation.swift */; };
 		65D3680D1E1844F800D03E86 /* CKOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F31E1844F800D03E86 /* CKOperation.swift */; };
-		65D3680E1E1844F800D03E86 /* CKQueryOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F41E1844F800D03E86 /* CKQueryOperation.swift */; };
 		65D3680F1E1844F800D03E86 /* CloudKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F51E1844F800D03E86 /* CloudKit.swift */; };
 		65D368101E1844F800D03E86 /* CloudKitCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F61E1844F800D03E86 /* CloudKitCapability.swift */; };
 		65D368111E1844F800D03E86 /* CloudKitError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367F71E1844F800D03E86 /* CloudKitError.swift */; };
@@ -1976,32 +1976,32 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				65D368071E1844F800D03E86 /* CKFetchSubscriptionsOperation.swift in Sources */,
-				65D368081E1844F800D03E86 /* CKMarkNotificationsReadOperation.swift in Sources */,
 				65D368121E1844F800D03E86 /* CloudKitSupport.swift in Sources */,
-				65D367FA1E1844F800D03E86 /* CKDatabaseOperation.swift in Sources */,
-				65D368031E1844F800D03E86 /* CKFetchRecordZoneChangesOperation.swift in Sources */,
+				65C7BBC62085D0D3009A6D6E /* CKDiscoverUserIdentitiesOperation.swift in Sources */,
+				65C7BBD52085D30C009A6D6E /* CKModifyRecordZonesOperation.swift in Sources */,
+				65C7BBCE2085D294009A6D6E /* CKFetchRecordZonesOperation.swift in Sources */,
+				65C7BBD72085D329009A6D6E /* CKQueryOperation.swift in Sources */,
+				65C7BBC52085CF46009A6D6E /* CKDiscoverAllUserIdentitiesOperation.swift in Sources */,
+				65C7BBCA2085D197009A6D6E /* CKFetchRecordChangesOperation.swift in Sources */,
+				65C7BBD32085D2EE009A6D6E /* CKModifyBadgeOperation.swift in Sources */,
+				65C7BBC82085D121009A6D6E /* CKFetchDatabaseChangesOperation.swift in Sources */,
 				65D368111E1844F800D03E86 /* CloudKitError.swift in Sources */,
+				65C7BBD02085D2B1009A6D6E /* CKFetchShareParticipantsOperation.swift in Sources */,
+				65C7BBCF2085D2A3009A6D6E /* CKFetchShareMetadataOperation.swift in Sources */,
+				65C7BBD22085D2E8009A6D6E /* CKMarkNotificationsReadOperation.swift in Sources */,
+				65C7BBC32085CF21009A6D6E /* CKDatabaseOperation.swift in Sources */,
+				65C7BBC72085D10E009A6D6E /* CKDiscoverUserInfosOperation.swift in Sources */,
 				65D368101E1844F800D03E86 /* CloudKitCapability.swift in Sources */,
-				65D367FD1E1844F800D03E86 /* CKDiscoverUserIdentitiesOperation.swift in Sources */,
-				65D367FC1E1844F800D03E86 /* CKDiscoverAllUserIdentitiesOperation.swift in Sources */,
-				65D368051E1844F800D03E86 /* CKFetchShareMetadataOperation.swift in Sources */,
-				65D367FB1E1844F800D03E86 /* CKDiscoverAllContactsOperation.swift in Sources */,
-				65D3680A1E1844F800D03E86 /* CKModifyRecordsOperation.swift in Sources */,
-				65D367FF1E1844F800D03E86 /* CKFetchDatabaseChangesOperation.swift in Sources */,
-				65D368001E1844F800D03E86 /* CKFetchNotificationChangesOperation.swift in Sources */,
 				65D3680D1E1844F800D03E86 /* CKOperation.swift in Sources */,
-				65D368061E1844F800D03E86 /* CKFetchShareParticipantsOperation.swift in Sources */,
-				65D367F91E1844F800D03E86 /* CKAcceptSharesOperation.swift in Sources */,
-				65D3680E1E1844F800D03E86 /* CKQueryOperation.swift in Sources */,
-				65D368011E1844F800D03E86 /* CKFetchRecordChangesOperation.swift in Sources */,
-				65D3680C1E1844F800D03E86 /* CKModifySubscriptionsOperation.swift in Sources */,
-				65D368091E1844F800D03E86 /* CKModifyBadgeOperation.swift in Sources */,
-				65D3680B1E1844F800D03E86 /* CKModifyRecordZonesOperation.swift in Sources */,
-				65D368041E1844F800D03E86 /* CKFetchRecordZonesOperation.swift in Sources */,
-				65D367FE1E1844F800D03E86 /* CKDiscoverUserInfosOperation.swift in Sources */,
+				65C7BBC42085CF26009A6D6E /* CKDiscoverAllContactsOperation.swift in Sources */,
 				65D3680F1E1844F800D03E86 /* CloudKit.swift in Sources */,
-				65D368021E1844F800D03E86 /* CKFetchRecordsOperation.swift in Sources */,
+				65C7BBD12085D2DC009A6D6E /* CKFetchSubscriptionsOperation.swift in Sources */,
+				65C7BBC92085D17C009A6D6E /* CKFetchNotificationChangesOperation.swift in Sources */,
+				65C7BBD42085D2F3009A6D6E /* CKModifyRecordsOperation.swift in Sources */,
+				65C7BBC22085CEF4009A6D6E /* CKAcceptSharesOperation.swift in Sources */,
+				65C7BBCB2085D1B4009A6D6E /* CKFetchRecordsOperation.swift in Sources */,
+				65C7BBCD2085D26F009A6D6E /* CKFetchRecordZoneChangesOperation.swift in Sources */,
+				65C7BBD62085D31F009A6D6E /* CKModifySubscriptionsOperation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKit.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,9 +28,8 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -59,7 +58,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitCloud.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitCloud.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,9 +28,8 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -59,7 +58,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitLocation.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitLocation.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,9 +28,8 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -59,7 +58,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitMac.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitMac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,9 +28,8 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -59,7 +58,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitMobile.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitMobile.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -42,9 +42,8 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -73,7 +72,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitNetwork.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitNetwork.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,9 +28,8 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -59,7 +58,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitTV.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/ProcedureKitTV.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,9 +28,8 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -59,7 +58,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/Stress Tests.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/Stress Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,7 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableUBSanitizer = "YES"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -57,7 +56,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/TestingProcedureKit.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/TestingProcedureKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,7 +28,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -39,7 +38,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/ProcedureKit/Collection+ProcedureKit.swift
+++ b/Sources/ProcedureKit/Collection+ProcedureKit.swift
@@ -24,7 +24,7 @@ extension Collection where Iterator.Element: Operation {
     }
 
     internal var conditions: [Condition] {
-        return flatMap { $0 as? Condition }
+        return compactMap { $0 as? Condition }
     }
     
     @available(*, deprecated: 4.5.0, message: "Use underlying quality of service APIs instead.")
@@ -97,7 +97,7 @@ extension Collection where Iterator.Element: OutputProcedure {
     /// - Returns: a ResultProcedure<[T]> procedure.
     public func flatMap<T>(transform: @escaping (Self.Iterator.Element.Output) throws -> T?) -> ResultProcedure<[T]> {
 
-        let mapped = ResultProcedure { try self.flatMap { $0.output.success }.flatMap(transform) }
+        let mapped = ResultProcedure { try self.compactMap { $0.output.success }.compactMap(transform) }
 
         forEach { mapped.add(dependency: $0) }
 
@@ -113,7 +113,7 @@ extension Collection where Iterator.Element: OutputProcedure {
     /// - Returns: a ResultProcedure<ReducedResult> procedure
     public func reduce<ReducedResult>(_ initialResult: ReducedResult, _ nextPartialResult: @escaping (ReducedResult, Self.Iterator.Element.Output) throws -> ReducedResult) -> ResultProcedure<ReducedResult> {
 
-        let result = ResultProcedure { try self.flatMap { $0.output.success }.reduce(initialResult, nextPartialResult) }
+        let result = ResultProcedure { try self.compactMap { $0.output.success }.reduce(initialResult, nextPartialResult) }
 
         forEach { result.add(dependency: $0) }
 

--- a/Sources/ProcedureKit/Filter.swift
+++ b/Sources/ProcedureKit/Filter.swift
@@ -6,7 +6,7 @@
 
 open class FilterProcedure<Element>: ReduceProcedure<Element, Array<Element>> {
 
-    public init<S: Sequence>(source: S, isIncluded: @escaping (Element) throws -> Bool) where S.Iterator.Element == Element, S.SubSequence: Sequence, S.SubSequence.Iterator.Element == Element, S.SubSequence.SubSequence == S.SubSequence {
+    public init<S: Sequence>(source: S, isIncluded: @escaping (Element) throws -> Bool) where S.Iterator.Element == Element {
         super.init(source: source, initial: []) { acc, element in
             guard try isIncluded(element) else { return acc }
             return acc + [element]

--- a/Sources/ProcedureKit/Map.swift
+++ b/Sources/ProcedureKit/Map.swift
@@ -6,7 +6,7 @@
 
 open class MapProcedure<Element, U>: ReduceProcedure<Element, Array<U>> {
 
-    public init<S: Sequence>(source: S, transform: @escaping (Element) throws -> U) where S.Iterator.Element == Element, S.SubSequence: Sequence, S.SubSequence.Iterator.Element == Element, S.SubSequence.SubSequence == S.SubSequence {
+    public init<S: Sequence>(source: S, transform: @escaping (Element) throws -> U) where S.Iterator.Element == Element {
         super.init(source: source, initial: Array<U>()) { acc, element in
             var accumulator = acc
             try accumulator.append(transform(element))
@@ -28,7 +28,7 @@ public extension OutputProcedure where Self.Output: Sequence {
 
 open class FlatMapProcedure<Element, U>: ReduceProcedure<Element, Array<U>> {
 
-    public init<S: Sequence>(source: S, transform: @escaping (Element) throws -> U?) where S.Iterator.Element == Element, S.SubSequence: Sequence, S.SubSequence.Iterator.Element == Element, S.SubSequence.SubSequence == S.SubSequence {
+    public init<S: Sequence>(source: S, transform: @escaping (Element) throws -> U?) where S.Iterator.Element == Element {
         super.init(source: source, initial: Array<U>()) { acc, element in
             guard let u = try transform(element) else { return acc }
             return acc + [u]

--- a/Sources/ProcedureKit/Reachability.swift
+++ b/Sources/ProcedureKit/Reachability.swift
@@ -49,7 +49,7 @@ public protocol NetworkReachabilityDelegate: class {
 
 public protocol NetworkReachability {
 
-    weak var delegate: NetworkReachabilityDelegate? { get set }
+    var delegate: NetworkReachabilityDelegate? { get set }
 
     var log: LoggerProtocol { get }
 

--- a/Sources/ProcedureKit/Reduce.swift
+++ b/Sources/ProcedureKit/Reduce.swift
@@ -6,7 +6,7 @@
 
 open class ReduceProcedure<Element, U>: TransformProcedure<AnySequence<Element>, U> {
 
-    public init<S: Sequence>(source: S, initial: U, nextPartialResult block: @escaping (U, Element) throws -> U) where S.Iterator.Element == Element, S.SubSequence: Sequence, S.SubSequence.Iterator.Element == Element, S.SubSequence.SubSequence == S.SubSequence {
+    public init<S: Sequence>(source: S, initial: U, nextPartialResult block: @escaping (U, Element) throws -> U) where S.Iterator.Element == Element {
         super.init { try $0.reduce(initial, block) }
         self.input = .ready(AnySequence(source))
         self.output = .ready(.success(initial))

--- a/Sources/ProcedureKitCloud/CKDiscoverAllUserIdentitiesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKDiscoverAllUserIdentitiesOperation.swift
@@ -5,6 +5,7 @@
 //
 
 #if !os(tvOS)
+#if !swift(>=4.1)
 
 #if SWIFT_PACKAGE
     import ProcedureKit
@@ -78,4 +79,5 @@ extension CloudKitProcedure where T: CKDiscoverAllUserIdentitiesOperationProtoco
     }
 }
 
+#endif
 #endif

--- a/Sources/ProcedureKitCloud/CKDiscoverUserIdentitiesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKDiscoverUserIdentitiesOperation.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 #if SWIFT_PACKAGE
     import ProcedureKit
     import Foundation
@@ -92,3 +94,5 @@ extension CloudKitProcedure where T: CKDiscoverUserIdentitiesOperationProtocol {
         appendConfigureBlock { $0.setDiscoverUserIdentitiesCompletionBlock(block) }
     }
 }
+
+#endif

--- a/Sources/ProcedureKitCloud/CKFetchDatabaseChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchDatabaseChangesOperation.swift
@@ -38,6 +38,8 @@ extension CloudKitProcedure where T: CKFetchAllChanges {
     }
 }
 
+#if !swift(>=4.1)
+
 /// A generic protocol which exposes the properties used by Apple's CKFetchDatabaseChangesOperationType.
 public protocol CKFetchDatabaseChangesOperationProtocol: CKDatabaseOperationProtocol, CKFetchAllChanges, CKPreviousServerChangeToken, CKResultsLimit {
 
@@ -148,3 +150,5 @@ extension CloudKitProcedure where T: CKFetchDatabaseChangesOperationProtocol {
         appendConfigureBlock { $0.setFetchDatabaseChangesCompletionBlock(block) }
     }
 }
+
+#endif

--- a/Sources/ProcedureKitCloud/CKFetchNotificationChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchNotificationChangesOperation.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 #if SWIFT_PACKAGE
     import ProcedureKit
     import Foundation
@@ -80,3 +82,5 @@ extension CloudKitProcedure where T: CKFetchNotificationChangesOperationProtocol
         appendConfigureBlock { $0.setFetchNotificationChangesCompletionBlock(block) }
     }
 }
+
+#endif

--- a/Sources/ProcedureKitCloud/CKFetchRecordChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchRecordChangesOperation.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 #if SWIFT_PACKAGE
     import ProcedureKit
     import Foundation
@@ -125,3 +127,5 @@ extension CloudKitProcedure where T: CKFetchRecordChangesOperationProtocol {
         appendConfigureBlock { $0.setFetchRecordChangesCompletionBlock(block) }
     }
 }
+
+#endif

--- a/Sources/ProcedureKitCloud/CKFetchRecordZoneChangesOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchRecordZoneChangesOperation.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 #if SWIFT_PACKAGE
     import ProcedureKit
     import Foundation
@@ -185,3 +187,5 @@ extension CloudKitProcedure where T: CKFetchRecordZoneChangesOperationProtocol {
         appendConfigureBlock { $0.setFetchRecordZoneChangesCompletionBlock(block) }
     }
 }
+
+#endif

--- a/Sources/ProcedureKitCloud/CKFetchRecordsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchRecordsOperation.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 #if SWIFT_PACKAGE
     import ProcedureKit
     import Foundation
@@ -117,3 +119,5 @@ extension CloudKitProcedure where T: CKFetchRecordsOperationProtocol {
         appendConfigureBlock { $0.setFetchRecordsCompletionBlock(block) }
     }
 }
+
+#endif

--- a/Sources/ProcedureKitCloud/CKFetchShareParticipantsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKFetchShareParticipantsOperation.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 #if SWIFT_PACKAGE
     import ProcedureKit
     import Foundation
@@ -95,3 +97,5 @@ extension CloudKitProcedure where T: CKFetchShareParticipantsOperationProtocol {
         appendConfigureBlock { $0.setFetchShareParticipantsCompletionBlock(block) }
     }
 }
+
+#endif

--- a/Sources/ProcedureKitCloud/CKModifyRecordsOperation.swift
+++ b/Sources/ProcedureKitCloud/CKModifyRecordsOperation.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 #if SWIFT_PACKAGE
     import ProcedureKit
     import Foundation
@@ -193,3 +195,5 @@ extension CloudKitProcedure where T: CKModifyRecordsOperationProtocol {
         appendConfigureBlock { $0.setModifyRecordsCompletionBlock(block) }
     }
 }
+
+#endif

--- a/Sources/ProcedureKitCloud/CKQueryOperation.swift
+++ b/Sources/ProcedureKitCloud/CKQueryOperation.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 #if SWIFT_PACKAGE
     import ProcedureKit
     import Foundation
@@ -131,3 +133,5 @@ extension CloudKitProcedure where T: CKQueryOperationProtocol {
         appendConfigureBlock { $0.setQueryCompletionBlock(block) }
     }
 }
+
+#endif

--- a/Sources/ProcedureKitCloud/CloudKit.swift
+++ b/Sources/ProcedureKitCloud/CloudKit.swift
@@ -45,7 +45,7 @@ public final class CloudKitRecovery<T: Operation> where T: CKOperationProtocol, 
     }
 
     func cloudKitErrors(fromInfo info: RetryFailureInfo<WrappedOperation>) -> (CKError.Code, T.AssociatedError)? {
-        let mapped: [(CKError.Code, T.AssociatedError)] = info.errors.flatMap { error in
+        let mapped: [(CKError.Code, T.AssociatedError)] = info.errors.compactMap { error in
             guard
                 let cloudKitError = error as? T.AssociatedError,
                 let code = cloudKitError.code

--- a/Sources/ProcedureKitMobile/BackgroundObserver.swift
+++ b/Sources/ProcedureKitMobile/BackgroundObserver.swift
@@ -229,7 +229,7 @@ internal class BackgroundManager {
                 _backgroundEventHandlersPerProcedure.removeValue(forKey: procedure)
                 return backgroundTasks
             }
-            let backgroundTaskIdentifiers: [UIBackgroundTaskIdentifier]? = backgroundTasks?.flatMap {
+            let backgroundTaskIdentifiers: [UIBackgroundTaskIdentifier]? = backgroundTasks?.compactMap {
                 let identifier = $0.returnCurrentAndOverwrite(with: UIBackgroundTaskInvalid)
                 guard identifier != UIBackgroundTaskInvalid else { return nil }
                 return identifier

--- a/Tests/ProcedureKitCloudTests/CKDiscoverAllUserIdentitiesOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKDiscoverAllUserIdentitiesOperationTests.swift
@@ -5,6 +5,7 @@
 //
 
 #if !os(tvOS)
+#if !swift(>=4.1)
 
 import XCTest
 import CloudKit
@@ -214,4 +215,5 @@ class CloudKitProcedureDiscoverAllUserIdentitiesOperationTests: CKProcedureTestC
     }
 }
 
+#endif
 #endif

--- a/Tests/ProcedureKitCloudTests/CKDiscoverUserIdentitiesOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKDiscoverUserIdentitiesOperationTests.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 import XCTest
 import CloudKit
 import ProcedureKit
@@ -226,3 +228,5 @@ class CloudKitProcedureDiscoverUserIdentitiesOperationTests: CKProcedureTestCase
     }
     
 }
+
+#endif

--- a/Tests/ProcedureKitCloudTests/CKFetchDatabaseChangesOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKFetchDatabaseChangesOperationTests.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 import XCTest
 import CloudKit
 import ProcedureKit
@@ -293,4 +295,6 @@ class CloudKitProcedureFetchDatabaseChangesOperationTests: CKProcedureTestCase {
     }
     
 }
+
+#endif
 

--- a/Tests/ProcedureKitCloudTests/CKFetchNotificationChangesOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKFetchNotificationChangesOperationTests.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 import XCTest
 import CloudKit
 import ProcedureKit
@@ -261,3 +263,5 @@ class CloudKitProcedureFetchNotificationChangesOperationTests: CKProcedureTestCa
     }
     
 }
+
+#endif

--- a/Tests/ProcedureKitCloudTests/CKFetchRecordChangesOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKFetchRecordChangesOperationTests.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 import XCTest
 import CloudKit
 import ProcedureKit
@@ -271,3 +273,4 @@ class CloudKitProcedureFetchRecordChangesOperationTests: CKProcedureTestCase {
     
 }
 
+#endif

--- a/Tests/ProcedureKitCloudTests/CKFetchRecordZoneChangesOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKFetchRecordZoneChangesOperationTests.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 import XCTest
 import CloudKit
 import ProcedureKit
@@ -305,4 +307,6 @@ class CloudKitProcedureFetchRecordZoneChangesOperationTests: CKProcedureTestCase
         XCTAssertFalse(didExecuteBlock)
     }
 }
+
+#endif
 

--- a/Tests/ProcedureKitCloudTests/CKFetchRecordsOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKFetchRecordsOperationTests.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 import XCTest
 import CloudKit
 import ProcedureKit
@@ -274,4 +276,6 @@ class CloudKitProcedureFetchRecordOperationTests: CKProcedureTestCase {
     }
     
 }
+
+#endif
 

--- a/Tests/ProcedureKitCloudTests/CKFetchShareParticipantsOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKFetchShareParticipantsOperationTests.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 import XCTest
 import CloudKit
 import ProcedureKit
@@ -226,4 +228,4 @@ class CloudKitProcedureFetchShareParticipantsOperationTests: CKProcedureTestCase
     
 }
 
-
+#endif

--- a/Tests/ProcedureKitCloudTests/CKModifyRecordsOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKModifyRecordsOperationTests.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 import XCTest
 import CloudKit
 import ProcedureKit
@@ -338,4 +340,5 @@ class CloudKitProcedureModifyRecordsOperationTests: CKProcedureTestCase {
     
 }
 
+#endif
 

--- a/Tests/ProcedureKitCloudTests/CKQueryOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKQueryOperationTests.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2016 ProcedureKit. All rights reserved.
 //
 
+#if !swift(>=4.1)
+
 import XCTest
 import CloudKit
 import ProcedureKit
@@ -268,3 +270,5 @@ class CloudKitProcedureQueryOperationTests: CKProcedureTestCase {
     }
     
 }
+
+#endif


### PR DESCRIPTION
This currently failing to compile due to _ProcedureKitCloud_ code. This is the error:

```
CompileSwift normal x86_64 /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CKDiscoverUserIdentitiesOperation.swift
    cd /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -c /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CloudKitSupport.swift /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CKDatabaseOperation.swift /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CloudKitError.swift /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CloudKitCapability.swift -primary-file /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CKDiscoverUserIdentitiesOperation.swift /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CKOperation.swift /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CloudKit.swift -target x86_64-apple-macosx10.11 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -I /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Products/Debug -F /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Products/Debug -application-extension -enable-testing -g -import-underlying-module -module-cache-path /Users/daniel/Library/Developer/Xcode/DerivedData/ModuleCache.noindex -profile-generate -profile-coverage-mapping -swift-version 4 -enforce-exclusivity=checked -Onone -D DEBUG -disable-swift3-objc-inference -serialize-debugging-options -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/ProcedureKitCloud-generated-files.hmap -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/ProcedureKitCloud-own-target-headers.hmap -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/ProcedureKitCloud-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/ProcedureKitCloud-project-headers.hmap -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Products/Debug/include -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/DerivedSources/x86_64 -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/DerivedSources -Xcc -DDEBUG=1 -Xcc -ivfsoverlay -Xcc /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/unextended-module-overlay.yaml -Xcc -working-directory/Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit -emit-module-doc-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation~partial.swiftdoc -serialize-diagnostics-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation.dia -module-name ProcedureKitCloud -emit-module-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation~partial.swiftmodule -emit-dependencies-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation.d -emit-reference-dependencies-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation.swiftdeps -o /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation.o -index-store-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Index/DataStore -index-system-modules

0  swift                    0x00000001044a5ffa PrintStackTraceSignalHandler(void*) + 42
1  swift                    0x00000001044a53b6 SignalHandler(int) + 966
2  libsystem_platform.dylib 0x00007fff6dd06f5a _sigtramp + 26
3  libsystem_platform.dylib 0x00007ffeef173ad0 _sigtramp + 2168900496
4  swift                    0x0000000101e27d1c swift::Mangle::ASTMangler::appendType(swift::Type) + 3116
5  swift                    0x0000000101e28c4f swift::Mangle::ASTMangler::appendType(swift::Type) + 7007
6  swift                    0x0000000101e2906c swift::Mangle::ASTMangler::appendType(swift::Type) + 8060
7  swift                    0x0000000100c9a488 swift::irgen::IRGenModule::createNominalType(swift::CanType) + 568
8  swift                    0x0000000100bf321d swift::irgen::TypeConverter::convertEnumType(swift::TypeBase*, swift::CanType, swift::EnumDecl*) + 77
9  swift                    0x0000000100c98d61 swift::irgen::TypeConverter::convertAnyNominalType(swift::CanType, swift::NominalTypeDecl*) + 449
10 swift                    0x0000000100c98164 swift::irgen::TypeConverter::getTypeEntry(swift::CanType) + 1060
11 swift                    0x0000000100cfdba8 isLargeLoadableType(swift::GenericEnvironment*, swift::SILType, swift::irgen::IRGenModule&) + 200
12 swift                    0x0000000100cfb2dd (anonymous namespace)::LoadableStorageAllocation::allocateLoadableStorage() + 12525
13 swift                    0x0000000100cf2ba8 (anonymous namespace)::LoadableByAddress::run() + 1096
14 swift                    0x0000000101601db9 swift::SILPassManager::runOneIteration() + 10217
15 swift                    0x0000000100ca990b runIRGenPreparePasses(swift::SILModule&, swift::irgen::IRGenModule&) + 1659
16 swift                    0x0000000100caa4b4 performIRGeneration(swift::IRGenOptions&, swift::ModuleDecl*, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule> >, llvm::StringRef, llvm::LLVMContext&, swift::SourceFile*, llvm::GlobalVariable**, unsigned int) + 1284
17 swift                    0x0000000100b05dce performCompile(swift::CompilerInstance&, swift::CompilerInvocation&, llvm::ArrayRef<char const*>, int&, swift::FrontendObserver*, swift::UnifiedStatsReporter*) + 38110
18 swift                    0x0000000100afae64 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 7908
19 swift                    0x0000000100aaf8b5 main + 18917
20 libdyld.dylib            0x00007fff6d9f8015 start + 1
Stack dump:
0.	Program arguments: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -c /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CloudKitSupport.swift /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CKDatabaseOperation.swift /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CloudKitError.swift /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CloudKitCapability.swift -primary-file /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CKDiscoverUserIdentitiesOperation.swift /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CKOperation.swift /Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit/Sources/ProcedureKitCloud/CloudKit.swift -target x86_64-apple-macosx10.11 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -I /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Products/Debug -F /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Products/Debug -application-extension -enable-testing -g -import-underlying-module -module-cache-path /Users/daniel/Library/Developer/Xcode/DerivedData/ModuleCache.noindex -profile-generate -profile-coverage-mapping -swift-version 4 -enforce-exclusivity=checked -Onone -D DEBUG -disable-swift3-objc-inference -serialize-debugging-options -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/ProcedureKitCloud-generated-files.hmap -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/ProcedureKitCloud-own-target-headers.hmap -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/ProcedureKitCloud-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/ProcedureKitCloud-project-headers.hmap -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Products/Debug/include -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/DerivedSources/x86_64 -Xcc -I/Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/DerivedSources -Xcc -DDEBUG=1 -Xcc -ivfsoverlay -Xcc /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/unextended-module-overlay.yaml -Xcc -working-directory/Users/daniel/CloudStation/Development/ProcedureKit/ProcedureKit -emit-module-doc-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation~partial.swiftdoc -serialize-diagnostics-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation.dia -module-name ProcedureKitCloud -emit-module-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation~partial.swiftmodule -emit-dependencies-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation.d -emit-reference-dependencies-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation.swiftdeps -o /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Build/Intermediates.noindex/ProcedureKit.build/Debug/ProcedureKitCloud.build/Objects-normal/x86_64/CKDiscoverUserIdentitiesOperation.o -index-store-path /Users/daniel/Library/Developer/Xcode/DerivedData/ProcedureKit-aclzhkcnkavbdngwdrktepvbagxs/Index/DataStore -index-system-modules 
1.	While running pass #106 SILModuleTransform "SIL Large Loadable type by-address lowering.".
2.	While converting type 'Optional<(@inout_aliasable @block_storage @callee_guaranteed (@owned CKUserIdentity, @owned CKUserIdentityLookupInfo) -> (), CKUserIdentity) -> ()>'
error: Segmentation fault: 11
```

and the offending bit of code is in here:

```swift
/// A generic protocol which exposes the properties used by Apple's CKDiscoverUserIdentitiesOperation.
public protocol CKDiscoverUserIdentitiesOperationProtocol: CKOperationProtocol {

    /// - returns: the user identity lookup info used in discovery
    var userIdentityLookupInfos: [UserIdentityLookupInfo] { get set }

    /// - returns: the block used to return discovered user identities
    var userIdentityDiscoveredBlock: ((UserIdentity, UserIdentityLookupInfo) -> Void)? { get set }

    /// - returns: the completion block used for discovering user identities
    var discoverUserIdentitiesCompletionBlock: ((Error?) -> Void)? { get set }
}
```

where it doesn't like the closure:

```swift
var userIdentityDiscoveredBlock: ((UserIdentity, UserIdentityLookupInfo) -> Void)? { get set }
```

I'm investigating....
