### PR TITLE
Refactors Logger

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		65A0E4C320BB1975002D6C8C /* LoadCoreDataProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A0E4C220BB1975002D6C8C /* LoadCoreDataProcedureTests.swift */; };
 		65A0E4C520BB2E51002D6C8C /* SaveManagedObjectContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A0E4C420BB2E51002D6C8C /* SaveManagedObjectContext.swift */; };
 		65A0E4C820BC5540002D6C8C /* SaveManagedObjectContextProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A0E4C620BC548A002D6C8C /* SaveManagedObjectContextProcedureTests.swift */; };
+		65A1923920F88FD300E0D42C /* LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A1923820F88FD300E0D42C /* LoggingTests.swift */; };
+		65A1923B20F8900100E0D42C /* TestableLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65A1923A20F8900100E0D42C /* TestableLogging.swift */; };
 		65A72C2A1DA7F37C008597CA /* ProcedureKit.framework in Copy Dependencies */ = {isa = PBXBuildFile; fileRef = 65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		65A72C2B1DA7F37C008597CA /* TestingProcedureKit.framework in Copy Dependencies */ = {isa = PBXBuildFile; fileRef = 65CFC6161D60900000CAD875 /* TestingProcedureKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		65AB7DDA209B95B400726796 /* Batch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AB7DD9209B95B400726796 /* Batch.swift */; };
@@ -580,6 +582,8 @@
 		65A0E4C220BB1975002D6C8C /* LoadCoreDataProcedureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadCoreDataProcedureTests.swift; sourceTree = "<group>"; };
 		65A0E4C420BB2E51002D6C8C /* SaveManagedObjectContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveManagedObjectContext.swift; sourceTree = "<group>"; };
 		65A0E4C620BC548A002D6C8C /* SaveManagedObjectContextProcedureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveManagedObjectContextProcedureTests.swift; sourceTree = "<group>"; };
+		65A1923820F88FD300E0D42C /* LoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingTests.swift; sourceTree = "<group>"; };
+		65A1923A20F8900100E0D42C /* TestableLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestableLogging.swift; sourceTree = "<group>"; };
 		65AB7DD9209B95B400726796 /* Batch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Batch.swift; sourceTree = "<group>"; };
 		65AEF19E20A3AE340089B6C8 /* ViewControllerContainment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerContainment.swift; sourceTree = "<group>"; };
 		65C88D761DC4EB4300C8D4EB /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Warnings.xcconfig; path = "Supporting Files/Warnings.xcconfig"; sourceTree = "<group>"; };
@@ -1162,6 +1166,7 @@
 				652F903E209E445200365B2D /* IgnoreErrorsProcedureTests.swift */,
 				EEE79AED1E21C9750030C768 /* KVONotificationTests.swift */,
 				65D366F31E183FB000D03E86 /* LoggerTests.swift */,
+				65A1923820F88FD300E0D42C /* LoggingTests.swift */,
 				65D366F41E183FB000D03E86 /* MapProcedureTests.swift */,
 				65D366F51E183FB000D03E86 /* MutualExclusivityTests.swift */,
 				65D366F61E183FB000D03E86 /* NegatedConditionTests.swift */,
@@ -1222,6 +1227,7 @@
 				65D367CA1E1844E500D03E86 /* QueueTestDelegate.swift */,
 				65D367CB1E1844E500D03E86 /* RepeatTestCase.swift */,
 				65D367CC1E1844E500D03E86 /* StressTestCase.swift */,
+				65A1923A20F8900100E0D42C /* TestableLogging.swift */,
 				65D367CD1E1844E500D03E86 /* TestableNetwork.swift */,
 				65D367CE1E1844E500D03E86 /* TestableNetworkReachability.swift */,
 				65D367CF1E1844E500D03E86 /* TestCondition.swift */,
@@ -2332,6 +2338,7 @@
 				652F903F209E445200365B2D /* IgnoreErrorsProcedureTests.swift in Sources */,
 				65D367091E183FB000D03E86 /* BlockObserverTests.swift in Sources */,
 				65D367391E183FB000D03E86 /* RetryProcedureTests.swift in Sources */,
+				65A1923920F88FD300E0D42C /* LoggingTests.swift in Sources */,
 				65D367331E183FB000D03E86 /* ReduceProcedureTests.swift in Sources */,
 				65D367251E183FB000D03E86 /* NetworkObserverTests.swift in Sources */,
 				65D367191E183FB000D03E86 /* FinishingTests.swift in Sources */,
@@ -2376,6 +2383,7 @@
 				65D367D41E1844E500D03E86 /* GroupTestCase.swift in Sources */,
 				65D367D21E1844E500D03E86 /* CapabilityTestCase.swift in Sources */,
 				65D367D81E1844E500D03E86 /* StressTestCase.swift in Sources */,
+				65A1923B20F8900100E0D42C /* TestableLogging.swift in Sources */,
 				65D367D61E1844E500D03E86 /* QueueTestDelegate.swift in Sources */,
 				65D367D51E1844E500D03E86 /* ProcedureKitTestCase.swift in Sources */,
 				65D367DB1E1844E500D03E86 /* TestCondition.swift in Sources */,

--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -138,7 +138,6 @@
 		65D367171E183FB000D03E86 /* FilterProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D366F01E183FB000D03E86 /* FilterProcedureTests.swift */; };
 		65D367191E183FB000D03E86 /* FinishingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D366F11E183FB000D03E86 /* FinishingTests.swift */; };
 		65D3671B1E183FB000D03E86 /* GroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D366F21E183FB000D03E86 /* GroupTests.swift */; };
-		65D3671D1E183FB000D03E86 /* LoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D366F31E183FB000D03E86 /* LoggerTests.swift */; };
 		65D3671F1E183FB000D03E86 /* MapProcedureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D366F41E183FB000D03E86 /* MapProcedureTests.swift */; };
 		65D367211E183FB000D03E86 /* MutualExclusivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D366F51E183FB000D03E86 /* MutualExclusivityTests.swift */; };
 		65D367231E183FB000D03E86 /* NegatedConditionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D366F61E183FB000D03E86 /* NegatedConditionTests.swift */; };
@@ -2338,7 +2337,6 @@
 				65D367191E183FB000D03E86 /* FinishingTests.swift in Sources */,
 				EEE79AEE1E21C9750030C768 /* KVONotificationTests.swift in Sources */,
 				65D367131E183FB000D03E86 /* ConditionTests.swift in Sources */,
-				65D3671D1E183FB000D03E86 /* LoggerTests.swift in Sources */,
 				65D3673D1E183FB000D03E86 /* TimeoutObserverTests.swift in Sources */,
 				EE3371091E29AD5A004272E9 /* DispatchQueueExtensionsTests.swift in Sources */,
 				65D3673F1E183FB000D03E86 /* TransformProcedureTests.swift in Sources */,

--- a/Sources/ProcedureKit/Any.swift
+++ b/Sources/ProcedureKit/Any.swift
@@ -58,11 +58,11 @@ public class AnyInputProcedure<Input>: GroupProcedure, InputProcedure {
         }
     }
 
-    public init<Base: Procedure>(dispatchQueue: DispatchQueue? = nil, _ base: Base) where Base: InputProcedure,
-                                                                                        Input == Base.Input {
+    public init<Base: Procedure>(dispatchQueue: DispatchQueue? = nil, _ base: Base) where Base: InputProcedure, Input == Base.Input {
         self.inputBox = ProcedureInputBoxCreator.inputBox(for: base)
         super.init(dispatchQueue: dispatchQueue, operations: [base])
         self.log.enabled = false
+        self.system.enabled = false
     }
 }
 
@@ -77,11 +77,11 @@ public class AnyOutputProcedure<Output>: GroupProcedure, OutputProcedure {
         }
     }
 
-    public init<Base: Procedure>(dispatchQueue: DispatchQueue? = nil, _ base: Base) where Base: OutputProcedure,
-                                                                                            Output == Base.Output {
+    public init<Base: Procedure>(dispatchQueue: DispatchQueue? = nil, _ base: Base) where Base: OutputProcedure, Output == Base.Output {
         self.outputBox = ProcedureOutputBoxCreator.outputBox(for: base)
         super.init(dispatchQueue: dispatchQueue, operations: [base])
         self.log.enabled = false
+        self.system.enabled = false
     }
 }
 
@@ -106,11 +106,11 @@ public class AnyProcedure<Input, Output>: GroupProcedure, InputProcedure, Output
         }
     }
 
