### PR TITLE
Make new platform schemes used by CI test only schemes.

### DIFF
--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/Mac.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/Mac.xcscheme
@@ -9,84 +9,84 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-               BuildableName = "ProcedureKit.framework"
-               BlueprintName = "ProcedureKit"
+               BlueprintIdentifier = "65CFC5F81D608A5500CAD875"
+               BuildableName = "ProcedureKitTests.xctest"
+               BlueprintName = "ProcedureKitTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "653CA0591D60AA990070B7A2"
-               BuildableName = "ProcedureKitCloud.framework"
-               BlueprintName = "ProcedureKitCloud"
+               BlueprintIdentifier = "653CA0611D60AA990070B7A2"
+               BuildableName = "ProcedureKitCloudTests.xctest"
+               BlueprintName = "ProcedureKitCloudTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65A0E49820B85168002D6C8C"
-               BuildableName = "ProcedureKitCoreData.framework"
-               BlueprintName = "ProcedureKitCoreData"
+               BlueprintIdentifier = "65A0E4A020B85169002D6C8C"
+               BuildableName = "ProcedureKitCoreDataTests.xctest"
+               BlueprintName = "ProcedureKitCoreDataTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6594841D1DAAA2B90028F83B"
-               BuildableName = "ProcedureKitLocation.framework"
-               BlueprintName = "ProcedureKitLocation"
+               BlueprintIdentifier = "659484251DAAA2B90028F83B"
+               BuildableName = "ProcedureKitLocationTests.xctest"
+               BlueprintName = "ProcedureKitLocationTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "653CA02F1D60A5D10070B7A2"
-               BuildableName = "ProcedureKitMac.framework"
-               BlueprintName = "ProcedureKitMac"
+               BlueprintIdentifier = "653CA0371D60A5D10070B7A2"
+               BuildableName = "ProcedureKitMacTests.xctest"
+               BlueprintName = "ProcedureKitMacTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65ECB2CC1DB4F0C000F96F46"
-               BuildableName = "ProcedureKitNetwork.framework"
-               BlueprintName = "ProcedureKitNetwork"
+               BlueprintIdentifier = "65ECB2D41DB4F0C000F96F46"
+               BuildableName = "ProcedureKitNetworkTests.xctest"
+               BlueprintName = "ProcedureKitNetworkTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -208,9 +208,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-            BuildableName = "ProcedureKit.framework"
-            BlueprintName = "ProcedureKit"
+            BlueprintIdentifier = "65CFC5F81D608A5500CAD875"
+            BuildableName = "ProcedureKitTests.xctest"
+            BlueprintName = "ProcedureKitTests"
             ReferencedContainer = "container:ProcedureKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -230,9 +230,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-            BuildableName = "ProcedureKit.framework"
-            BlueprintName = "ProcedureKit"
+            BlueprintIdentifier = "65CFC5F81D608A5500CAD875"
+            BuildableName = "ProcedureKitTests.xctest"
+            BlueprintName = "ProcedureKitTests"
             ReferencedContainer = "container:ProcedureKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -245,15 +245,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-            BuildableName = "ProcedureKit.framework"
-            BlueprintName = "ProcedureKit"
-            ReferencedContainer = "container:ProcedureKit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -9,98 +9,84 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-               BuildableName = "ProcedureKit.framework"
-               BlueprintName = "ProcedureKit"
+               BlueprintIdentifier = "65CFC5F81D608A5500CAD875"
+               BuildableName = "ProcedureKitTests.xctest"
+               BlueprintName = "ProcedureKitTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "653CA0591D60AA990070B7A2"
-               BuildableName = "ProcedureKitCloud.framework"
-               BlueprintName = "ProcedureKitCloud"
+               BlueprintIdentifier = "653CA0611D60AA990070B7A2"
+               BuildableName = "ProcedureKitCloudTests.xctest"
+               BlueprintName = "ProcedureKitCloudTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65A0E49820B85168002D6C8C"
-               BuildableName = "ProcedureKitCoreData.framework"
-               BlueprintName = "ProcedureKitCoreData"
+               BlueprintIdentifier = "65A0E4A020B85169002D6C8C"
+               BuildableName = "ProcedureKitCoreDataTests.xctest"
+               BlueprintName = "ProcedureKitCoreDataTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6594841D1DAAA2B90028F83B"
-               BuildableName = "ProcedureKitLocation.framework"
-               BlueprintName = "ProcedureKitLocation"
+               BlueprintIdentifier = "659484251DAAA2B90028F83B"
+               BuildableName = "ProcedureKitLocationTests.xctest"
+               BlueprintName = "ProcedureKitLocationTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "653C9FC01D6097A40070B7A2"
-               BuildableName = "ProcedureKitMobile.framework"
-               BlueprintName = "ProcedureKitMobile"
+               BlueprintIdentifier = "65ECB2D41DB4F0C000F96F46"
+               BuildableName = "ProcedureKitNetworkTests.xctest"
+               BlueprintName = "ProcedureKitNetworkTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65ECB2CC1DB4F0C000F96F46"
-               BuildableName = "ProcedureKitNetwork.framework"
-               BlueprintName = "ProcedureKitNetwork"
-               ReferencedContainer = "container:ProcedureKit.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65CFC6151D60900000CAD875"
-               BuildableName = "TestingProcedureKit.framework"
-               BlueprintName = "TestingProcedureKit"
+               BlueprintIdentifier = "653C9FC81D6097A40070B7A2"
+               BuildableName = "ProcedureKitMobileTests.xctest"
+               BlueprintName = "ProcedureKitMobileTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -215,9 +201,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-            BuildableName = "ProcedureKit.framework"
-            BlueprintName = "ProcedureKit"
+            BlueprintIdentifier = "65CFC5F81D608A5500CAD875"
+            BuildableName = "ProcedureKitTests.xctest"
+            BlueprintName = "ProcedureKitTests"
             ReferencedContainer = "container:ProcedureKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -237,9 +223,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-            BuildableName = "ProcedureKit.framework"
