### PR TITLE
API renames for Swift 3/4 naming conventions

### DIFF
--- a/Sources/ProcedureKit/Block.swift
+++ b/Sources/ProcedureKit/Block.swift
@@ -111,7 +111,7 @@ open class UIBlockProcedure: AsyncBlockProcedure {
                 }
             }
 
-            ProcedureQueue.main.add(operation: sub)
+            ProcedureQueue.main.addOperation(sub)
         }
     }
 }

--- a/Sources/ProcedureKit/Collection+ProcedureKit.swift
+++ b/Sources/ProcedureKit/Collection+ProcedureKit.swift
@@ -82,7 +82,7 @@ extension Collection where Iterator.Element: Operation {
      - parameter queue: a ProcedureQueue, with a default argument
     */
     func enqueue(on queue: ProcedureQueue = ProcedureQueue()) {
-        queue.add(operations: self)
+        queue.addOperations(self)
     }
 }
 

--- a/Sources/ProcedureKit/Condition.swift
+++ b/Sources/ProcedureKit/Condition.swift
@@ -962,14 +962,14 @@ internal class ConditionEvaluationContext {
     func queue(operation: Operation) -> ProcedureFuture {
         return stateLock.withCriticalScope {
             if _isCancelled { operation.cancel() }
-            return _procedureQueue.add(operation: operation)
+            return _procedureQueue.addOperation(operation)
         }
     }
 
     func queue<S>(operations: S) -> ProcedureFuture where S: Sequence, S.Iterator.Element: Operation {
         return stateLock.withCriticalScope {
             if _isCancelled { operations.forEach { $0.cancel() } }
-            return _procedureQueue.add(operations: operations)
+            return _procedureQueue.addOperations(operations)
         }
     }
 
@@ -977,7 +977,7 @@ internal class ConditionEvaluationContext {
         stateLock.withCriticalScope {
             for operations in operations {
                 if _isCancelled { operations.forEach { $0.cancel() } }
-                _procedureQueue.add(operations: operations)
+                _procedureQueue.addOperations(operations)
             }
         }
     }

--- a/Sources/ProcedureKit/Group.swift
+++ b/Sources/ProcedureKit/Group.swift
@@ -407,7 +407,7 @@ public extension GroupProcedure {
         optimizedDispatchEventNotify(group: willAddObserversGroup) {
 
             // Add to queue
-            self.queue.add(operations: additional, withContext: self.queueAddContext).then(on: self) {
+            self.queue.addOperations(additional, withContext: self.queueAddContext).then(on: self) {
 
                 if let pendingEvent = pendingEvent {
                     pendingEvent.doBeforeEvent {

--- a/Sources/ProcedureKit/Procedure.swift
+++ b/Sources/ProcedureKit/Procedure.swift
@@ -895,7 +895,7 @@ open class Procedure: Operation, ProcedureProtocol {
         log.verbose(message: ".produce() | [event]: AddOperation(\(operation.operationName)) to queue.")
 
         // Add the new produced operation to the ProcedureQueue on which this Procedure was added
-        queue.add(operation: operation, withContext: queueAddContext).then(on: self) {
+        queue.addOperation(operation, withContext: queueAddContext).then(on: self) {
 
             // After adding to the queue completes, proceed to step 3 of handling produce()
             self._produce_step3(operation: operation, onQueue: queue, before: pendingEvent, promise: promise)

--- a/Sources/ProcedureKit/ProcedureQueue.swift
+++ b/Sources/ProcedureKit/ProcedureQueue.swift
@@ -205,7 +205,7 @@ open class ProcedureQueue: OperationQueue {
      - parameter context: an optional parameter that is passed-through to the Will/DidAdd delegate callbacks
      - returns: a `ProcedureFuture` that is signaled once the operation has been added to the `ProcedureQueue`
      */
-    @discardableResult open func add(operation: Operation, withContext context: Any? = nil) -> ProcedureFuture {
+    @discardableResult open func addOperation(_ operation: Operation, withContext context: Any? = nil) -> ProcedureFuture {
 
         let promise = ProcedurePromise()
 
@@ -221,7 +221,7 @@ open class ProcedureQueue: OperationQueue {
         //    have been called
         //  - the operation may not have been added to the queue yet, but *will* be (if not)
         //
-        _add(operation: operation, context: context, promise: promise)
+        _addOperation(operation, withContext: context, promise: promise)
 
         return promise.future
     }
@@ -242,7 +242,7 @@ open class ProcedureQueue: OperationQueue {
 
     /// Overrides and wraps the Swift 3 interface
     open override func addOperation(_ operation: Operation) {
-        add(operation: operation)
+        addOperation(operation, withContext: nil)
     }
 
     /**
@@ -284,7 +284,7 @@ open class ProcedureQueue: OperationQueue {
 
     // MARK: - Private Implementation
 
-    private func _add(operation: Operation, context: Any?, promise: ProcedurePromise) {
+    private func _addOperation(_ operation: Operation, withContext context: Any?, promise: ProcedurePromise) {
 
         // Stage 1: Add observers / completion block,
         //          willEnqueue(on: self)
@@ -557,11 +557,10 @@ public extension ProcedureQueue {
      - parameter context: an optional parameter that is passed-through to the Will/DidAdd delegate callbacks
      - returns: a `ProcedureFuture` that is signaled once the operations have been added to the `ProcedureQueue`
      */
-    @discardableResult
-    final func add<S: Sequence>(operations: S, withContext context: Any? = nil) -> ProcedureFuture where S.Iterator.Element: Operation {
+    @discardableResult final func addOperations<S: Sequence>(_ operations: S, withContext context: Any? = nil) -> ProcedureFuture where S.Iterator.Element: Operation {
 
         let futures = operations.map {
-            add(operation: $0, withContext: context)
+            addOperation($0, withContext: context)
         }
 
         return futures.future
@@ -574,8 +573,8 @@ public extension ProcedureQueue {
      - parameter context: an optional parameter that is passed-through to the Will/DidAdd delegate callbacks
      - returns: a `ProcedureFuture` that is signaled once the operations have been added to the `ProcedureQueue`
      */
-    final func add(operations: Operation..., withContext context: Any? = nil) -> ProcedureFuture {
-        return add(operations: operations, withContext: context)
+    @discardableResult final func addOperations(_ operations: Operation..., withContext context: Any? = nil) -> ProcedureFuture {
+        return addOperations(operations, withContext: context)
     }
 }
 
@@ -586,7 +585,7 @@ public extension OperationQueue {
      Add operations to the queue as an array
      - parameter operations: a array of `Operation` instances.
      */
-    final func add<S>(operations: S) where S: Sequence, S.Iterator.Element: Operation {
+    final func addOperations<S>(_ operations: S) where S: Sequence, S.Iterator.Element: Operation {
         addOperations(Array(operations), waitUntilFinished: false)
     }
 
@@ -594,8 +593,8 @@ public extension OperationQueue {
      Add operations to the queue as a variadic parameter
      - parameter operations: a variadic array of `Operation` instances.
      */
-    final func add(operations: Operation...) {
-        add(operations: operations)
+    final func addOperations(_ operations: Operation...) {
+        addOperations(operations)
     }
 }
 
@@ -616,3 +615,34 @@ fileprivate class _SyncAlreadyAvailableFuture: ProcedureFuture {
 
 @available(*, unavailable, renamed: "ProcedureQueueDelegate")
 public protocol OperationQueueDelegate: class { }
+
+public extension ProcedureQueue {
+
+    @available(*, deprecated, renamed: "addOperation(_:withContext:)", message: "This has been renamed to use Swift 3/4 naming conventions")
+    @discardableResult func add(operation: Operation, withContext context: Any? = nil) -> ProcedureFuture {
+        return addOperation(operation, withContext: context)
+    }
+
+    @available(*, deprecated, renamed: "addOperations(_:withContext:)", message: "This has been renamed to use Swift 3/4 naming conventions")
+    @discardableResult final func add<S: Sequence>(operations: S, withContext context: Any? = nil) -> ProcedureFuture where S.Iterator.Element: Operation {
+        return addOperations(operations, withContext: context)
+    }
+
+    @available(*, deprecated, renamed: "addOperations(_:withContext:)", message: "This has been renamed to use Swift 3/4 naming conventions")
+    final func add(operations: Operation..., withContext context: Any? = nil) -> ProcedureFuture {
+        return addOperations(operations, withContext: context)
+    }
+}
+
+public extension OperationQueue {
+
+    @available(*, deprecated, renamed: "addOperations(_:)", message: "This has been renamed to use Swift 3/4 naming conventions")
+    final func add<S>(operations: S) where S: Sequence, S.Iterator.Element: Operation {
+        addOperations(operations)
+    }
+
+    @available(*, deprecated, renamed: "addOperations(_:)", message: "This has been renamed to use Swift 3/4 naming conventions")
+    final func add(operations: Operation...) {
+        addOperations(operations)
+    }
+}

--- a/Tests/ProcedureKitTests/ConditionTests.swift
+++ b/Tests/ProcedureKitTests/ConditionTests.swift
@@ -503,7 +503,7 @@ class ConditionTests: ProcedureKitTestCase {
             }
         }
         queue.delegate = customDelegate
-        queue.add(operations: procedure, dependency)
+        queue.addOperations(procedure, dependency)
 
         // wait until the procedure has been added to the queue
         // and the dependency has been started
@@ -573,7 +573,7 @@ class ConditionTests: ProcedureKitTestCase {
         }))
         procedure.add(dependency: dependency)
 
-        queue.add(operations: procedure, dependency, additionalDependency)
+        queue.addOperations(procedure, dependency, additionalDependency)
 
         // wait until the first dependency has finished,
         // and the additionalDependency has started
@@ -1126,7 +1126,7 @@ class ConditionTests: ProcedureKitTestCase {
 
         procedure.add(condition: testCondition)
         addCompletionBlockTo(procedure: procedure)
-        queue.add(operation: procedure)
+        queue.addOperation(procedure)
 
         XCTAssertTrue(conditionWasEvaluatedGroup.wait(timeout: .now() + 1.0) == .timedOut, "The condition was evaluated, despite the ProcedureQueue being suspended.")
 

--- a/Tests/ProcedureKitTests/GroupTests.swift
+++ b/Tests/ProcedureKitTests/GroupTests.swift
@@ -177,7 +177,7 @@ class GroupTests: GroupTestCase {
         }
 
         addCompletionBlockTo(procedure: group)
-        procedureQueue.add(operation: group)
+        procedureQueue.addOperation(group)
         waitForExpectations(timeout: 3)
 
         XCTAssertTrue(didExecuteOnDesiredQueue.access, "execute() did not execute on the desired underlyingQueue")
@@ -451,7 +451,7 @@ extension GroupTests {
         // Adding a TestProcedure to the otherQueue should not result in the Group's
         // Will/DidAddChild observers being called, nor should the Group wait
         // on the other queue's TestProcedure to finish.
-        otherQueue.add(operation: TestProcedure())
+        otherQueue.addOperation(TestProcedure())
         wait(for: group)
         XCTAssertTrue(group.isFinished)
         XCTAssertFalse(observerCalledFromGroupDelegate)

--- a/Tests/ProcedureKitTests/MutualExclusivityTests.swift
+++ b/Tests/ProcedureKitTests/MutualExclusivityTests.swift
@@ -165,7 +165,7 @@ class MutualExclusiveTests: ProcedureKitTestCase {
         )
 
         addCompletionBlockTo(procedure: procedure)
-        queue.add(operation: procedure)
+        queue.addOperation(procedure)
         waitForExpectations(timeout: 3)
 
         PKAssertProcedureFinished(procedure)
@@ -260,10 +260,10 @@ class MutualExclusiveConcurrencyTests: ConcurrencyTestCase {
         procedure2.add(dependency: procedure1)
 
         // add procedure2 to the queue first
-        queue.add(operation: procedure2).then(on: DispatchQueue.main) { [weak weakQueue = self.queue] in
+        queue.addOperation(procedure2).then(on: DispatchQueue.main) { [weak weakQueue = self.queue] in
             guard let queue = weakQueue else { return }
             // then add procedure1 to the queue
-            queue.add(operation: procedure1)
+            queue.addOperation(procedure1)
         }
 
         waitForExpectations(timeout: 2)
@@ -314,7 +314,7 @@ class MutualExclusiveConcurrencyTests: ConcurrencyTestCase {
                 expProcedureWasStarted.fulfill()
             }
 
-            queue!.add(operation: procedure1)
+            queue!.addOperation(procedure1)
             waitForExpectations(timeout: 3) // wait for the Procedure to be started by the queue
 
             // store a weak reference to the ProcedureQueue

--- a/Tests/ProcedureKitTests/ProcedureTests.swift
+++ b/Tests/ProcedureKitTests/ProcedureTests.swift
@@ -86,7 +86,7 @@ class QueueDelegateTests: ProcedureKitTestCase {
 
         expectQueueDelegateDidFinishFor(operations: [operation], procedures: [finishedProcedure])
 
-        queue.add(operations: [operation, finishedProcedure]).then(on: DispatchQueue.main) {
+        queue.addOperations([operation, finishedProcedure]).then(on: DispatchQueue.main) {
             expAddFinished?.fulfill()
         }
         waitForExpectations(timeout: 3)
@@ -103,7 +103,7 @@ class QueueDelegateTests: ProcedureKitTestCase {
 
         expectQueueDelegateDidFinishFor(procedures: [procedure])
 
-        queue.add(operation: procedure).then(on: DispatchQueue.main) {
+        queue.addOperation(procedure).then(on: DispatchQueue.main) {
             expAddFinished?.fulfill()
         }
         waitForExpectations(timeout: 3)
@@ -289,7 +289,7 @@ class ExecutionTests: ProcedureKitTestCase {
         }
 
         addCompletionBlockTo(procedure: procedure)
-        procedureQueue.add(operation: procedure)
+        procedureQueue.addOperation(procedure)
         waitForExpectations(timeout: 3)
 
         XCTAssertTrue(didExecuteOnDesiredQueue.access, "execute() did not execute on the desired underlyingQueue")

--- a/Tests/ProcedureKitTests/RetryProcedureTests.swift
+++ b/Tests/ProcedureKitTests/RetryProcedureTests.swift
@@ -99,7 +99,7 @@ class RetryProcedureTests: RetryTestCase {
             retry.addDidFinishBlockObserver { _, _ in
                 semaphore.signal()
             }
-            queue.add(operation: retry)
+            queue.addOperation(retry)
             semaphore.wait()
         }
 


### PR DESCRIPTION
This is to address the issue raised in #796. 

- [x] `ProcedureQueue.swift`
- [ ] `Procedure.swift`
- [ ] `Condition.swift`