-    public init<Base: Procedure>(dispatchQueue: DispatchQueue? = nil, _ base: Base)
-                            where Base: InputProcedure & OutputProcedure, Output == Base.Output, Input == Base.Input {
+    public init<Base: Procedure>(dispatchQueue: DispatchQueue? = nil, _ base: Base) where Base: InputProcedure & OutputProcedure, Output == Base.Output, Input == Base.Input {
         self.inputBox = ProcedureInputBoxCreator.inputBox(for: base)
         self.outputBox = ProcedureOutputBoxCreator.outputBox(for: base)
         super.init(dispatchQueue: dispatchQueue, operations: [base])
-        log.enabled = false
+        self.log.enabled = false
+        self.system.enabled = false
     }
 }

--- a/Sources/ProcedureKit/AnyObserver.swift
+++ b/Sources/ProcedureKit/AnyObserver.swift
@@ -114,7 +114,7 @@ internal class TransformObserver<O: ProcedureProtocol, R: ProcedureProtocol>: Pr
 
     private func typedProcedure(_ procedure: R, event: Event) -> O? {
         guard let typedProcedure = procedureTransformBlock(procedure) else {
-            procedure.log.warning(message: ("Observer will not receive event (\(event.string)). Unable to convert \(procedure) to the expected type \"\(String(describing: O.self))\""))
+            procedure.log.warning.message("Observer will not receive event (\(event.string)). Unable to convert \(procedure) to the expected type \"\(String(describing: O.self))\"")
             return nil
         }
         return typedProcedure

--- a/Sources/ProcedureKit/Block.swift
+++ b/Sources/ProcedureKit/Block.swift
@@ -102,6 +102,7 @@ open class UIBlockProcedure: AsyncBlockProcedure {
             }
 
             sub.log.enabled = false
+            sub.system.enabled = false
 
             sub.addDidFinishBlockObserver { (_, error) in
                 if let error = error {

--- a/Sources/ProcedureKit/Group.swift
+++ b/Sources/ProcedureKit/Group.swift
@@ -298,7 +298,7 @@ public extension GroupProcedure {
         }
         set {
             groupStateLock.withCriticalScope {
-                log.verbose(message: "isSuspended = \(newValue), (old value: \(_groupIsSuspended))")
+                system.verbose.message("isSuspended = \(newValue), (old value: \(_groupIsSuspended))")
                 _groupIsSuspended = newValue
                 queue.isSuspended = newValue
             }
@@ -336,6 +336,9 @@ public extension GroupProcedure {
 
     private func shouldAdd<Additional: Collection>(additional: Additional, toOperationsArray shouldAddToProperty: Bool) -> Bool where Additional.Iterator.Element: Operation {
         return groupStateLock.withCriticalScope {
+
+            system.verbose.trace()
+
             guard !_groupIsFinishing else {
                 assertionFailure("Cannot add new operations to a group after the group has started to finish.")
                 return false
@@ -373,7 +376,8 @@ public extension GroupProcedure {
             return
         }
 
-        log.verbose(message: "is adding \(additional.count) child operations to the queue.")
+        system.verbose.trace()
+        system.verbose.message("is adding \(additional.count) child operations to the queue.")
 
         // If the Group is cancelled, cancel the additional operations
         if isCancelled {
@@ -394,6 +398,8 @@ public extension GroupProcedure {
 
         eventQueue.debugAssertIsOnQueue()
 
+        system.verbose.trace()
+
         // groupWillAdd(child:) override
         additional.forEach { self.groupWillAdd(child: $0) }
 
@@ -411,7 +417,7 @@ public extension GroupProcedure {
 
                 if let pendingEvent = pendingEvent {
                     pendingEvent.doBeforeEvent {
-                        self.log.verbose(message: "Children (\(additional)) added prior to (\(pendingEvent)).")
+                        self.system.verbose.message("Children (\(additional)) added prior to (\(pendingEvent)).")
                     }
                 }
 
@@ -423,7 +429,7 @@ public extension GroupProcedure {
                 }
 
                 self.optimizedDispatchEventNotify(group: didAddObserversGroup) {
-                    self.log.verbose(message: "finished adding child operations to the queue.")
+                    self.system.verbose.message("finished adding child operations to the queue.")
                 }
             }
         }
@@ -489,7 +495,7 @@ internal extension GroupProcedure {
 
                 transformChildError(procedure, &childError)
 
-                strongGroup.log.verbose(message: "Child error for <\(procedure.operationName)> was transformed.")
+                strongGroup.system.verbose.message("Child error for <\(procedure.operationName)> was transformed.")
             }
             return promise.future
         }
@@ -627,8 +633,8 @@ fileprivate extension GroupProcedure {
         func execute() {
 
             if let group = group {
-
-                group.log.verbose(message: "executing can finish group operation.")
+                group.system.verbose.trace()
+                group.system.verbose.message("executing can finish group operation.")
 
                 // All operations that were added as a side-effect of anything up to
                 // WillFinishObservers of prior operations should have been executed.
@@ -652,7 +658,7 @@ fileprivate extension GroupProcedure {
                         // Children were added after this CanFinishOperation became
                         // ready, but before it executed or before the lock could be acquired.
 
-                        group.log.verbose(message: "cannot finish now, as there are children still active.")
+                        group.system.verbose.message("cannot finish now, as there are children still active.")
 
                         // The GroupProcedure should wait for these children to finish
                         // before finishing. Add the oustanding children as
@@ -667,7 +673,7 @@ fileprivate extension GroupProcedure {
                         // There are no additional children to handle.
                         // Ensure that no new operations can be added.
 
-                        group.log.verbose(message: "can now finish.")
+                        group.system.verbose.message("can now finish.")
 
                         group._groupIsFinishing = true
 

--- a/Sources/ProcedureKit/IgnoreErrors.swift
+++ b/Sources/ProcedureKit/IgnoreErrors.swift
@@ -22,6 +22,6 @@ final public class IgnoreErrorsProcedure<T: Procedure>: ComposedProcedure<T> {
         }
 
         // If there are errors, just log them.
-        log.warning(message: "Ignoring \(e) errors from \(child.operationName).")
+        system.warning.message("Ignoring \(e) errors from \(child.operationName).")
     }
 }

--- a/Sources/ProcedureKit/Logging.swift
+++ b/Sources/ProcedureKit/Logging.swift
@@ -397,7 +397,7 @@ public extension Log {
     public struct Writers {
 
         public static let standard: LogWriter = {
-            if #available(iOS 10.0, iOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *) {
+            if #available(iOS 10.0, iOSApplicationExtension 10.0, tvOS 10.0, tvOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *) {
                 return OSLogWriter()
             }
             else {
@@ -406,7 +406,7 @@ public extension Log {
         }()
 
         public static let system: LogWriter = {
-            if #available(iOS 10.0, iOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *) {
+            if #available(iOS 10.0, iOSApplicationExtension 10.0, tvOS 10.0, tvOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *) {
                 return Log.Writers.OSLogWriter(log: .procedure)
             }
             else {
@@ -503,7 +503,7 @@ extension Log.Severity: CustomStringConvertible {
 
 // MARK: - OS Log Writer
 
-@available(iOS 10.0, iOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *)
+@available(iOS 10.0, iOSApplicationExtension 10.0, tvOS 10.0, tvOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *)
 internal extension Log.Severity {
 
     var logType: OSLogType {
@@ -520,7 +520,7 @@ internal extension Log.Severity {
     }
 }
 
-@available(iOS 10.0, iOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *)
+@available(iOS 10.0, iOSApplicationExtension 10.0, tvOS 10.0, tvOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *)
 internal extension OSLog {
 
     static let procedure = OSLog(subsystem: "run.kit.procedure", category: "ProcedureKit")
@@ -528,7 +528,7 @@ internal extension OSLog {
 
 internal extension Log.Writers {
 
-    @available(iOS 10.0, iOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *)
+    @available(iOS 10.0, iOSApplicationExtension 10.0, tvOS 10.0, tvOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *)
     class OSLogWriter: LogWriter {
 
         let log: OSLog

--- a/Sources/ProcedureKit/Logging.swift
+++ b/Sources/ProcedureKit/Logging.swift
@@ -108,6 +108,15 @@ public class Log {
             return "\(metadata) \(payload.description)"
         }
 
+        public var message: String? {
+            switch payload {
+            case let .message(message):
+                return message
+            default:
+                return nil
+            }
+        }
+
         public init(payload: Payload, formattedMetadata: String? = nil, severity: Log.Severity, file: String, function: String, line: Int, threadID: UInt64, timestamp: Date = Date()) {
             self.payload = payload
             self.formattedMetadata = formattedMetadata
@@ -122,7 +131,9 @@ public class Log {
         }
 
         func append(formattedMetadata newFormattedMetadata: String?) -> Log.Entry {
-            guard let newFormattedMetadata = newFormattedMetadata else { return self }
+            guard let newFormattedMetadata = newFormattedMetadata?.trimmingCharacters(in: .whitespacesAndNewlines) else { return self }
+            guard false == newFormattedMetadata.isEmpty else { return self }
+
             let new: String
             if let old = formattedMetadata, !old.isEmpty {
                 new = "\(old) \(newFormattedMetadata)"
@@ -203,7 +214,7 @@ public typealias ProcedureLog = LogChannels & LogChannel
 public extension LogChannel {
 
     func shouldWrite(severity: Log.Severity) -> Bool {
-        return enabled && Log.enabled && (severity >= Log.severity)
+        return enabled && Log.enabled && (severity >= self.severity)
     }
 
     func write(entry: Log.Entry) {
@@ -551,7 +562,7 @@ public extension LogChannel {
 
     @available(*, deprecated: 5.0.0, renamed: "info.message", message: "The .notice severity has been deprecated use .info, .event or .debug instead")
     func notice(message: @autoclosure () -> String, file: String = #file, function: String = #function, line: Int = #line) {
-//        info(file: file, function: function, line: line, message: message)
+        self.message(message(), file: file, function: function, line: line)
     }
 }
 

--- a/Sources/ProcedureKit/Logging.swift
+++ b/Sources/ProcedureKit/Logging.swift
@@ -294,7 +294,7 @@ internal class OSLogWriter: LogWriter {
     }
 
     func writeLog(with attributes: Log.Attributes, message: @escaping () -> String) {
-        os_log("%{public}s", log: log, type: attributes.severity.logType, message())
+        os_log("%{public}@", log: log, type: attributes.severity.logType, message())
     }
 }
 

--- a/Sources/ProcedureKit/Logging.swift
+++ b/Sources/ProcedureKit/Logging.swift
@@ -78,7 +78,7 @@ public class Log {
     public static let defaultWriters: [LogWriter] = {
         var writers: [LogWriter] = []
 
-        if #available(iOSApplicationExtension 10.0, OSXApplicationExtension 10.12, *) {
+        if #available(iOS 10.0, iOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *) {
             writers.append(OSLogWriter())
         } else {
             writers.append(PrintLogWriter())
@@ -263,7 +263,7 @@ internal struct LoggerContext: LoggerProtocol {
 
 // MARK: - OS Log Writer
 
-@available(iOSApplicationExtension 10.0, OSXApplicationExtension 10.12, *)
+@available(iOS 10.0, iOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *)
 internal extension Log.Severity {
 
     var logType: OSLogType {
@@ -278,13 +278,13 @@ internal extension Log.Severity {
     }
 }
 
-@available(iOSApplicationExtension 10.0, OSXApplicationExtension 10.12, *)
+@available(iOS 10.0, iOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *)
 internal extension OSLog {
 
     static let procedure = OSLog(subsystem: "run.kit.procedure", category: "ProcedureKit")
 }
 
-@available(iOSApplicationExtension 10.0, OSXApplicationExtension 10.12, *)
+@available(iOS 10.0, iOSApplicationExtension 10.0, OSX 10.12, OSXApplicationExtension 10.12, *)
 internal class OSLogWriter: LogWriter {
 
     let log: OSLog

--- a/Sources/ProcedureKit/PendingEvent.swift
+++ b/Sources/ProcedureKit/PendingEvent.swift
@@ -99,7 +99,7 @@ final public class PendingEvent: CustomStringConvertible {
     }
 
     private func debugProceed() {
-        procedure.log.verbose(message: "(\(self)) is ready to proceed")
+        (procedure as? Procedure)?.system.verbose.message("(\(self)) is ready to proceed")
     }
 
     public var description: String {

--- a/Sources/ProcedureKit/Procedure.swift
+++ b/Sources/ProcedureKit/Procedure.swift
@@ -430,6 +430,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
     final internal var system: ProcedureLog {
         get { return synchronise { protectedProperties.system } }
+        set { synchronise { protectedProperties.system = newValue } }
     }
 
     // MARK: Observers
@@ -791,7 +792,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
         guard nextState2 == .executing else { return }
 
-        system.info.message("Will Execute")
+        system.verbose.message("Will Execute")
 
         // Call the execute() function (which should be overriden in Procedure subclasses)
         if let underlyingQueue = queue?.underlyingQueue {

--- a/Sources/ProcedureKit/Procedure.swift
+++ b/Sources/ProcedureKit/Procedure.swift
@@ -792,7 +792,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
         guard nextState2 == .executing else { return }
 
-        log.info(message: "Will Execute")
+        log.verbose(message: "Will Execute")
 
         // Call the execute() function (which should be overriden in Procedure subclasses)
         if let underlyingQueue = queue?.underlyingQueue {
@@ -862,7 +862,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
         let promise = ProcedurePromise()
 
-        log.info(message: ".produce() | Will add \(operation.operationName)")
+        log.verbose(message: ".produce() | Will add \(operation.operationName)")
 
         // Dispatch the innards of produce() onto the EventQueue
         dispatchEvent {
@@ -1007,10 +1007,10 @@ open class Procedure: Operation, ProcedureProtocol {
         }
 
         if let error = resultingError {
-            log.info(message: "Will cancel with error: \(error).")
+            log.verbose(message: "Will cancel with error: \(error).")
         }
         else {
-            log.info(message: "Will cancel with no error.")
+            log.verbose(message: "Will cancel without error.")
         }
 
         didChangeValue(forKey: .cancelled)
@@ -1206,10 +1206,10 @@ open class Procedure: Operation, ProcedureProtocol {
         }
 
         if let error = resultingError {
-            log.info(message: "Will finish with error: \(error).")
+            log.verbose(message: "Will finish with error: \(error).")
         }
         else {
-            log.info(message: "Will finish with no errors.")
+            log.verbose(message: "Will finish with no errors.")
         }
 
         procedureWillFinish(with: resultingError)
@@ -1265,7 +1265,7 @@ open class Procedure: Operation, ProcedureProtocol {
                     self.log.info(message: "Did finish with error: \(error).")
                 }
                 else {
-                    self.log.info(message: "Did finish with no errors.")
+                    self.log.info(message: "Did finish without errors.")
                 }
             }
         }
@@ -1602,7 +1602,7 @@ extension Procedure {
                     self.finish()
                     return
                 case let .failure(error):
-                    procedure.log.verbose(message: "Condition(s) failed with errors: \(error).")
+                    procedure.log.verbose(message: "Condition(s) failed with error: \(error).")
                     procedure.cancel(with: error)
                     // Finish this EvaluateConditions operation immediately
                     self.finish()

--- a/Sources/ProcedureKit/Procedure.swift
+++ b/Sources/ProcedureKit/Procedure.swift
@@ -365,7 +365,8 @@ open class Procedure: Operation, ProcedureProtocol {
     private var _log: LoggerProtocol {
         get {
             let operationName = self.operationName
-            return LoggerContext(parent: protectedProperties.log, operationName: operationName)
+            return LoggerContext(parent: protectedProperties.log)
+//            return LoggerContext(parent: protectedProperties.log, operationName: operationName)
         }
     }
 
@@ -424,12 +425,11 @@ open class Procedure: Operation, ProcedureProtocol {
     final public var log: LoggerProtocol {
         get {
             let operationName = self.operationName
-            return synchronise { LoggerContext(parent: protectedProperties.log, operationName: operationName) }
+            return synchronise { LoggerContext(parent: protectedProperties.log) }
+//            return synchronise { LoggerContext(parent: protectedProperties.log, operationName: operationName) }
         }
         set {
-            synchronise {
-                protectedProperties.log = newValue
-            }
+            synchronise { protectedProperties.log = newValue }
         }
     }
 
@@ -792,7 +792,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
         guard nextState2 == .executing else { return }
 
-        log.notice(message: "Will Execute")
+        log.info(message: "Will Execute")
 
         // Call the execute() function (which should be overriden in Procedure subclasses)
         if let underlyingQueue = queue?.underlyingQueue {
@@ -836,7 +836,7 @@ open class Procedure: Operation, ProcedureProtocol {
         }
 
         // Log that execute() has returned
-        log.notice(message: "Did Execute")
+        log.info(message: "Did Execute")
     }
 
     /// Procedure subclasses must override `execute()`.
@@ -862,7 +862,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
         let promise = ProcedurePromise()
 
-        log.notice(message: ".produce() | Will add \(operation.operationName)")
+        log.info(message: ".produce() | Will add \(operation.operationName)")
 
         // Dispatch the innards of produce() onto the EventQueue
         dispatchEvent {
@@ -911,7 +911,7 @@ open class Procedure: Operation, ProcedureProtocol {
             }
         }
 
-        log.notice(message: ".produce() | Did add \(operation.operationName)")
+        log.info(message: ".produce() | Did add \(operation.operationName)")
 
         log.verbose(message: ".produce() | [observers]: DidAddOperation(\(operation.operationName))")
 
@@ -1007,10 +1007,10 @@ open class Procedure: Operation, ProcedureProtocol {
         }
 
         if let error = resultingError {
-            log.notice(message: "Will cancel with error: \(error).")
+            log.info(message: "Will cancel with error: \(error).")
         }
         else {
-            log.notice(message: "Will cancel with no error.")
+            log.info(message: "Will cancel with no error.")
         }
 
         didChangeValue(forKey: .cancelled)
@@ -1206,10 +1206,10 @@ open class Procedure: Operation, ProcedureProtocol {
         }
 
         if let error = resultingError {
-            log.notice(message: "Will finish with error: \(error).")
+            log.info(message: "Will finish with error: \(error).")
         }
         else {
-            log.notice(message: "Will finish with no errors.")
+            log.info(message: "Will finish with no errors.")
         }
 
         procedureWillFinish(with: resultingError)
@@ -1262,10 +1262,10 @@ open class Procedure: Operation, ProcedureProtocol {
                 // Once all the DidFinishObservers have completed, log a final notice
 
                 if let error = resultingError {
-                    self.log.notice(message: "Did finish with error: \(error).")
+                    self.log.info(message: "Did finish with error: \(error).")
                 }
                 else {
-                    self.log.notice(message: "Did finish with no errors.")
+                    self.log.info(message: "Did finish with no errors.")
                 }
             }
         }

--- a/Sources/ProcedureKit/Procedure.swift
+++ b/Sources/ProcedureKit/Procedure.swift
@@ -428,7 +428,7 @@ open class Procedure: Operation, ProcedureProtocol {
         set { synchronise { protectedProperties.log = newValue } }
     }
 
-    final internal var system: ProcedureLog {
+    final public var system: ProcedureLog {
         get { return synchronise { protectedProperties.system } }
         set { synchronise { protectedProperties.system = newValue } }
     }
@@ -1089,8 +1089,6 @@ open class Procedure: Operation, ProcedureProtocol {
      - parameter errors: an array of `Error`, which defaults to empty.
      */
     public func finish(with error: Error? = nil) {
-        system.verbose.trace()
-        system.verbose.message("finish() called")
         finish(with: error, from: .finish)
     }
 
@@ -1275,7 +1273,7 @@ open class Procedure: Operation, ProcedureProtocol {
                 // Once all the DidFinishObservers have completed, log a final notice
 
                 if let error = resultingError {
-                    self.system.info.message("Did finish with error: \(error).")
+                    self.system.warning.message("Did finish with error: \(error).")
                 }
                 else {
                     self.system.info.message("Did finish without errors.")

--- a/Sources/ProcedureKit/Procedure.swift
+++ b/Sources/ProcedureKit/Procedure.swift
@@ -198,6 +198,14 @@ open class Procedure: Operation, ProcedureProtocol {
         }
     }
 
+    open override var name: String? {
+        didSet {
+            synchronise {
+                protectedProperties.log.setDefaultAdaptors(withOperationName: operationName)
+            }
+        }
+    }
+
     internal let identifier = UUID()
 
     internal var typeDescription: String {
@@ -363,11 +371,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
     // the log variable to be used *within* the stateLock
     private var _log: LoggerProtocol {
-        get {
-            let operationName = self.operationName
-            return LoggerContext(parent: protectedProperties.log)
-//            return LoggerContext(parent: protectedProperties.log, operationName: operationName)
-        }
+        get { return LoggerContext(parent: protectedProperties.log) }
     }
 
     // MARK: Errors
@@ -424,9 +428,9 @@ open class Procedure: Operation, ProcedureProtocol {
      */
     final public var log: LoggerProtocol {
         get {
-            let operationName = self.operationName
-            return synchronise { LoggerContext(parent: protectedProperties.log) }
-//            return synchronise { LoggerContext(parent: protectedProperties.log, operationName: operationName) }
+            return synchronise {
+                return LoggerContext(parent: protectedProperties.log)
+            }
         }
         set {
             synchronise { protectedProperties.log = newValue }

--- a/Sources/ProcedureKit/ProcedureProcotol.swift
+++ b/Sources/ProcedureKit/ProcedureProcotol.swift
@@ -18,7 +18,7 @@ public protocol ProcedureProtocol: class {
 
     var error: Error? { get }
 
-    var log: LoggerProtocol { get }
+    var log: ProcedureLog { get }
 
     // Execution
 

--- a/Sources/ProcedureKit/ProcedureProcotol.swift
+++ b/Sources/ProcedureKit/ProcedureProcotol.swift
@@ -92,7 +92,7 @@ public extension ProcedureProtocol {
     }
 
     func procedureDidCancel(withErrors errors: [Error]) {
-            procedureDidCancel(with: errors.first)
+        procedureDidCancel(with: errors.first)
     }
 
     func finish(withErrors errors: [Error]) {

--- a/Sources/ProcedureKit/ProcedureQueue.swift
+++ b/Sources/ProcedureKit/ProcedureQueue.swift
@@ -328,7 +328,7 @@ open class ProcedureQueue: OperationQueue {
 
         // Procedure subclass
 
-        procedure.log.verbose(message: "Adding to queue")
+        procedure.system.verbose.message("Adding to queue")
 
         /// Add an observer to invoke the will finish delegate method
         procedure.addWillFinishBlockObserver { [weak self] procedure, error, pendingFinish in

--- a/Sources/ProcedureKit/Profiler.swift
+++ b/Sources/ProcedureKit/Profiler.swift
@@ -270,22 +270,23 @@ struct PrintableProfileResult: CustomStringConvertible {
     }
 }
 
-public class _ProcedureProfileLogger<Manager: LogManagerProtocol>: ProcedureProfilerReporter {
+public class _ProcedureProfileLogger<Manager: GlobalLogSettingsProtocol>: ProcedureProfilerReporter {
 
-    private(set) var logger: _Logger<Manager>
+    private(set) var logger: ProcedureKitLogger<Manager>
 
-    public init(severity: LogSeverity = Manager.severity, enabled: Bool = Manager.enabled, logger: @escaping LoggerBlockType = Manager.logger) {
+    public init(enabled: Bool = Manager.enabled, severity: Log.Severity = Manager.severity) {
 
-        self.logger = _Logger<Manager>(severity: severity, enabled: enabled, logger: logger)
+        self.logger = ProcedureKitLogger<Manager>(enabled: enabled, severity: severity)
     }
 
     public func finishedProfiling(withResult result: ProfileResult) {
-        self.logger.operationName = result.identity.description
+        // TODO: Set Operation Name properly
+//        self.logger.operationName = result.identity.description
         self.logger.info(message: "finished profiling with results:\n\(PrintableProfileResult(result: result))")
     }
 }
 
-public typealias ProcedureProfileLogger = _ProcedureProfileLogger<LogManager>
+public typealias ProcedureProfileLogger = _ProcedureProfileLogger<Log>
 
 public extension ProcedureProfiler {
 

--- a/Sources/ProcedureKit/Profiler.swift
+++ b/Sources/ProcedureKit/Profiler.swift
@@ -270,19 +270,11 @@ struct PrintableProfileResult: CustomStringConvertible {
     }
 }
 
-public class _ProcedureProfileLogger<Manager: GlobalLogSettingsProtocol>: ProcedureProfilerReporter {
-
-    private(set) var logger: ProcedureKitLogger<Manager>
-
-    public init(enabled: Bool = Manager.enabled, severity: Log.Severity = Manager.severity) {
-
-        self.logger = ProcedureKitLogger<Manager>(enabled: enabled, severity: severity)
-    }
+public class _ProcedureProfileLogger<Settings: LogSettings>: Log.Channels<Settings>, ProcedureProfilerReporter {
 
     public func finishedProfiling(withResult result: ProfileResult) {
-        // TODO: Set Operation Name properly
-//        self.logger.operationName = result.identity.description
-        self.logger.info(message: "finished profiling with results:\n\(PrintableProfileResult(result: result))")
+        formatter = Log.Formatters.makeProcedureLogFormatter(operationName: result.identity.description)
+        current.message("finished profiling with results:\n\(PrintableProfileResult(result: result))")
     }
 }
 

--- a/Sources/ProcedureKit/Reachability.swift
+++ b/Sources/ProcedureKit/Reachability.swift
@@ -51,8 +51,6 @@ public protocol NetworkReachability {
 
     var delegate: NetworkReachabilityDelegate? { get set }
 
-    var log: LoggerProtocol { get }
-
     func startNotifier(onQueue queue: DispatchQueue) throws
 
     func stopNotifier()

--- a/Sources/ProcedureKit/Repeat.swift
+++ b/Sources/ProcedureKit/Repeat.swift
@@ -229,7 +229,7 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
 
         guard shouldAddNext(), let payload = _next() else { return false }
 
-        log.notice(message: "Will add next operation.")
+        log.info(message: "Will add next operation.")
 
         _repeatStateLock.withCriticalScope {
             if let newConfigureBlock = payload.configure {

--- a/Sources/ProcedureKit/Repeat.swift
+++ b/Sources/ProcedureKit/Repeat.swift
@@ -229,7 +229,8 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
 
         guard shouldAddNext(), let payload = _next() else { return false }
 
-        log.info(message: "Will add next operation.")
+        system.verbose.trace()
+        system.info.message("Will add next operation.")
 
         _repeatStateLock.withCriticalScope {
             if let newConfigureBlock = payload.configure {
@@ -320,7 +321,8 @@ open class RepeatProcedure<T: Operation>: GroupProcedure {
     // of the _repeatStateLock.
     private func _replace(configureBlock block: @escaping Payload.ConfigureBlock) {
         _configure = block
-        log.verbose(message: "did replace configure block.")
+        system.verbose.trace()
+        system.verbose.message("did replace configure block.")
     }
 }
 

--- a/Sources/ProcedureKit/Retry.swift
+++ b/Sources/ProcedureKit/Retry.swift
@@ -32,7 +32,7 @@ public struct RetryFailureInfo<T: Procedure> {
     public let addOperations: (Operation...) -> Void
 
     /// - returns: a logger (from the RetryProcedure)
-    public let log: LoggerProtocol
+    public let log: ProcedureLog
 
     /**
      - returns: the block which is used to replace the
@@ -146,10 +146,8 @@ open class RetryProcedure<T: Procedure>: RepeatProcedure<T> {
 
         var willAttemptAnotherOperation = false
         defer {
-            log.info(message: "\(willAttemptAnotherOperation ? "will attempt" : "will not attempt") recovery from error: \(childError) in operation: \(child)")
+            system.info.message("\(willAttemptAnotherOperation ? "will attempt" : "will not attempt") recovery from error: \(childError) in operation: \(child)")
         }
-
-        print("*** - child error: \(childError)")
 
         retry.info = createFailureInfo(for: current, error: childError)
         willAttemptAnotherOperation = _addNextOperation()

--- a/Sources/ProcedureKit/Retry.swift
+++ b/Sources/ProcedureKit/Retry.swift
@@ -146,7 +146,7 @@ open class RetryProcedure<T: Procedure>: RepeatProcedure<T> {
 
         var willAttemptAnotherOperation = false
         defer {
-            log.notice(message: "\(willAttemptAnotherOperation ? "will attempt" : "will not attempt") recovery from error: \(childError) in operation: \(child)")
+            log.info(message: "\(willAttemptAnotherOperation ? "will attempt" : "will not attempt") recovery from error: \(childError) in operation: \(child)")
         }
 
         print("*** - child error: \(childError)")

--- a/Sources/ProcedureKitCloud/CloudKit.swift
+++ b/Sources/ProcedureKitCloud/CloudKit.swift
@@ -19,8 +19,8 @@ public final class CKProcedure<T: Operation>: ComposedProcedure<T> where T: CKOp
 
     init(dispatchQueue: DispatchQueue? = nil, timeout: TimeInterval? = 30, operation: T) {
         super.init(dispatchQueue: dispatchQueue, operation: operation)
-        log.enabled = false
-        system.enabled = false
+        self.log.enabled = false
+        self.system.enabled = false
         if let observer = timeout.map({ TimeoutObserver(by: $0) }) {
             addObserver(observer)
         }

--- a/Sources/ProcedureKitCloud/CloudKit.swift
+++ b/Sources/ProcedureKitCloud/CloudKit.swift
@@ -20,6 +20,7 @@ public final class CKProcedure<T: Operation>: ComposedProcedure<T> where T: CKOp
     init(dispatchQueue: DispatchQueue? = nil, timeout: TimeInterval? = 30, operation: T) {
         super.init(dispatchQueue: dispatchQueue, operation: operation)
         log.enabled = false
+        system.enabled = false
         if let observer = timeout.map({ TimeoutObserver(by: $0) }) {
             addObserver(observer)
         }

--- a/Sources/ProcedureKitCloud/CloudKit.swift
+++ b/Sources/ProcedureKitCloud/CloudKit.swift
@@ -34,7 +34,7 @@ public final class CloudKitRecovery<T: Operation> where T: CKOperationProtocol, 
     public typealias ConfigureBlock = (WrappedOperation) -> Void
     public typealias Recovery = (Delay?, ConfigureBlock)
     public typealias Payload = RepeatProcedurePayload<WrappedOperation>
-    public typealias Handler = (T, T.AssociatedError, LoggerProtocol, Recovery) -> Recovery?
+    public typealias Handler = (T, T.AssociatedError, LogChannels, Recovery) -> Recovery?
 
     var defaultHandlers: [CKError.Code: Handler] = [:]
     var customHandlers: [CKError.Code: Handler] = [:]
@@ -76,7 +76,7 @@ public final class CloudKitRecovery<T: Operation> where T: CKOperationProtocol, 
     func addDefaultHandlers() {
 
         let exit: Handler = { _, error, log, _ in
-            log.fatal(message: "Exiting due to CloudKit Error: \(error)")
+            log.fatal.message("Exiting due to CloudKit Error: \(error)")
             return nil
         }
 
@@ -92,7 +92,7 @@ public final class CloudKitRecovery<T: Operation> where T: CKOperationProtocol, 
         set(defaultHandlerForCode: .operationCancelled, handler: exit)
 
         let retry: Handler = { _, error, log, suggestion in
-            log.info(message: "Will retry after receiving error: \(error)")
+            log.info.message("Will retry after receiving error: \(error)")
             return error.retryAfterDelay.map { ($0, suggestion.1) } ?? suggestion
         }
 

--- a/Sources/ProcedureKitLocation/UserLocation.swift
+++ b/Sources/ProcedureKitLocation/UserLocation.swift
@@ -84,7 +84,7 @@ open class UserLocationProcedure: Procedure, OutputProcedure, CLLocationManagerD
             output = .ready(.success(location))
             return
         }
-        log.info(message: "Updated last location: \(location)")
+        log.info.message("Updated last location: \(location)")
         DispatchQueue.main.async { [weak self] in
             guard let strongSelf = self, !strongSelf.isFinished else { return }
             strongSelf.stopLocationUpdates()

--- a/Sources/ProcedureKitMobile/Alert.swift
+++ b/Sources/ProcedureKitMobile/Alert.swift
@@ -101,7 +101,7 @@ public class AlertProcedure: UIProcedure {
     public init(presentAlertFrom presenting: PresentingViewController, withPreferredStyle preferredAlertStyle: UIAlertControllerStyle = .alert, waitForDismissal: Bool = true) {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: preferredAlertStyle)
         super.init(present: alert, from: presenting, withStyle: .present, inNavigationController: false, sender: nil, finishAfterPresenting: !waitForDismissal)
-        add(condition: MutuallyExclusive<UIAlertController>())
+        addCondition(MutuallyExclusive<UIAlertController>())
     }
 
     /**

--- a/Sources/ProcedureKitMobile/BackgroundObserver.swift
+++ b/Sources/ProcedureKitMobile/BackgroundObserver.swift
@@ -109,12 +109,12 @@ public class BackgroundObserver: ProcedureObserver {
         }
 
         guard result.contains(.success) else {
-            procedure.log.warning(message: BackgroundObserver.logMessage_FailedToInitiateBackgroundTask)
+            procedure.log.warning.message(BackgroundObserver.logMessage_FailedToInitiateBackgroundTask)
             return
         }
 
         if result.contains(.additionalHandlersForThisProcedure) {
-            procedure.log.info(message: "More than one BackgroundObserver has been attached to this Procedure")
+            procedure.log.warning.message("More than one BackgroundObserver has been attached to this Procedure")
         }
     }
 

--- a/Sources/ProcedureKitMobile/UserConfirmation.swift
+++ b/Sources/ProcedureKitMobile/UserConfirmation.swift
@@ -29,7 +29,7 @@ public class UserConfirmationCondition: Condition {
         alert.add(actionWithTitle: cancelMessage, style: .cancel) { [weak self] _, _ in
             self?.response = .cancelled
         }
-        produce(dependency: alert)
+        produceDependency(alert)
     }
 
     public override func evaluate(procedure: Procedure, completion: @escaping (ConditionResult) -> Void) {

--- a/Sources/ProcedureKitNetwork/NetworkReachability.swift
+++ b/Sources/ProcedureKitNetwork/NetworkReachability.swift
@@ -114,8 +114,6 @@ extension Reachability {
         fileprivate private(set) var threadSafeProtector = Protector(false)
         weak var delegate: NetworkReachabilityDelegate?
 
-        var log: LoggerProtocol
-
         var notifierIsRunning: Bool {
             get { return threadSafeProtector.access }
             set {
@@ -125,9 +123,8 @@ extension Reachability {
             }
         }
 
-        init(log logger: LoggerProtocol = Logger()) {
+        init() {
             defaultRouteReachability = try! Device.makeDefaultRouteReachability() // swiftlint:disable:this force_try
-            log = logger
         }
 
         deinit {

--- a/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
+++ b/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
@@ -16,7 +16,6 @@ open class ProcedureKitTestCase: XCTestCase {
 
     open override func setUp() {
         super.setUp()
-        Log.severity = .verbose
         queue = ProcedureQueue()
         delegate = QueueTestDelegate()
         queue.delegate = delegate

--- a/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
+++ b/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
@@ -127,6 +127,7 @@ open class ProcedureKitTestCase: XCTestCase {
     func makeFinishingProcedure(for procedure: Procedure, withExpectationDescription expectationDescription: String = #function) -> Procedure {
         let finishing = BlockProcedure { }
         finishing.log.enabled = false
+        finishing.system.enabled = false
         finishing.addDependency(procedure)
         // Adds a will add operation observer, which adds the produced operation as a dependency
         // of the finishing procedure. This way, we don't actually finish, until the

--- a/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
+++ b/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
@@ -15,7 +15,7 @@ open class ProcedureKitTestCase: XCTestCase {
     open var procedure: TestProcedure!
 
     open override func setUp() {
-        super.setUp()
+        super.setUp()    
         queue = ProcedureQueue()
         delegate = QueueTestDelegate()
         queue.delegate = delegate
@@ -33,7 +33,7 @@ open class ProcedureKitTestCase: XCTestCase {
         delegate = nil
         queue = nil
         procedure = nil
-        LogManager.severity = .warning
+        Log.severity = .warning
         ExclusivityManager.__tearDownForUnitTesting()
         super.tearDown()
     }

--- a/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
+++ b/Sources/TestingProcedureKit/ProcedureKitTestCase.swift
@@ -15,7 +15,8 @@ open class ProcedureKitTestCase: XCTestCase {
     open var procedure: TestProcedure!
 
     open override func setUp() {
-        super.setUp()    
+        super.setUp()
+        Log.severity = .verbose
         queue = ProcedureQueue()
         delegate = QueueTestDelegate()
         queue.delegate = delegate

--- a/Sources/TestingProcedureKit/TestableLogging.swift
+++ b/Sources/TestingProcedureKit/TestableLogging.swift
@@ -1,0 +1,79 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2015-2018 ProcedureKit. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import ProcedureKit
+
+public class TestableLogWriter: LogWriter {
+
+    private let stateLock = PThreadMutex()
+    private var _entries: [Log.Entry] = []
+
+    public init() { }
+
+    @discardableResult
+    private func synchronise<T>(block: () -> T) -> T {
+        return stateLock.withCriticalScope(block: block)
+    }
+
+    public var entries: [Log.Entry] {
+        return synchronise { _entries }
+    }
+
+    public func write(entry: Log.Entry) {
+        synchronise { _entries.append(entry) }
+    }
+}
+
+public class TestableLogFormatter: LogFormatter {
+
+    private let stateLock = PThreadMutex()
+    private var _entries: [Log.Entry] = []
+
+    public init() { }
+
+    @discardableResult
+    private func synchronise<T>(block: () -> T) -> T {
+        return stateLock.withCriticalScope(block: block)
+    }
+
+    public var entries: [Log.Entry] {
+        return synchronise { _entries }
+    }
+
+    public func format(entry: Log.Entry) -> Log.Entry {
+        return synchronise {
+            _entries.append(entry)
+            return entry
+        }
+    }
+}
+
+public class TestableLogSettings: LogSettings {
+
+    private static var shared: LogChannel = Log.Channel<TestableLogSettings>(enabled: true, severity: .verbose, writer: TestableLogWriter(), formatter: TestableLogFormatter())
+
+    public static var enabled: Bool {
+        get { return shared.enabled }
+        set { shared.enabled = newValue }
+    }
+
+    public static var severity: Log.Severity {
+        get { return shared.severity }
+        set { shared.severity = newValue }
+    }
+
+    public static var writer: LogWriter {
+        get { return shared.writer }
+        set { shared.writer = newValue }
+    }
+
+    public static var formatter: LogFormatter {
+        get { return shared.formatter }
+        set { shared.formatter = newValue }
+    }
+}

--- a/Sources/TestingProcedureKit/TestableNetworkReachability.swift
+++ b/Sources/TestingProcedureKit/TestableNetworkReachability.swift
@@ -37,7 +37,7 @@ public class TestableNetworkReachability {
         }
     }
 
-    public var log: LoggerProtocol {
+    public var log: LogChannel {
         get { return stateLock.withCriticalScope { _log } }
         set {
             stateLock.withCriticalScope {
@@ -62,7 +62,7 @@ public class TestableNetworkReachability {
     }
     private var _didStartNotifier = false
     private var _didStopNotifier = false
-    private var _log: LoggerProtocol = Logger()
+    private var _log: LogChannel = Log.Channel<Log>()
     private weak var _delegate: NetworkReachabilityDelegate?
 
     public init() { }
@@ -71,13 +71,13 @@ public class TestableNetworkReachability {
 extension TestableNetworkReachability: NetworkReachability {
 
     public func startNotifier(onQueue queue: DispatchQueue) throws {
-        log.notice(message: "Started Reachability Notifier")
+        log.message("Started Reachability Notifier")
         didStartNotifier = true
         delegate?.didChangeReachability(flags: flags)
     }
 
     public func stopNotifier() {
-        log.notice(message: "Stopped Reachability Notifier")
+        log.message("Stopped Reachability Notifier")
         didStopNotifier = true
     }
 }

--- a/Tests/ProcedureKitCloudTests/CKAcceptSharesOperationTests.swift
+++ b/Tests/ProcedureKitCloudTests/CKAcceptSharesOperationTests.swift
@@ -198,7 +198,6 @@ class CloudKitProcedureAcceptSharesOperationTests: CKProcedureTestCase {
         }
         var didExecuteBlock = false
         cloudkit.setAcceptSharesCompletionBlock { didExecuteBlock = true }
-        cloudkit.log.severity = .verbose
         wait(for: cloudkit)
         PKAssertProcedureFinished(cloudkit)
         XCTAssertTrue(didExecuteBlock)

--- a/Tests/ProcedureKitMobileTests/BackgroundObserverTests.swift
+++ b/Tests/ProcedureKitMobileTests/BackgroundObserverTests.swift
@@ -89,7 +89,7 @@ class BackgroundObserverTests: ProcedureKitTestCase {
         }
 
         // add the background observer
-        procedure.add(observer: backgroundObserver)
+        procedure.addObserver(backgroundObserver)
 
         // wait for attaching the BackgroundObserver to attempt to begin the background task
         weak var expDidBeginTask = expectation(description: "Attaching BackgroundObserver did begin background task")

--- a/Tests/ProcedureKitMobileTests/UIProcedureTests.swift
+++ b/Tests/ProcedureKitMobileTests/UIProcedureTests.swift
@@ -105,7 +105,7 @@ class UIProcedureTests: ProcedureKitTestCase {
         let ui = UIProcedure(present: presented, from: presenting, withStyle: .present, sender: nil, waitForDismissal: true)
         let delay = DelayProcedure(by: 0.1)
         let dismiss = BlockProcedure { [unowned self] in self.presented.dismissTheViewController() }
-        dismiss.add(dependency: delay)
+        dismiss.addDependency(delay)
         wait(for: ui, delay, dismiss)
         PKAssertProcedureFinished(ui)
     }

--- a/Tests/ProcedureKitNetworkTests/NetworkProcedureTests.swift
+++ b/Tests/ProcedureKitNetworkTests/NetworkProcedureTests.swift
@@ -147,7 +147,6 @@ class NetworkProcedureTests: ProcedureKitTestCase {
         makeSessionSuccessful.addDependency(delay)
 
         let procedure = NetworkProcedure<Target>(resilience: resilience, body: createNetworkProcedure)
-        procedure.log.severity = .notice
         procedure.reachability = manager
 
         wait(forAll: [procedure, delay, makeSessionSuccessful], withTimeout: 4)
@@ -163,7 +162,6 @@ class NetworkProcedureTests: ProcedureKitTestCase {
         makeSessionSuccessful.addDependency(delay)
 
         let procedure = NetworkProcedure<Target>(resilience: resilience, body: createNetworkProcedure)
-        procedure.log.severity = .notice
         procedure.reachability = manager
 
         wait(forAll: [procedure, delay, makeSessionSuccessful], withTimeout: 4)

--- a/Tests/ProcedureKitNetworkTests/NetworkProcedureTests.swift
+++ b/Tests/ProcedureKitNetworkTests/NetworkProcedureTests.swift
@@ -49,13 +49,13 @@ class NetworkReachabilityWaitProcedureTests: ProcedureKitTestCase {
         let changeNetwork1 = BlockProcedure {
             self.network.flags = [ .reachable, .isWWAN ]
         }
-        changeNetwork1.add(dependency: delay1)
+        changeNetwork1.addDependency(delay1)
 
         let delay2 = DelayProcedure(by: 0.2)
         let changeNetwork2 = BlockProcedure {
             self.network.flags = .reachable
         }
-        changeNetwork2.add(dependency: delay2)
+        changeNetwork2.addDependency(delay2)
 
 
         wait(forAll: [delay1, changeNetwork1, delay2, changeNetwork2, procedure])

--- a/Tests/ProcedureKitTests/ConditionTests.swift
+++ b/Tests/ProcedureKitTests/ConditionTests.swift
@@ -109,7 +109,6 @@ class ConditionTests: ProcedureKitTestCase {
     }
 
     func test__single_condition_which_is_failed() {
-        procedure.log.severity = .verbose
         procedure.addCondition(FalseCondition())
         wait(for: procedure)
         PKAssertProcedureCancelledWithError(procedure, ProcedureKitError.FalseCondition())

--- a/Tests/ProcedureKitTests/LoggerTests.swift
+++ b/Tests/ProcedureKitTests/LoggerTests.swift
@@ -10,24 +10,24 @@ import TestingProcedureKit
 
 class LoggingTests: ProcedureKitTestCase {
 
-    static let defaultLogManager = LogManager.sharedInstance
+    static let defaultEnabled = Log.enabled
+    static let defaultSeverity = Log.severity
 
     override func tearDown() {
-        LogManager.enabled = LoggingTests.defaultLogManager.enabled
-        LogManager.severity = LoggingTests.defaultLogManager.severity
-        LogManager.logger = LoggingTests.defaultLogManager.logger
+        Log.enabled = LoggingTests.defaultEnabled
+        Log.severity = LoggingTests.defaultSeverity
         super.tearDown()
     }
 }
 
 class LoggerTests: LoggingTests {
 
-    var severity: LogSeverity!
+    var severity: Log.Severity!
     var log: Logger!
 
     override func setUp() {
         super.setUp()
-        severity = .notice
+        severity = .info
         log = Logger(severity: severity)
     }
 
@@ -42,14 +42,14 @@ class LoggerTests: LoggingTests {
 
     func test__init__severity_defaults_to_global_severity() {
         log = Logger()
-        XCTAssertEqual(log.severity, LogManager.severity)
+        XCTAssertEqual(log.severity, Log.severity)
     }
 
     func test__init__enabled_defaults_to_global_enabled() {
         log = Logger()
         XCTAssertTrue(log.enabled)
     }
-
+/*
     func test__operation_name_with_name_set() {
         let op = BlockOperation()
         op.name = "A Block"
@@ -73,15 +73,16 @@ class LoggerTests: LoggingTests {
         let message = log.messageWithOperationName("a message")
         XCTAssertEqual(message, "MyOperation: a message")
     }
+*/
 }
 
 class LogManagerTests: LoggingTests {
 
     func test__severity() {
-        LogManager.severity = .info
-        XCTAssertEqual(LogManager.severity, .info)
+        Log.severity = .debug
+        XCTAssertEqual(Log.severity, .debug)
     }
-
+/*
     func test__custom_logger() {
         var receivedMessage: String? = nil
         var receivedSeverity: LogSeverity? = nil
@@ -94,7 +95,10 @@ class LogManagerTests: LoggingTests {
         XCTAssertEqual(receivedMessage ?? "Uh Oh", "Hello World!")
         XCTAssertEqual(receivedSeverity ?? .verbose, .fatal)
     }
+*/
 }
+
+/*
 
 class RunAllTheLoggersTests: XCTestCase {
 
@@ -151,3 +155,4 @@ class RunAllTheLoggersTests: XCTestCase {
     }
 }
 
+*/

--- a/Tests/ProcedureKitTests/LoggerTests.swift
+++ b/Tests/ProcedureKitTests/LoggerTests.swift
@@ -8,19 +8,7 @@ import XCTest
 @testable import ProcedureKit
 import TestingProcedureKit
 
-class LoggingTests: ProcedureKitTestCase {
-
-    static let defaultEnabled = Log.enabled
-    static let defaultSeverity = Log.severity
-
-    override func tearDown() {
-        Log.enabled = LoggingTests.defaultEnabled
-        Log.severity = LoggingTests.defaultSeverity
-        super.tearDown()
-    }
-}
-
-class LoggerTests: LoggingTests {
+class LoggerTests: LoggingTestCase {
 
     var severity: Log.Severity!
     var log: Logger!
@@ -76,7 +64,7 @@ class LoggerTests: LoggingTests {
 */
 }
 
-class LogManagerTests: LoggingTests {
+class LogManagerTests: LoggingTestCase {
 
     func test__severity() {
         Log.severity = .debug

--- a/Tests/ProcedureKitTests/LoggingTests.swift
+++ b/Tests/ProcedureKitTests/LoggingTests.swift
@@ -8,25 +8,7 @@ import XCTest
 @testable import ProcedureKit
 import TestingProcedureKit
 
-class LoggingTestCase: ProcedureKitTestCase {
-
-    static let defaultEnabled = Log.enabled
-    static let defaultSeverity = Log.severity
-
-    override func setUp() {
-        super.setUp()
-        TestableLogSettings.writer = TestableLogWriter()
-        TestableLogSettings.formatter = TestableLogFormatter()
-    }
-
-    override func tearDown() {
-        Log.enabled = LoggingTestCase.defaultEnabled
-        Log.severity = LoggingTestCase.defaultSeverity
-        super.tearDown()
-    }
-}
-
-class LogEntryPayloadTests: LoggingTestCase {
+class LogEntryTests: LoggingTestCase {
 
     func test__trace_description() {
         let payload: Log.Entry.Payload = .trace
@@ -46,6 +28,20 @@ class LogEntryPayloadTests: LoggingTestCase {
     func test__value_nil_description() {
         let payload: Log.Entry.Payload = .value(nil)
         XCTAssertEqual(payload.description, "<nil-value>")
+    }
+
+    func test__appendFormattedMetadata() {
+        let appended = entry
+            .append(formattedMetadata: "Foo")
+            .append(formattedMetadata: nil)
+            .append(formattedMetadata: "")
+            .append(formattedMetadata: "   ")
+            .append(formattedMetadata: "Bar")
+        XCTAssertEqual(appended.formattedMetadata, "Foo Bar")
+        guard case let .message(text) = entry.payload else {
+            XCTFail("Entry did not have a message payload"); return
+        }
+        XCTAssertEqual(text, "Hello World")
     }
 }
 
@@ -87,4 +83,138 @@ class LogChannelTests: LoggingTestCase {
         XCTAssertEqual(channel.severity, .debug)
     }
 
+    func test__channel_shouldWrite_false_when_log_settings_disabled() {
+        Log.enabled = false
+        XCTAssertFalse(channel.shouldWrite(severity: .fatal))
+    }
+
+    func test__channel_shouldWrite_false_when_channel_disabled() {
+        channel.enabled = false
+        XCTAssertFalse(channel.shouldWrite(severity: .fatal))
+    }
+
+    func test__writer_receives_log_entry_with_trace() {
+        guard let writer = TestableLogSettings.writer as? TestableLogWriter else {
+            XCTFail("Did not have a testable log writer"); return
+        }
+        XCTAssertEqual(writer.entries.count, 0)
+        channel.trace()
+        XCTAssertEqual(writer.entries.count, 1)
+        guard let payload = writer.entries.first?.payload, case .trace = payload else {
+            XCTFail("Entry did not have a trace payload"); return
+        }
+    }
+
+    func test__writer_does_not_receive_log_entry_with_trace_when_disabled() {
+        guard let writer = TestableLogSettings.writer as? TestableLogWriter else {
+            XCTFail("Did not have a testable log writer"); return
+        }
+        channel.enabled = false
+        channel.trace()
+        XCTAssertEqual(writer.entries.count, 0)
+    }
+
+    func test__writer_receives_log_entry_with_message() {
+        guard let writer = TestableLogSettings.writer as? TestableLogWriter else {
+            XCTFail("Did not have a testable log writer"); return
+        }
+        XCTAssertEqual(writer.entries.count, 0)
+        channel.message("Hello World")
+        XCTAssertEqual(writer.entries.count, 1)
+        guard let payload = writer.entries.first?.payload, case let .message(text) = payload else {
+            XCTFail("Entry did not have a message payload"); return
+        }
+        XCTAssertEqual(text, "Hello World")
+    }
+
+    func test__writer_does_not_receive_log_entry_with_message_when_disabled() {
+        guard let writer = TestableLogSettings.writer as? TestableLogWriter else {
+            XCTFail("Did not have a testable log writer"); return
+        }
+        channel.enabled = false
+        channel.message("Hello World")
+        XCTAssertEqual(writer.entries.count, 0)
+    }
+
+
+    func test__writer_receives_log_entry_with_value() {
+        guard let writer = TestableLogSettings.writer as? TestableLogWriter else {
+            XCTFail("Did not have a testable log writer"); return
+        }
+        XCTAssertEqual(writer.entries.count, 0)
+        channel.value("Hello World")
+        XCTAssertEqual(writer.entries.count, 1)
+        guard let payload = writer.entries.first?.payload, case let .value(value) = payload, let text = value as? String else {
+            XCTFail("Entry did not have a message payload"); return
+        }
+        XCTAssertEqual(text, "Hello World")
+    }
+
+    func test__writer_does_not_receive_log_entry_with_value_when_disabled() {
+        guard let writer = TestableLogSettings.writer as? TestableLogWriter else {
+            XCTFail("Did not have a testable log writer"); return
+        }
+        channel.enabled = false
+        channel.value("Hello World")
+        XCTAssertEqual(writer.entries.count, 0)
+    }
 }
+
+class LogChannelsTests: LoggingTestCase {
+
+    var channels: Log.Channels<TestableLogSettings>!
+
+    override func setUp() {
+        super.setUp()
+        channels = Log.Channels<TestableLogSettings>()
+    }
+
+    override func tearDown() {
+        channels = nil
+        super.tearDown()
+    }
+
+    func test__setting_enabled_sets_all_channels() {
+        channels.enabled = false
+        XCTAssertFalse(channels.verbose.enabled)
+        XCTAssertFalse(channels.info.enabled)
+        XCTAssertFalse(channels.event.enabled)
+        XCTAssertFalse(channels.debug.enabled)
+        XCTAssertFalse(channels.warning.enabled)
+        XCTAssertFalse(channels.fatal.enabled)
+        channels.enabled = true
+        XCTAssertTrue(channels.verbose.enabled)
+        XCTAssertTrue(channels.info.enabled)
+        XCTAssertTrue(channels.event.enabled)
+        XCTAssertTrue(channels.debug.enabled)
+        XCTAssertTrue(channels.warning.enabled)
+        XCTAssertTrue(channels.fatal.enabled)
+    }
+
+    func test__setting_writer() {
+        let writer = TestableLogWriter()
+        channels.writer = writer
+        channels.debug.message("Hello World")
+        XCTAssertEqual(writer.entries.count, 1)
+        guard let payload = writer.entries.first?.payload, case let .message(text) = payload else {
+            XCTFail("Entry did not have a message payload"); return
+        }
+        XCTAssertEqual(text, "Hello World")
+    }
+
+    func test__getting_current_channel() {
+        channels.severity = .verbose
+        XCTAssertEqual(channels.current.severity, .verbose)
+        channels.severity = .info
+        XCTAssertEqual(channels.current.severity, .info)
+        channels.severity = .event
+        XCTAssertEqual(channels.current.severity, .event)
+        channels.severity = .debug
+        XCTAssertEqual(channels.current.severity, .debug)
+        channels.severity = .warning
+        XCTAssertEqual(channels.current.severity, .warning)
+        channels.severity = .fatal
+        XCTAssertEqual(channels.current.severity, .fatal)
+    }
+}
+

--- a/Tests/ProcedureKitTests/LoggingTests.swift
+++ b/Tests/ProcedureKitTests/LoggingTests.swift
@@ -1,0 +1,90 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2015-2018 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+@testable import ProcedureKit
+import TestingProcedureKit
+
+class LoggingTestCase: ProcedureKitTestCase {
+
+    static let defaultEnabled = Log.enabled
+    static let defaultSeverity = Log.severity
+
+    override func setUp() {
+        super.setUp()
+        TestableLogSettings.writer = TestableLogWriter()
+        TestableLogSettings.formatter = TestableLogFormatter()
+    }
+
+    override func tearDown() {
+        Log.enabled = LoggingTestCase.defaultEnabled
+        Log.severity = LoggingTestCase.defaultSeverity
+        super.tearDown()
+    }
+}
+
+class LogEntryPayloadTests: LoggingTestCase {
+
+    func test__trace_description() {
+        let payload: Log.Entry.Payload = .trace
+        XCTAssertEqual(payload.description, "")
+    }
+
+    func test__message_description() {
+        let payload: Log.Entry.Payload = .message("Hello World")
+        XCTAssertEqual(payload.description, "Hello World")
+    }
+
+    func test__value_description() {
+        let payload: Log.Entry.Payload = .value("Hello World")
+        XCTAssertEqual(payload.description, "Hello World")
+    }
+
+    func test__value_nil_description() {
+        let payload: Log.Entry.Payload = .value(nil)
+        XCTAssertEqual(payload.description, "<nil-value>")
+    }
+}
+
+class LogChannelTests: LoggingTestCase {
+
+    var channel: Log.Channel<TestableLogSettings>!
+
+    override func setUp() {
+        super.setUp()
+        channel = Log.Channel<TestableLogSettings>()
+    }
+
+    override func tearDown() {
+        channel = nil
+        super.tearDown()
+    }
+
+    func test__channel_enabled_initialized_from_settings() {
+        channel = Log.Channel<TestableLogSettings>()
+        XCTAssertEqual(channel.enabled, TestableLogSettings.enabled)
+        XCTAssertTrue(channel.enabled)
+    }
+
+    func test__channel_enabled_initialized_from_init() {
+        channel = Log.Channel<TestableLogSettings>(enabled: false)
+        XCTAssertNotEqual(channel.enabled, TestableLogSettings.enabled)
+        XCTAssertFalse(channel.enabled)
+    }
+
+    func test__channel_severity_initialized_from_settings() {
+        channel = Log.Channel<TestableLogSettings>()
+        XCTAssertEqual(channel.severity, TestableLogSettings.severity)
+        XCTAssertEqual(channel.severity, .verbose)
+    }
+
+    func test__channel_severity_initialized_from_init() {
+        channel = Log.Channel<TestableLogSettings>(severity: .debug)
+        XCTAssertNotEqual(channel.severity, TestableLogSettings.severity)
+        XCTAssertEqual(channel.severity, .debug)
+    }
+
+}

--- a/Tests/ProcedureKitTests/ProcedureTests.swift
+++ b/Tests/ProcedureKitTests/ProcedureTests.swift
@@ -560,7 +560,6 @@ class ProduceTests: ProcedureKitTestCase {
     }
 
     func test__procedure_produce_operation_before_finish() {
-        LogManager.severity = .verbose
         let producedOperation = BlockProcedure { usleep(5000) }
         producedOperation.name = "ProducedOperation"
         let procedure = EventConcurrencyTrackingProcedure() { procedure in

--- a/Tests/ProcedureKitTests/ProcedureTests.swift
+++ b/Tests/ProcedureKitTests/ProcedureTests.swift
@@ -389,6 +389,8 @@ class ProcedureTests: ProcedureKitTestCase {
 
         let group = GroupProcedure(operations: [])
         XCTAssertEqual(group.name, "GroupProcedure")
+
+        wait(for: group)
     }
 
     func test__identity_is_equatable() {

--- a/Tests/ProcedureKitTests/ResultInjectionTests.swift
+++ b/Tests/ProcedureKitTests/ResultInjectionTests.swift
@@ -17,7 +17,7 @@ class DataProcessing: Procedure, InputProcedure, OutputProcedure {
             finish(with: ProcedureKitError.requirementNotSatisfied())
             return
         }
-        log.info(message: output)
+        log.info.message(output)
         finish()
     }
 }
@@ -28,7 +28,7 @@ class Printing: Procedure, InputProcedure, OutputProcedure {
 
     override func execute() {
         if let message = input.value {
-            log.info(message: message)
+            log.info.message(message)
         }
         finish()
     }


### PR DESCRIPTION
- [x] Refactor the log severity to better support different logging.
    We need "system" logging for _ProcedureKit_ itself. However, we also want to allow "user" logging for framework consumers.
- [ ] Use `os_log` where available, support allowance for the user to over-ride the "user" subsystem & category of the user's log.