### PR TITLE
Expose convenient initialiser for Retry

### DIFF
--- a/Sources/ProcedureKit/Repeat.swift
+++ b/Sources/ProcedureKit/Repeat.swift
@@ -323,6 +323,7 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
 /// trigger another repeated value. In other words, the current
 /// just finished instance determines whether a new instance is
 /// executed next, or the repeating finishes.
+@available(*, deprecated: 4.6.0, message: "Use RepeatProcedure or RetryProcedure instead")
 public protocol Repeatable {
 
     /// Determines whether or not a subsequent instance of the
@@ -333,6 +334,7 @@ public protocol Repeatable {
     func shouldRepeat(count: Int) -> Bool
 }
 
+@available(*, deprecated: 4.6.0, message: "Use RepeatProcedure or RetryProcedure instead")
 extension RepeatProcedure where T: Repeatable {
 
     /// Initialize RepeatProcedure with a WaitStrategy and a closure. The closure returns
@@ -353,6 +355,7 @@ extension RepeatProcedure where T: Repeatable {
     ///   - max: an optional Int, which defaults to nil.
     ///   - wait: a WaitStrategy value, which defaults to .immediate
     ///   - body: an espacing closure which returns an optional T
+    @available(*, deprecated: 4.6.0, message: "Use RepeatProcedure or RetryProcedure instead")
     public convenience init(dispatchQueue: DispatchQueue? = nil, max: Int? = nil, wait: WaitStrategy = .immediate, body: @escaping () -> T?) {
         self.init(dispatchQueue: dispatchQueue, max: max, wait: wait, iterator: RepeatableGenerator(AnyIterator(body)))
     }
@@ -417,6 +420,7 @@ extension RepeatProcedure: OutputProcedure where T: OutputProcedure {
 
 // MARK: - Iterators
 
+@available(*, deprecated: 4.6.0, message: "Use RepeatProcedure or RetryProcedure instead")
 internal struct RepeatableGenerator<Element: Repeatable>: IteratorProtocol {
 
     private var iterator: CountingIterator<Element>

--- a/Sources/ProcedureKit/Retry.swift
+++ b/Sources/ProcedureKit/Retry.swift
@@ -109,6 +109,12 @@ open class RetryProcedure<T: Procedure>: RepeatProcedure<T> {
         super.init(dispatchQueue: dispatchQueue, max: max, iterator: retry)
     }
 
+    public init(upto max: Int, wait: WaitStrategy = .constant(0.2), body: @escaping () -> T?) {
+        let payloadIterator = MapIterator(PairIterator(primary: AnyIterator(body), secondary: Delay.iterator(wait.iterator))) { Payload(operation: $0.0, delay: $0.1) }
+        retry = RetryIterator(handler: { $1 }, iterator: payloadIterator)
+        super.init(max: max, iterator: retry)
+    }
+
     /// Handle child willFinish event
     ///
     /// This is used by RetryProcedure to trigger adding the next Procedure,

--- a/Tests/ProcedureKitTests/RetryProcedureTests.swift
+++ b/Tests/ProcedureKitTests/RetryProcedureTests.swift
@@ -38,6 +38,13 @@ class RetryProcedureTests: RetryTestCase {
         XCTAssertEqual(retry.count, 3)
     }
 
+    func test__with_block_fails_after_max() {
+        retry = Retry(upto: 3) { TestProcedure(error: ProcedureKitError.unknown) }
+        wait(for: retry)
+        XCTAssertProcedureFinishedWithErrors(retry)
+        XCTAssertEqual(retry.count, 3)
+    }
+
     func test__with_input_procedure_payload() {
 
         let outputProcedure = TestProcedure()


### PR DESCRIPTION
A common usage is likely, to just try the operation again, therefore an init which takes:

- max count
- wait strategy
- operation closure