### PR TITLE
Result Injection improvements

### DIFF
--- a/Sources/ProcedureKit/AnyObserver.swift
+++ b/Sources/ProcedureKit/AnyObserver.swift
@@ -8,6 +8,7 @@ import Foundation
 
 class AnyObserverBox_<Procedure: ProcedureProtocol>: ProcedureObserver {
     func didAttach(to procedure: Procedure) { _abstractMethod() }
+    func didSetInputReady(on procedure: Procedure) { _abstractMethod() }
     func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) { _abstractMethod() }
     func did(execute procedure: Procedure) { _abstractMethod() }
     func did(cancel procedure: Procedure, withErrors errors: [Error]) { _abstractMethod() }
@@ -27,6 +28,10 @@ class AnyObserverBox<Base: ProcedureObserver>: AnyObserverBox_<Base.Procedure> {
 
     override func didAttach(to procedure: Base.Procedure) {
         base.didAttach(to: procedure)
+    }
+
+    override func didSetInputReady(on procedure: Base.Procedure) {
+        base.didSetInputReady(on: procedure)
     }
 
     override func will(execute procedure: Base.Procedure, pendingExecute: PendingExecuteEvent) {
@@ -83,6 +88,7 @@ internal class TransformObserver<O: ProcedureProtocol, R: ProcedureProtocol>: Pr
 
     private enum Event {
         case didAttach
+        case didSetInputReady
         case willExecute
         case didExecute
         case didCancel
@@ -94,6 +100,7 @@ internal class TransformObserver<O: ProcedureProtocol, R: ProcedureProtocol>: Pr
         var string: String {
             switch self {
             case .didAttach: return "didAttach"
+            case .didSetInputReady: return "didSetInputReady"
             case .willExecute: return "willExecute"
             case .didExecute: return "didExecute"
             case .didCancel: return "didCancel"
@@ -116,6 +123,11 @@ internal class TransformObserver<O: ProcedureProtocol, R: ProcedureProtocol>: Pr
     func didAttach(to procedure: Procedure) {
         guard let baseProcedure = typedProcedure(procedure, event: .didAttach) else { return }
         wrapped.didAttach(to: baseProcedure)
+    }
+
+    func didSetInputReady(on procedure: Procedure) {
+        guard let baseProcedure = typedProcedure(procedure, event: .didAttach) else { return }
+        wrapped.didSetInputReady(on: baseProcedure)
     }
 
     func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) {
@@ -169,6 +181,10 @@ public struct AnyObserver<Procedure: ProcedureProtocol>: ProcedureObserver {
 
     public func didAttach(to procedure: Procedure) {
         box.didAttach(to: procedure)
+    }
+
+    public func didSetInputReady(on procedure: Procedure) {
+        box.didSetInputReady(on: procedure)
     }
 
     public func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) {

--- a/Sources/ProcedureKit/PendingEvent.swift
+++ b/Sources/ProcedureKit/PendingEvent.swift
@@ -56,6 +56,7 @@ final public class PendingEvent: CustomStringConvertible {
 
         public var description: String {
             switch self {
+            case .postDidAttach: return "PostDidAttach"
             case .addOperation: return "AddOperation"
             case .postDidAddOperation: return "PostAddOperation"
             case .execute: return "Execute"
@@ -63,7 +64,6 @@ final public class PendingEvent: CustomStringConvertible {
             case .postDidCancel: return "PostDidCancel"
             case .finish: return "Finish"
             case .postDidFinish: return "PostFinish"
-            case .postDidAttach: return "PostDidAttach"
             }
         }
     }
@@ -108,14 +108,15 @@ final public class PendingEvent: CustomStringConvertible {
 }
 
 internal extension PendingEvent {
-    static let execute: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .execute) }
-    static let postDidExecute: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .postDidExecute) }
-    static let finish: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .finish) }
-    static let postFinish: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .postDidFinish) }
+    static let postDidAttach: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .postDidAttach) }
     static let addOperation: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .addOperation) }
     static let postDidAdd: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .postDidAddOperation) }
-    static let postDidAttach: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .postDidAttach) }
+    static let execute: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .execute) }
+    static let postDidExecute: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .postDidExecute) }
     static let postDidCancel: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .postDidCancel) }
+    static let finish: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .finish) }
+    static let postFinish: (Procedure) -> PendingEvent = { PendingEvent(forProcedure: $0, withEvent: .postDidFinish) }
+
 }
 
 public typealias PendingExecuteEvent = PendingEvent

--- a/Sources/ProcedureKit/Procedure.swift
+++ b/Sources/ProcedureKit/Procedure.swift
@@ -1301,6 +1301,7 @@ open class Procedure: Operation, ProcedureProtocol {
     ///   - block: a block that will be called for every observer, on the appropriate queue/thread
     /// - Returns: a DispatchGroup that will be signaled (ready) when the PendingEvent is ready (i.e. when
     ///            all of the observers have completed their work)
+    @discardableResult
     internal func dispatchObservers(pendingEvent: (Procedure) -> PendingEvent, block: @escaping (AnyObserver<Procedure>, PendingEvent) -> Void) -> DispatchGroup {
         debugAssertIsOnEventQueue() // This function should only be called if already on the EventQueue
 

--- a/Sources/ProcedureKit/ProcedureObserver.swift
+++ b/Sources/ProcedureKit/ProcedureObserver.swift
@@ -22,6 +22,14 @@ public protocol ProcedureObserver {
     func didAttach(to procedure: Procedure)
 
     /**
+     Observer gets notified when the attached InputProcedure has
+     it's input value set ready.
+
+     - parameter procedure: the observed procedure, P
+     */
+    func didSetInputReady(on procedure: Procedure)
+
+    /**
      The procedure will execute.
 
      - parameter procedure: the observed `Procedure`.
@@ -107,6 +115,9 @@ public extension ProcedureObserver {
 
     /// Do nothing.
     func didAttach(to procedure: Procedure) { }
+
+    /// Do nothing
+    func didSetInputReady(on procedure: Procedure) { }
 
     /// Do nothing.
     func will(execute procedure: Procedure, pendingExecute: PendingExecuteEvent) { }


### PR DESCRIPTION
Result injection works really well to chain units of work together, mapping state via a sequence of `Input -> Output` transitions.

However, the common scenario, once this has been built will be to encapsulate those smaller units of work with a `GroupProcedure` to hide the details of that state transition. At the moment, this is totally possible, but it does require unnecessary boiler plate, which we can remove.

Essentially, we want to be able to do something like this:

```swift
final class MyGroup: GroupProcedure, InputProcedure, OutputProcedure {

    typealias StageA = TransformProcedure<Foo, Bar>
    typealias StageB = TransformProcedure<Bar, Baz>
    typealias StageC = TransformProcedure<Baz, Bat>

    var input: Pending<Foo>
    var ouput: Pending<ProcedureResult<Bat>>

    init() {
 
        let a = StageA { /* etc */ }
        let b = StageB { /* etc */ }.injectResult(from: a)
        let c = StageC { /* etc */ }.injectResult(from: b)

        super.init(operations: [a, b, c])

        // We want to "bind" the input property 
        //   of the StageA procedure to the group itself
        bind(to: a)

        // We want to "bind" the output property 
        //    of the group (i.e. self) to the StageC procedure output
        bind(from: c) 
    }
}
```

Those two "bind" APIs will use observers to set the `input` and `output` properties to the equivalent of the property on the receiver.