### PR TITLE
Make Location Procedures Testable in client code

### DIFF
--- a/Sources/ProcedureKitLocation/LocationSupport.swift
+++ b/Sources/ProcedureKitLocation/LocationSupport.swift
@@ -69,18 +69,12 @@ public protocol LocationServicesRegistrar {
     func locationServicesEnabled() -> Bool
 
     @available(iOS 8.0, *)
-    func requestWhenInUseAuthorization()
-
-    @available(iOS 8.0, *)
-    func requestAlwaysAuthorization()
-
-    @available(iOS 8.0, *)
     func requestAuthorization(withRequirement: LocationUsage?)
 }
 
 public typealias LocationFetcher = LocationServices & LocationServicesRegistrar
 
-public extension LocationServicesRegistrar {
+public extension LocationServicesRegistrar where Self: CLLocationManager {
     @available(iOS 8.0, *)
     public func requestAuthorization(withRequirement requirement: LocationUsage?) {
         #if os(iOS) || os(watchOS)

--- a/Sources/ProcedureKitLocation/ReverseGeocodeUserLocation.swift
+++ b/Sources/ProcedureKitLocation/ReverseGeocodeUserLocation.swift
@@ -69,7 +69,8 @@ open class ReverseGeocodeUserLocationProcedure: GroupProcedure, OutputProcedure 
         set { assertionFailure("\(#function) should not be publically settable.") }
     }
 
-    public init(dispatchQueue: DispatchQueue? = nil, timeout: TimeInterval = 3.0, accuracy: CLLocationAccuracy = kCLLocationAccuracyThreeKilometers, completion: CompletionBlock? = nil) {
+    public init(dispatchQueue: DispatchQueue? = nil, timeout: TimeInterval = 3.0, accuracy: CLLocationAccuracy = kCLLocationAccuracyThreeKilometers,
+                locationFetcher: LocationFetcher? = nil, geocoder: ReverseGeocoder? = nil, completion: CompletionBlock? = nil) {
 
         finishing = Finishing(completion: completion)
 
@@ -95,13 +96,13 @@ open class ReverseGeocodeUserLocationProcedure: GroupProcedure, OutputProcedure 
         addObserver(TimeoutObserver(by: timeout))
     }
 
-    internal func set(manager: LocationServicesRegistrarProtocol & LocationServicesProtocol) -> ReverseGeocodeUserLocationProcedure {
+    public func set(fetcher: LocationFetcher) -> ReverseGeocodeUserLocationProcedure {
         precondition(!isExecuting)
-        userLocation.manager = manager
+        userLocation.fetcher = fetcher
         return self
     }
 
-    internal func set(geocoder: ReverseGeocodeProtocol & GeocodeProtocol) -> ReverseGeocodeUserLocationProcedure {
+    public func set(geocoder: ReverseGeocoder) -> ReverseGeocodeUserLocationProcedure {
         precondition(!isExecuting)
         reverseGeocodeLocation.geocoder = geocoder
         return self

--- a/Tests/ProcedureKitLocationTests/LocationCapabilityTests.swift
+++ b/Tests/ProcedureKitLocationTests/LocationCapabilityTests.swift
@@ -11,13 +11,13 @@ import ProcedureKit
 import TestingProcedureKit
 @testable import ProcedureKitLocation
 
-class CLLocationManagerTests: XCTestCase, CLLocationManagerDelegate {
+class CLLocationManagerTests: XCTestCase, LocationFetcherDelegate, CLLocationManagerDelegate {
 
     func test__extension_set_delegate_works() {
         let manager = CLLocationManager.make()
-        manager.pk_set(delegate: self)
+        manager.locationFetcherDelegate = self
         XCTAssertNotNil(manager.delegate)
-        manager.pk_set(delegate: nil)
+        manager.locationFetcherDelegate = nil
         XCTAssertNil(manager.delegate)
     }
 }
@@ -133,7 +133,7 @@ class LocationCapabilityTests: XCTestCase {
     #if os(iOS)
     func test__given_when_in_use_require_always_request_authorization() {
         weak var exp = expectation(description: "Test: \(#function)")
-        registrar.authorizationStatus = .authorizedWhenInUse
+        registrar.authStatus = .authorizedWhenInUse
         capability = Capability.Location(.always)
         capability.registrar = registrar
         var didComplete = false
@@ -152,7 +152,7 @@ class LocationCapabilityTests: XCTestCase {
 
     func test__given_denied_does_not_request_authorization() {
         weak var exp = expectation(description: "Test: \(#function)")
-        registrar.authorizationStatus = .denied
+        registrar.authStatus = .denied
         var didComplete = false
         capability.requestAuthorization {
             didComplete = true
@@ -167,7 +167,7 @@ class LocationCapabilityTests: XCTestCase {
 
     func test__given_already_authorized_sufficiently_does_not_request_authorization() {
         weak var exp = expectation(description: "Test: \(#function)")
-        registrar.authorizationStatus = {
+        registrar.authStatus = {
             if #available(OSX 10.12, iOS 8.0, tvOS 8.0, watchOS 2.0, *) {
                 return CLAuthorizationStatus.authorizedAlways
             }

--- a/Tests/ProcedureKitLocationTests/ReverseGeocodeUserLocationProcedureTests.swift
+++ b/Tests/ProcedureKitLocationTests/ReverseGeocodeUserLocationProcedureTests.swift
@@ -13,7 +13,7 @@ class ReverseGeocodeUserLocationProcedureTests: LocationProcedureTestCase {
 
     func test__geocoder_starts() {
         geocoder.placemarks = [placemark]
-        let procedure = ReverseGeocodeUserLocationProcedure().set(manager: manager).set(geocoder: geocoder)
+        let procedure = ReverseGeocodeUserLocationProcedure().set(fetcher: locationFetcher).set(geocoder: geocoder)
         wait(for: procedure)
         PKAssertProcedureFinished(procedure)
         XCTAssertEqual(geocoder.didReverseGeocodeLocation, location)
@@ -26,7 +26,7 @@ class ReverseGeocodeUserLocationProcedureTests: LocationProcedureTestCase {
         let procedure = ReverseGeocodeUserLocationProcedure { result in
             didReceiveUserLocationPlacemark = result
             exp.fulfill()
-        }.set(manager: manager).set(geocoder: geocoder)
+        }.set(fetcher: locationFetcher).set(geocoder: geocoder)
         wait(for: procedure)
         PKAssertProcedureFinished(procedure)
         XCTAssertNotNil(didReceiveUserLocationPlacemark)
@@ -35,8 +35,8 @@ class ReverseGeocodeUserLocationProcedureTests: LocationProcedureTestCase {
 
     func test__user_location_returns_error_cancels_with_error() {
         let error = TestError()
-        manager.returnedError = error
-        let procedure = ReverseGeocodeUserLocationProcedure().set(manager: manager).set(geocoder: geocoder)
+        locationFetcher.returnedError = error
+        let procedure = ReverseGeocodeUserLocationProcedure().set(fetcher: locationFetcher).set(geocoder: geocoder)
         wait(for: procedure)
         // There are actually 3 errors here, because the UserLocation fails with
         // an error, the procedures which depend on it then both cancel with errors
@@ -45,8 +45,8 @@ class ReverseGeocodeUserLocationProcedureTests: LocationProcedureTestCase {
     }
 
     func test__no_user_location_finishes_with_errors() {
-        manager.returnedLocation = nil
-        let procedure = ReverseGeocodeUserLocationProcedure(timeout: 1).set(manager: manager).set(geocoder: geocoder)
+        locationFetcher.returnedLocation = nil
+        let procedure = ReverseGeocodeUserLocationProcedure(timeout: 1).set(fetcher: locationFetcher).set(geocoder: geocoder)
         wait(for: procedure)
         PKAssertProcedureCancelledWithError(procedure, ProcedureKitError.timedOut(with: .by(1)))
     }

--- a/Tests/ProcedureKitLocationTests/UserLocationProcedureTests.swift
+++ b/Tests/ProcedureKitLocationTests/UserLocationProcedureTests.swift
@@ -14,69 +14,62 @@ import TestingProcedureKit
 class UserLocationProcedureTests: LocationProcedureTestCase {
 
     func test__received_location_is_set() {
-        let procedure = UserLocationProcedure(accuracy: accuracy)
-        procedure.manager = manager
+        let procedure = UserLocationProcedure(accuracy: accuracy, locationFetcher: locationFetcher)
         wait(for: procedure)
         PKAssertProcedureFinished(procedure)
         XCTAssertEqual(procedure.output.success, location)
-        XCTAssertEqual(manager.didSetDesiredAccuracy, accuracy)
-        XCTAssertTrue(manager.didSetDelegate)
-        XCTAssertTrue(manager.didStartUpdatingLocation)
-        XCTAssertTrue(manager.didStopUpdatingLocation)
+        XCTAssertEqual(locationFetcher.didSetDesiredAccuracy, accuracy)
+        XCTAssertTrue(locationFetcher.didSetDelegate)
+        XCTAssertTrue(locationFetcher.didStartUpdatingLocation)
+        XCTAssertTrue(locationFetcher.didStopUpdatingLocation)
     }
 
     func test__receives_location_in_completion_block() {
         var receivedLocation: CLLocation? = nil
-        let procedure = UserLocationProcedure(accuracy: accuracy) { location in
+        let procedure = UserLocationProcedure(accuracy: accuracy, locationFetcher: locationFetcher) { location in
             receivedLocation = location
         }
-        procedure.manager = manager
         wait(for: procedure)
         PKAssertProcedureFinished(procedure)
         XCTAssertEqual(receivedLocation, location)
-        XCTAssertEqual(manager.didSetDesiredAccuracy, accuracy)
-        XCTAssertTrue(manager.didSetDelegate)
-        XCTAssertTrue(manager.didStartUpdatingLocation)
-        XCTAssertTrue(manager.didStopUpdatingLocation)
+        XCTAssertEqual(locationFetcher.didSetDesiredAccuracy, accuracy)
+        XCTAssertTrue(locationFetcher.didSetDelegate)
+        XCTAssertTrue(locationFetcher.didStartUpdatingLocation)
+        XCTAssertTrue(locationFetcher.didStopUpdatingLocation)
     }
 
     func test__updates_stop_when_cancelled() {
-        let procedure = UserLocationProcedure(accuracy: accuracy)
-        procedure.manager = manager
+        let procedure = UserLocationProcedure(accuracy: accuracy, locationFetcher: locationFetcher)
         check(procedure: procedure) { $0.cancel() }
-        XCTAssertTrue(manager.didStopUpdatingLocation)
+        XCTAssertTrue(locationFetcher.didStopUpdatingLocation)
     }
 
     func test__updates_stop_when_deallocated() {
-        var tmp: UserLocationProcedure! = UserLocationProcedure(accuracy: accuracy)
-        tmp.manager = manager
+        var tmp: UserLocationProcedure! = UserLocationProcedure(accuracy: accuracy, locationFetcher: locationFetcher)
         tmp = nil
         // because of the asynchronous nature of a Procedure, deinit could occur in
         // another thread that is still finishing up a block and releases the last reference
         // to `tmp` - therefore, wait for a short bit to allow for that case
-        XCTAssertEqual(manager.waitForDidStopUpdatingLocation(withTimeout: 0.5), .success)
+        XCTAssertEqual(locationFetcher.waitForDidStopUpdatingLocation(withTimeout: 0.5), .success)
     }
 
     func test__finishes_if_accuracy_is_best() {
-        let procedure = UserLocationProcedure(accuracy: kCLLocationAccuracyBestForNavigation)
-        procedure.manager = manager
+        let procedure = UserLocationProcedure(accuracy: kCLLocationAccuracyBestForNavigation, locationFetcher: locationFetcher)
         wait(for: procedure)
         PKAssertProcedureFinished(procedure)
     }
 
     func test__finishes_with_error_if_location_manager_fails() {
         let error = TestError()
-        manager.returnedError = error
-        let procedure = UserLocationProcedure(accuracy: accuracy)
-        procedure.manager = manager
+        locationFetcher.returnedError = error
+        let procedure = UserLocationProcedure(accuracy: accuracy, locationFetcher: locationFetcher)
         wait(for: procedure)
         PKAssertProcedureFinishedWithError(procedure, error)
     }
 
     func test__cancels_with_timeout_if_location_manager_takes_too_long() {
-        manager.returnAfterDelay = 0.2
-        let procedure = UserLocationProcedure(timeout: 0.1, accuracy: accuracy)
-        procedure.manager = manager
+        locationFetcher.returnAfterDelay = 0.2
+        let procedure = UserLocationProcedure(timeout: 0.1, accuracy: accuracy, locationFetcher: locationFetcher)
         wait(for: procedure)
         PKAssertProcedureCancelledWithError(procedure, ProcedureKitError.timedOut(with: .by(0.1)))
     }

--- a/Tests/ProcedureKitLocationTests/UserLocationProcedureTests.swift
+++ b/Tests/ProcedureKitLocationTests/UserLocationProcedureTests.swift
@@ -46,6 +46,7 @@ class UserLocationProcedureTests: LocationProcedureTestCase {
 
     func test__updates_stop_when_deallocated() {
         var tmp: UserLocationProcedure! = UserLocationProcedure(accuracy: accuracy, locationFetcher: locationFetcher)
+        XCTAssertNotNil(tmp)
         tmp = nil
         // because of the asynchronous nature of a Procedure, deinit could occur in
         // another thread that is still finishing up a block and releases the last reference


### PR DESCRIPTION
This PR exposes the ability for client code to inject mock LocationFetcher (CLLocationManager), and ReverseGeocoder (CLGeocoder) into location procedures. 

This is necessary to allow any client code that depends on or uses, especially in GroupProcedures, a procedure from ProcedureKitLocation. Without these changes, client code is subject to the state of the device/simulator during unit tests, making it impossible to validate behaviour when location services is disabled, no location is available, etc. 