-            BlueprintName = "ProcedureKit"
+            BlueprintIdentifier = "65CFC5F81D608A5500CAD875"
+            BuildableName = "ProcedureKitTests.xctest"
+            BlueprintName = "ProcedureKitTests"
             ReferencedContainer = "container:ProcedureKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -252,15 +238,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-            BuildableName = "ProcedureKit.framework"
-            BlueprintName = "ProcedureKit"
-            ReferencedContainer = "container:ProcedureKit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/ProcedureKit.xcodeproj/xcshareddata/xcschemes/tvOS.xcscheme
+++ b/ProcedureKit.xcodeproj/xcshareddata/xcschemes/tvOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0940"
-   version = "1.3">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -9,84 +9,84 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-               BuildableName = "ProcedureKit.framework"
-               BlueprintName = "ProcedureKit"
+               BlueprintIdentifier = "65CFC5F81D608A5500CAD875"
+               BuildableName = "ProcedureKitTests.xctest"
+               BlueprintName = "ProcedureKitTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "653CA0591D60AA990070B7A2"
-               BuildableName = "ProcedureKitCloud.framework"
-               BlueprintName = "ProcedureKitCloud"
+               BlueprintIdentifier = "653CA0611D60AA990070B7A2"
+               BuildableName = "ProcedureKitCloudTests.xctest"
+               BlueprintName = "ProcedureKitCloudTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65A0E49820B85168002D6C8C"
-               BuildableName = "ProcedureKitCoreData.framework"
-               BlueprintName = "ProcedureKitCoreData"
+               BlueprintIdentifier = "65A0E4A020B85169002D6C8C"
+               BuildableName = "ProcedureKitCoreDataTests.xctest"
+               BlueprintName = "ProcedureKitCoreDataTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6594841D1DAAA2B90028F83B"
-               BuildableName = "ProcedureKitLocation.framework"
-               BlueprintName = "ProcedureKitLocation"
+               BlueprintIdentifier = "659484251DAAA2B90028F83B"
+               BuildableName = "ProcedureKitLocationTests.xctest"
+               BlueprintName = "ProcedureKitLocationTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "65ECB2CC1DB4F0C000F96F46"
-               BuildableName = "ProcedureKitNetwork.framework"
-               BlueprintName = "ProcedureKitNetwork"
+               BlueprintIdentifier = "65ECB2D41DB4F0C000F96F46"
+               BuildableName = "ProcedureKitNetworkTests.xctest"
+               BlueprintName = "ProcedureKitNetworkTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "653C9FF21D609E650070B7A2"
-               BuildableName = "ProcedureKitTV.framework"
-               BlueprintName = "ProcedureKitTV"
+               BlueprintIdentifier = "653C9FFA1D609E660070B7A2"
+               BuildableName = "ProcedureKitTVTests.xctest"
+               BlueprintName = "ProcedureKitTVTests"
                ReferencedContainer = "container:ProcedureKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -220,9 +220,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-            BuildableName = "ProcedureKit.framework"
-            BlueprintName = "ProcedureKit"
+            BlueprintIdentifier = "65CFC5F81D608A5500CAD875"
+            BuildableName = "ProcedureKitTests.xctest"
+            BlueprintName = "ProcedureKitTests"
             ReferencedContainer = "container:ProcedureKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -242,9 +242,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-            BuildableName = "ProcedureKit.framework"
-            BlueprintName = "ProcedureKit"
+            BlueprintIdentifier = "65CFC5F81D608A5500CAD875"
+            BuildableName = "ProcedureKitTests.xctest"
+            BlueprintName = "ProcedureKitTests"
             ReferencedContainer = "container:ProcedureKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -257,15 +257,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "65CFC5EF1D608A5500CAD875"
-            BuildableName = "ProcedureKit.framework"
-            BlueprintName = "ProcedureKit"
-            ReferencedContainer = "container:ProcedureKit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
By removing the actual framework targets from the three platform test schemes, Carthage will avoid building them when bootstrapping / updating a project that depends on ProcedureKit. 

These changes fix #863.

Based on what I can see, the changes to the schemes should have no affect on installation via CocoaPods or SPM.