### PR TITLE
Move TryProcedureKit integration tests into main repo

### DIFF
--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -40,24 +40,16 @@ steps:
   agents:
     queue: "iOS-Simulator"
     xcode: "$XCODE"
-YAML
-
-if [[ "$BUILDKITE_BUILD_CREATOR" == "Daniel Thorpe" ]]; then
-cat <<-YAML
-
+    
 - wait
 
 - 
   name: "Test CocoaPods Integration"
-  trigger: "tryprocedurekit"
-  build:
-    message: "Testing ProcedureKit Integration via Cocoapods"
-    commit: "HEAD"
-    branch: "cocoapods"
-    env:
-      PROCEDUREKIT_HASH: "$COMMIT"
+  command: ".ci/scripts/test-cocoapods"  
+  agents:
+    queue: "iOS-Simulator"
+    xcode: "$XCODE"
 YAML
-fi
 
 cat <<-YAML
 

--- a/.ci/scripts/test-cocoapods
+++ b/.ci/scripts/test-cocoapods
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set +u
+source /usr/local/opt/chruby/share/chruby/chruby.sh
+chruby ruby
+set -u
+
+echo "cd Integrations/CocoaPods"
+cd "Integrations/CocoaPods"
+
+echo "bundle install --quiet"
+bundle install --quiet
+
+echo "--- CocoaPods"
+bundle exec pod install
+
+echo "--- Mac Build & Test"
+
+echo "bundle exec xcodebuild -workspace TryProcedureKit.xcworkspace -scheme TryProcedureKit clean build test | xcpretty"
+bundle exec xcodebuild -workspace TryProcedureKit.xcworkspace -scheme TryProcedureKit clean build test | xcpretty

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,8 @@ DerivedData
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
 #
-# Pods/
-# Examples/*/Pods
+Pods/
+**/**/Pods
 
 # Carthage
 #

--- a/Integrations/CocoaPods/Podfile
+++ b/Integrations/CocoaPods/Podfile
@@ -1,0 +1,25 @@
+target 'TryProcedureKit' do
+  platform :osx, '10.11'
+
+  use_frameworks!
+
+  pod 'ProcedureKit/All', :path => '../..'
+
+  target 'TryProcedureKitTests' do
+    inherit! :search_paths
+    pod 'TestingProcedureKit', :path => '../..'
+  end
+end
+
+target 'TryProcedureKit iOS' do
+  platform :ios, '10.0'
+  use_frameworks!
+
+  pod 'ProcedureKit/All', :path => '../..'
+  pod 'ProcedureKit/Mobile', :path => '../..'  
+
+  target 'TryProcedureKit iOSTests' do
+    inherit! :search_paths
+    pod 'TestingProcedureKit', :path => '../..'
+  end
+end

--- a/Integrations/CocoaPods/Podfile.lock
+++ b/Integrations/CocoaPods/Podfile.lock
@@ -1,0 +1,42 @@
+PODS:
+  - ProcedureKit (5.0.0.beta.1):
+    - ProcedureKit/Standard (= 5.0.0.beta.1)
+  - ProcedureKit/All (5.0.0.beta.1):
+    - ProcedureKit/Cloud
+    - ProcedureKit/CoreData
+    - ProcedureKit/Location
+    - ProcedureKit/Network
+  - ProcedureKit/Cloud (5.0.0.beta.1):
+    - ProcedureKit/Standard
+  - ProcedureKit/CoreData (5.0.0.beta.1):
+    - ProcedureKit/Standard
+  - ProcedureKit/Location (5.0.0.beta.1):
+    - ProcedureKit/Standard
+  - ProcedureKit/Mobile (5.0.0.beta.1):
+    - ProcedureKit/Standard
+  - ProcedureKit/Network (5.0.0.beta.1):
+    - ProcedureKit/Standard
+  - ProcedureKit/Standard (5.0.0.beta.1)
+  - TestingProcedureKit (5.0.0.beta.1):
+    - TestingProcedureKit/Testing (= 5.0.0.beta.1)
+  - TestingProcedureKit/Testing (5.0.0.beta.1):
+    - ProcedureKit
+
+DEPENDENCIES:
+  - ProcedureKit/All (from `../..`)
+  - ProcedureKit/Mobile (from `../..`)
+  - TestingProcedureKit (from `../..`)
+
+EXTERNAL SOURCES:
+  ProcedureKit:
+    :path: "../.."
+  TestingProcedureKit:
+    :path: "../.."
+
+SPEC CHECKSUMS:
+  ProcedureKit: 5a3655c01ab01af55f1b95a0ae37e2ea8bce112c
+  TestingProcedureKit: 63fb516c0c025e53462961e41593e979a8f13334
+
+PODFILE CHECKSUM: 26b080556a214485b05abef66f81f7be297d9efb
+
+COCOAPODS: 1.5.3

--- a/Integrations/CocoaPods/TryProcedureKit iOS/AppDelegate.swift
+++ b/Integrations/CocoaPods/TryProcedureKit iOS/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  TryProcedureKit iOS
+//
+//  Created by Daniel Thorpe on 05/12/2016.
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/Integrations/CocoaPods/TryProcedureKit iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Integrations/CocoaPods/TryProcedureKit iOS/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Integrations/CocoaPods/TryProcedureKit iOS/Base.lproj/LaunchScreen.storyboard
+++ b/Integrations/CocoaPods/TryProcedureKit iOS/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Integrations/CocoaPods/TryProcedureKit iOS/Base.lproj/Main.storyboard
+++ b/Integrations/CocoaPods/TryProcedureKit iOS/Base.lproj/Main.storyboard
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Dli-x0-utA">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="TryProcedureKit_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="n6s-6t-1Wl">
+                                <rect key="frame" x="172" y="318" width="30" height="30"/>
+                                <state key="normal" title="Go"/>
+                                <connections>
+                                    <action selector="go:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Cqm-k5-PH9"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aoN-oX-7KT">
+                                <rect key="frame" x="171" y="356" width="33" height="30"/>
+                                <state key="normal" title="Alert"/>
+                                <connections>
+                                    <action selector="alert:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Kdr-70-mat"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="n6s-6t-1Wl" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="5WW-5m-Pc8"/>
+                            <constraint firstItem="aoN-oX-7KT" firstAttribute="top" secondItem="n6s-6t-1Wl" secondAttribute="bottom" constant="8" id="HLu-bt-voI"/>
+                            <constraint firstItem="aoN-oX-7KT" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="KqS-Kl-89p"/>
+                            <constraint firstItem="n6s-6t-1Wl" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Sc7-0H-msG"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="3j6-6V-5PI"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="462" y="-635"/>
+        </scene>
+        <!--Another View Controller-->
+        <scene sceneID="7Rn-XB-hwV">
+            <objects>
+                <viewController storyboardIdentifier="another" id="Nja-sH-6E4" customClass="AnotherViewController" customModule="TryProcedureKit_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="IZf-ac-ZFY"/>
+                        <viewControllerLayoutGuide type="bottom" id="Bzf-uN-Wbc"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="HgZ-QP-NdB">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="81z-6Y-cyM">
+                                <rect key="frame" x="143" y="323" width="89" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="81z-6Y-cyM" firstAttribute="centerY" secondItem="HgZ-QP-NdB" secondAttribute="centerY" id="Fca-Ps-tqD"/>
+                            <constraint firstItem="81z-6Y-cyM" firstAttribute="centerX" secondItem="HgZ-QP-NdB" secondAttribute="centerX" id="xeF-dG-hwN"/>
+                        </constraints>
+                    </view>
+                    <toolbarItems/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <connections>
+                        <outlet property="label" destination="81z-6Y-cyM" id="fj3-3c-OFx"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Uag-wx-EDq" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1290" y="-636"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="LJj-1g-Pb2">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Dli-x0-utA" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="aBu-ae-Puj">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="8xl-i2-Y4h"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="mR1-Ln-btD" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-335" y="-634"/>
+        </scene>
+    </scenes>
+</document>

--- a/Integrations/CocoaPods/TryProcedureKit iOS/Info.plist
+++ b/Integrations/CocoaPods/TryProcedureKit iOS/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Integrations/CocoaPods/TryProcedureKit iOS/ViewController.swift
+++ b/Integrations/CocoaPods/TryProcedureKit iOS/ViewController.swift
@@ -1,0 +1,69 @@
+//
+//  ViewController.swift
+//  TryProcedureKit iOS
+//
+//  Created by Daniel Thorpe on 05/12/2016.
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import UIKit
+import ProcedureKit
+
+class AnotherViewController: UIViewController, DismissingViewController {
+
+    @IBOutlet weak var label: UILabel!
+    var didDismissViewControllerBlock: () -> Void = { }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel(_:)))
+    }
+
+    @IBAction func cancel(_ sender: UIButton) {
+        dismiss(animated: true, completion: didDismissViewControllerBlock)
+    }
+}
+
+class ViewController: UIViewController {
+
+    lazy var queue = ProcedureQueue()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        queue.addOperation(AsyncBlockProcedure { finishWithResult in
+            DispatchQueue.default.async {
+                print("Hello ProcedureKit")
+                finishWithResult(success)
+            }
+        })
+    }
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        print("\(type(of: self)) \(#function)")
+        super.dismiss(animated: flag, completion: completion)
+    }
+
+    @IBAction func go(_ sender: UIButton) {
+        guard
+            let storyboard = storyboard,
+            let another = storyboard.instantiateViewController(withIdentifier: "another") as? AnotherViewController
+        else { return }
+        let presentation = UIProcedure(present: another, from: self, withStyle: .present, waitForDismissal: true)
+        presentation.log.severity = .info
+        queue.addOperation(presentation)
+    }
+
+    @IBAction func alert(_ sender: UIButton) {
+        let alert = AlertProcedure(presentAlertFrom: self)
+        alert.add(actionWithTitle: "Sweet") { alert, action in
+            alert.log.info.message("Running the handler!")
+        }
+        alert.log.severity = .info
+        alert.title = "Hello World"
+        alert.message = "This is a message in an alert"
+        queue.addOperation(alert)
+    }
+}
+

--- a/Integrations/CocoaPods/TryProcedureKit iOSTests/Info.plist
+++ b/Integrations/CocoaPods/TryProcedureKit iOSTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Integrations/CocoaPods/TryProcedureKit iOSTests/TryProcedureKit_iOSTests.swift
+++ b/Integrations/CocoaPods/TryProcedureKit iOSTests/TryProcedureKit_iOSTests.swift
@@ -1,0 +1,36 @@
+//
+//  TryProcedureKit_iOSTests.swift
+//  TryProcedureKit iOSTests
+//
+//  Created by Daniel Thorpe on 05/12/2016.
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+@testable import TryProcedureKit_iOS
+
+class TryProcedureKit_iOSTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/Integrations/CocoaPods/TryProcedureKit.xcodeproj/project.pbxproj
+++ b/Integrations/CocoaPods/TryProcedureKit.xcodeproj/project.pbxproj
@@ -1,0 +1,923 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2C5D53E08E5AE0F233961E68 /* Pods_TryProcedureKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A01E9CD09C0388F209F3BFEB /* Pods_TryProcedureKitTests.framework */; };
+		3833776426F4F231C0D71DF9 /* Pods_TryProcedureKit_iOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C945E52D1FE103F80AC10B19 /* Pods_TryProcedureKit_iOSTests.framework */; };
+		65987D621DEDCB6D00868688 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65987D611DEDCB6D00868688 /* AppDelegate.swift */; };
+		65987D641DEDCB6D00868688 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65987D631DEDCB6D00868688 /* ViewController.swift */; };
+		65987D661DEDCB6D00868688 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 65987D651DEDCB6D00868688 /* Assets.xcassets */; };
+		65987D691DEDCB6D00868688 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 65987D671DEDCB6D00868688 /* Main.storyboard */; };
+		65987D741DEDCB6D00868688 /* TryProcedureKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65987D731DEDCB6D00868688 /* TryProcedureKitTests.swift */; };
+		65C540221DF5DA1500DCB059 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C540211DF5DA1500DCB059 /* AppDelegate.swift */; };
+		65C540241DF5DA1500DCB059 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C540231DF5DA1500DCB059 /* ViewController.swift */; };
+		65C540271DF5DA1500DCB059 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 65C540251DF5DA1500DCB059 /* Main.storyboard */; };
+		65C540291DF5DA1500DCB059 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 65C540281DF5DA1500DCB059 /* Assets.xcassets */; };
+		65C5402C1DF5DA1500DCB059 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 65C5402A1DF5DA1500DCB059 /* LaunchScreen.storyboard */; };
+		65C540371DF5DA1500DCB059 /* TryProcedureKit_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C540361DF5DA1500DCB059 /* TryProcedureKit_iOSTests.swift */; };
+		D9172DF90FED58818048C5EA /* Pods_TryProcedureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D3711ECF3ED2EEF87B754C60 /* Pods_TryProcedureKit.framework */; };
+		DE732B581EF976A594D792D5 /* Pods_TryProcedureKit_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E651D3358ADB59E3AC6FE61 /* Pods_TryProcedureKit_iOS.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		65987D701DEDCB6D00868688 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65987D561DEDCB6D00868688 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65987D5D1DEDCB6D00868688;
+			remoteInfo = TryProcedureKit;
+		};
+		65C540331DF5DA1500DCB059 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 65987D561DEDCB6D00868688 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65C5401E1DF5DA1500DCB059;
+			remoteInfo = "TryProcedureKit iOS";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		20BA1F62FDB673FAF14C8FD0 /* Pods-TryProcedureKit iOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TryProcedureKit iOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TryProcedureKit iOSTests/Pods-TryProcedureKit iOSTests.debug.xcconfig"; sourceTree = "<group>"; };
+		22D696D4AB45191E7B56C3F8 /* Pods-TryProcedureKit iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TryProcedureKit iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TryProcedureKit iOS/Pods-TryProcedureKit iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		3E651D3358ADB59E3AC6FE61 /* Pods_TryProcedureKit_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TryProcedureKit_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C75AB65DA9F459E58F44D20 /* Pods-TryProcedureKitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TryProcedureKitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TryProcedureKitTests/Pods-TryProcedureKitTests.release.xcconfig"; sourceTree = "<group>"; };
+		566864A4B9D3236BD0492C34 /* Pods-TryProcedureKit iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TryProcedureKit iOSTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-TryProcedureKit iOSTests/Pods-TryProcedureKit iOSTests.release.xcconfig"; sourceTree = "<group>"; };
+		64E1871A3A35473F2C6303A9 /* Pods-TryProcedureKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TryProcedureKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TryProcedureKitTests/Pods-TryProcedureKitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		65987D5E1DEDCB6D00868688 /* TryProcedureKit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TryProcedureKit.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		65987D611DEDCB6D00868688 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		65987D631DEDCB6D00868688 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		65987D651DEDCB6D00868688 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		65987D681DEDCB6D00868688 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		65987D6A1DEDCB6D00868688 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		65987D6F1DEDCB6D00868688 /* TryProcedureKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TryProcedureKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		65987D731DEDCB6D00868688 /* TryProcedureKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryProcedureKitTests.swift; sourceTree = "<group>"; };
+		65987D751DEDCB6D00868688 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		65C5401F1DF5DA1500DCB059 /* TryProcedureKit iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TryProcedureKit iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		65C540211DF5DA1500DCB059 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		65C540231DF5DA1500DCB059 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		65C540261DF5DA1500DCB059 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		65C540281DF5DA1500DCB059 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		65C5402B1DF5DA1500DCB059 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		65C5402D1DF5DA1500DCB059 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		65C540321DF5DA1500DCB059 /* TryProcedureKit iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TryProcedureKit iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		65C540361DF5DA1500DCB059 /* TryProcedureKit_iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryProcedureKit_iOSTests.swift; sourceTree = "<group>"; };
+		65C540381DF5DA1500DCB059 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A01E9CD09C0388F209F3BFEB /* Pods_TryProcedureKitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TryProcedureKitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A80C8A224A4D10648271BF7F /* Pods-TryProcedureKit iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TryProcedureKit iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-TryProcedureKit iOS/Pods-TryProcedureKit iOS.release.xcconfig"; sourceTree = "<group>"; };
+		C43DCAAEFE574A655166C29E /* Pods-TryProcedureKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TryProcedureKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-TryProcedureKit/Pods-TryProcedureKit.release.xcconfig"; sourceTree = "<group>"; };
+		C945E52D1FE103F80AC10B19 /* Pods_TryProcedureKit_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TryProcedureKit_iOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D3711ECF3ED2EEF87B754C60 /* Pods_TryProcedureKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TryProcedureKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DDEBF5EF4F1774FBA52EE748 /* Pods-TryProcedureKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TryProcedureKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TryProcedureKit/Pods-TryProcedureKit.debug.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		65987D5B1DEDCB6D00868688 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D9172DF90FED58818048C5EA /* Pods_TryProcedureKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65987D6C1DEDCB6D00868688 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2C5D53E08E5AE0F233961E68 /* Pods_TryProcedureKitTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65C5401C1DF5DA1500DCB059 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE732B581EF976A594D792D5 /* Pods_TryProcedureKit_iOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65C5402F1DF5DA1500DCB059 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3833776426F4F231C0D71DF9 /* Pods_TryProcedureKit_iOSTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		16161B80B77EFE30228DDFDF /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				DDEBF5EF4F1774FBA52EE748 /* Pods-TryProcedureKit.debug.xcconfig */,
+				C43DCAAEFE574A655166C29E /* Pods-TryProcedureKit.release.xcconfig */,
+				64E1871A3A35473F2C6303A9 /* Pods-TryProcedureKitTests.debug.xcconfig */,
+				4C75AB65DA9F459E58F44D20 /* Pods-TryProcedureKitTests.release.xcconfig */,
+				22D696D4AB45191E7B56C3F8 /* Pods-TryProcedureKit iOS.debug.xcconfig */,
+				A80C8A224A4D10648271BF7F /* Pods-TryProcedureKit iOS.release.xcconfig */,
+				20BA1F62FDB673FAF14C8FD0 /* Pods-TryProcedureKit iOSTests.debug.xcconfig */,
+				566864A4B9D3236BD0492C34 /* Pods-TryProcedureKit iOSTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		65987D551DEDCB6D00868688 = {
+			isa = PBXGroup;
+			children = (
+				65987D601DEDCB6D00868688 /* TryProcedureKit */,
+				65987D721DEDCB6D00868688 /* TryProcedureKitTests */,
+				65C540201DF5DA1500DCB059 /* TryProcedureKit iOS */,
+				65C540351DF5DA1500DCB059 /* TryProcedureKit iOSTests */,
+				65987D5F1DEDCB6D00868688 /* Products */,
+				16161B80B77EFE30228DDFDF /* Pods */,
+				6A4EA074A084AFA91D21B74C /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		65987D5F1DEDCB6D00868688 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				65987D5E1DEDCB6D00868688 /* TryProcedureKit.app */,
+				65987D6F1DEDCB6D00868688 /* TryProcedureKitTests.xctest */,
+				65C5401F1DF5DA1500DCB059 /* TryProcedureKit iOS.app */,
+				65C540321DF5DA1500DCB059 /* TryProcedureKit iOSTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		65987D601DEDCB6D00868688 /* TryProcedureKit */ = {
+			isa = PBXGroup;
+			children = (
+				65987D611DEDCB6D00868688 /* AppDelegate.swift */,
+				65987D631DEDCB6D00868688 /* ViewController.swift */,
+				65987D651DEDCB6D00868688 /* Assets.xcassets */,
+				65987D671DEDCB6D00868688 /* Main.storyboard */,
+				65987D6A1DEDCB6D00868688 /* Info.plist */,
+			);
+			path = TryProcedureKit;
+			sourceTree = "<group>";
+		};
+		65987D721DEDCB6D00868688 /* TryProcedureKitTests */ = {
+			isa = PBXGroup;
+			children = (
+				65987D731DEDCB6D00868688 /* TryProcedureKitTests.swift */,
+				65987D751DEDCB6D00868688 /* Info.plist */,
+			);
+			path = TryProcedureKitTests;
+			sourceTree = "<group>";
+		};
+		65C540201DF5DA1500DCB059 /* TryProcedureKit iOS */ = {
+			isa = PBXGroup;
+			children = (
+				65C540211DF5DA1500DCB059 /* AppDelegate.swift */,
+				65C540231DF5DA1500DCB059 /* ViewController.swift */,
+				65C540251DF5DA1500DCB059 /* Main.storyboard */,
+				65C540281DF5DA1500DCB059 /* Assets.xcassets */,
+				65C5402A1DF5DA1500DCB059 /* LaunchScreen.storyboard */,
+				65C5402D1DF5DA1500DCB059 /* Info.plist */,
+			);
+			path = "TryProcedureKit iOS";
+			sourceTree = "<group>";
+		};
+		65C540351DF5DA1500DCB059 /* TryProcedureKit iOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				65C540361DF5DA1500DCB059 /* TryProcedureKit_iOSTests.swift */,
+				65C540381DF5DA1500DCB059 /* Info.plist */,
+			);
+			path = "TryProcedureKit iOSTests";
+			sourceTree = "<group>";
+		};
+		6A4EA074A084AFA91D21B74C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D3711ECF3ED2EEF87B754C60 /* Pods_TryProcedureKit.framework */,
+				A01E9CD09C0388F209F3BFEB /* Pods_TryProcedureKitTests.framework */,
+				3E651D3358ADB59E3AC6FE61 /* Pods_TryProcedureKit_iOS.framework */,
+				C945E52D1FE103F80AC10B19 /* Pods_TryProcedureKit_iOSTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		65987D5D1DEDCB6D00868688 /* TryProcedureKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 65987D781DEDCB6D00868688 /* Build configuration list for PBXNativeTarget "TryProcedureKit" */;
+			buildPhases = (
+				CF2FFCBD41DC61EB25CA1F1A /* [CP] Check Pods Manifest.lock */,
+				65987D5A1DEDCB6D00868688 /* Sources */,
+				65987D5B1DEDCB6D00868688 /* Frameworks */,
+				65987D5C1DEDCB6D00868688 /* Resources */,
+				8E92736663D40AC48E98128E /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TryProcedureKit;
+			productName = TryProcedureKit;
+			productReference = 65987D5E1DEDCB6D00868688 /* TryProcedureKit.app */;
+			productType = "com.apple.product-type.application";
+		};
+		65987D6E1DEDCB6D00868688 /* TryProcedureKitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 65987D7B1DEDCB6D00868688 /* Build configuration list for PBXNativeTarget "TryProcedureKitTests" */;
+			buildPhases = (
+				BF084573A9B0660F4C1D1C29 /* [CP] Check Pods Manifest.lock */,
+				65987D6B1DEDCB6D00868688 /* Sources */,
+				65987D6C1DEDCB6D00868688 /* Frameworks */,
+				65987D6D1DEDCB6D00868688 /* Resources */,
+				999CE9F151E217BE25FA8F09 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				65987D711DEDCB6D00868688 /* PBXTargetDependency */,
+			);
+			name = TryProcedureKitTests;
+			productName = TryProcedureKitTests;
+			productReference = 65987D6F1DEDCB6D00868688 /* TryProcedureKitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		65C5401E1DF5DA1500DCB059 /* TryProcedureKit iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 65C5403D1DF5DA1500DCB059 /* Build configuration list for PBXNativeTarget "TryProcedureKit iOS" */;
+			buildPhases = (
+				BDE0E33DCEDDA35E8C213627 /* [CP] Check Pods Manifest.lock */,
+				65C5401B1DF5DA1500DCB059 /* Sources */,
+				65C5401C1DF5DA1500DCB059 /* Frameworks */,
+				65C5401D1DF5DA1500DCB059 /* Resources */,
+				91C29AF8EE5CC40A4A280F7A /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "TryProcedureKit iOS";
+			productName = "TryProcedureKit iOS";
+			productReference = 65C5401F1DF5DA1500DCB059 /* TryProcedureKit iOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		65C540311DF5DA1500DCB059 /* TryProcedureKit iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 65C5403E1DF5DA1500DCB059 /* Build configuration list for PBXNativeTarget "TryProcedureKit iOSTests" */;
+			buildPhases = (
+				072369E216DED42A9E1B98F5 /* [CP] Check Pods Manifest.lock */,
+				65C5402E1DF5DA1500DCB059 /* Sources */,
+				65C5402F1DF5DA1500DCB059 /* Frameworks */,
+				65C540301DF5DA1500DCB059 /* Resources */,
+				1C7F0F2104C8D40CC298466C /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				65C540341DF5DA1500DCB059 /* PBXTargetDependency */,
+			);
+			name = "TryProcedureKit iOSTests";
+			productName = "TryProcedureKit iOSTests";
+			productReference = 65C540321DF5DA1500DCB059 /* TryProcedureKit iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		65987D561DEDCB6D00868688 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0810;
+				LastUpgradeCheck = 0940;
+				ORGANIZATIONNAME = ProcedureKit;
+				TargetAttributes = {
+					65987D5D1DEDCB6D00868688 = {
+						CreatedOnToolsVersion = 8.1;
+						LastSwiftMigration = 0940;
+						ProvisioningStyle = Manual;
+					};
+					65987D6E1DEDCB6D00868688 = {
+						CreatedOnToolsVersion = 8.1;
+						LastSwiftMigration = 0940;
+						ProvisioningStyle = Manual;
+						TestTargetID = 65987D5D1DEDCB6D00868688;
+					};
+					65C5401E1DF5DA1500DCB059 = {
+						CreatedOnToolsVersion = 8.1;
+						LastSwiftMigration = 0940;
+						ProvisioningStyle = Manual;
+					};
+					65C540311DF5DA1500DCB059 = {
+						CreatedOnToolsVersion = 8.1;
+						LastSwiftMigration = 0940;
+						ProvisioningStyle = Manual;
+						TestTargetID = 65C5401E1DF5DA1500DCB059;
+					};
+				};
+			};
+			buildConfigurationList = 65987D591DEDCB6D00868688 /* Build configuration list for PBXProject "TryProcedureKit" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 65987D551DEDCB6D00868688;
+			productRefGroup = 65987D5F1DEDCB6D00868688 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				65987D5D1DEDCB6D00868688 /* TryProcedureKit */,
+				65987D6E1DEDCB6D00868688 /* TryProcedureKitTests */,
+				65C5401E1DF5DA1500DCB059 /* TryProcedureKit iOS */,
+				65C540311DF5DA1500DCB059 /* TryProcedureKit iOSTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		65987D5C1DEDCB6D00868688 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65987D661DEDCB6D00868688 /* Assets.xcassets in Resources */,
+				65987D691DEDCB6D00868688 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65987D6D1DEDCB6D00868688 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65C5401D1DF5DA1500DCB059 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65C5402C1DF5DA1500DCB059 /* LaunchScreen.storyboard in Resources */,
+				65C540291DF5DA1500DCB059 /* Assets.xcassets in Resources */,
+				65C540271DF5DA1500DCB059 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65C540301DF5DA1500DCB059 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		072369E216DED42A9E1B98F5 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TryProcedureKit iOSTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		1C7F0F2104C8D40CC298466C /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-TryProcedureKit iOSTests/Pods-TryProcedureKit iOSTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/ProcedureKit-iOS/ProcedureKit.framework",
+				"${BUILT_PRODUCTS_DIR}/TestingProcedureKit-iOS/TestingProcedureKit.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ProcedureKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TestingProcedureKit.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TryProcedureKit iOSTests/Pods-TryProcedureKit iOSTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8E92736663D40AC48E98128E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-TryProcedureKit/Pods-TryProcedureKit-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/ProcedureKit-All-Cloud-CoreData-Location-Network-Standard/ProcedureKit.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ProcedureKit.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TryProcedureKit/Pods-TryProcedureKit-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		91C29AF8EE5CC40A4A280F7A /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-TryProcedureKit iOS/Pods-TryProcedureKit iOS-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/ProcedureKit-ae76e0ea/ProcedureKit.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ProcedureKit.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TryProcedureKit iOS/Pods-TryProcedureKit iOS-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		999CE9F151E217BE25FA8F09 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-TryProcedureKitTests/Pods-TryProcedureKitTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/ProcedureKit-macOS/ProcedureKit.framework",
+				"${BUILT_PRODUCTS_DIR}/TestingProcedureKit-macOS/TestingProcedureKit.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ProcedureKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TestingProcedureKit.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TryProcedureKitTests/Pods-TryProcedureKitTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BDE0E33DCEDDA35E8C213627 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TryProcedureKit iOS-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		BF084573A9B0660F4C1D1C29 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TryProcedureKitTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CF2FFCBD41DC61EB25CA1F1A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TryProcedureKit-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		65987D5A1DEDCB6D00868688 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65987D641DEDCB6D00868688 /* ViewController.swift in Sources */,
+				65987D621DEDCB6D00868688 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65987D6B1DEDCB6D00868688 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65987D741DEDCB6D00868688 /* TryProcedureKitTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65C5401B1DF5DA1500DCB059 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65C540241DF5DA1500DCB059 /* ViewController.swift in Sources */,
+				65C540221DF5DA1500DCB059 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65C5402E1DF5DA1500DCB059 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				65C540371DF5DA1500DCB059 /* TryProcedureKit_iOSTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		65987D711DEDCB6D00868688 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65987D5D1DEDCB6D00868688 /* TryProcedureKit */;
+			targetProxy = 65987D701DEDCB6D00868688 /* PBXContainerItemProxy */;
+		};
+		65C540341DF5DA1500DCB059 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65C5401E1DF5DA1500DCB059 /* TryProcedureKit iOS */;
+			targetProxy = 65C540331DF5DA1500DCB059 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		65987D671DEDCB6D00868688 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				65987D681DEDCB6D00868688 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		65C540251DF5DA1500DCB059 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				65C540261DF5DA1500DCB059 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		65C5402A1DF5DA1500DCB059 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				65C5402B1DF5DA1500DCB059 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		65987D761DEDCB6D00868688 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		65987D771DEDCB6D00868688 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+			};
+			name = Release;
+		};
+		65987D791DEDCB6D00868688 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DDEBF5EF4F1774FBA52EE748 /* Pods-TryProcedureKit.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = TryProcedureKit/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = run.kit.procedure.TryProcedureKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		65987D7A1DEDCB6D00868688 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C43DCAAEFE574A655166C29E /* Pods-TryProcedureKit.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = TryProcedureKit/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = run.kit.procedure.TryProcedureKit;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		65987D7C1DEDCB6D00868688 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 64E1871A3A35473F2C6303A9 /* Pods-TryProcedureKitTests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = TryProcedureKitTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = run.kit.procedure.TryProcedureKitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TryProcedureKit.app/Contents/MacOS/TryProcedureKit";
+			};
+			name = Debug;
+		};
+		65987D7D1DEDCB6D00868688 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4C75AB65DA9F459E58F44D20 /* Pods-TryProcedureKitTests.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = TryProcedureKitTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = run.kit.procedure.TryProcedureKitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TryProcedureKit.app/Contents/MacOS/TryProcedureKit";
+			};
+			name = Release;
+		};
+		65C540391DF5DA1500DCB059 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 22D696D4AB45191E7B56C3F8 /* Pods-TryProcedureKit iOS.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "TryProcedureKit iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "run.kit.procedure.TryProcedureKit-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		65C5403A1DF5DA1500DCB059 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A80C8A224A4D10648271BF7F /* Pods-TryProcedureKit iOS.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "TryProcedureKit iOS/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "run.kit.procedure.TryProcedureKit-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 4.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		65C5403B1DF5DA1500DCB059 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 20BA1F62FDB673FAF14C8FD0 /* Pods-TryProcedureKit iOSTests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "TryProcedureKit iOSTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "run.kit.procedure.TryProcedureKit-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TryProcedureKit iOS.app/TryProcedureKit iOS";
+			};
+			name = Debug;
+		};
+		65C5403C1DF5DA1500DCB059 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 566864A4B9D3236BD0492C34 /* Pods-TryProcedureKit iOSTests.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "TryProcedureKit iOSTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "run.kit.procedure.TryProcedureKit-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TryProcedureKit iOS.app/TryProcedureKit iOS";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		65987D591DEDCB6D00868688 /* Build configuration list for PBXProject "TryProcedureKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				65987D761DEDCB6D00868688 /* Debug */,
+				65987D771DEDCB6D00868688 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		65987D781DEDCB6D00868688 /* Build configuration list for PBXNativeTarget "TryProcedureKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				65987D791DEDCB6D00868688 /* Debug */,
+				65987D7A1DEDCB6D00868688 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		65987D7B1DEDCB6D00868688 /* Build configuration list for PBXNativeTarget "TryProcedureKitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				65987D7C1DEDCB6D00868688 /* Debug */,
+				65987D7D1DEDCB6D00868688 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		65C5403D1DF5DA1500DCB059 /* Build configuration list for PBXNativeTarget "TryProcedureKit iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				65C540391DF5DA1500DCB059 /* Debug */,
+				65C5403A1DF5DA1500DCB059 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		65C5403E1DF5DA1500DCB059 /* Build configuration list for PBXNativeTarget "TryProcedureKit iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				65C5403B1DF5DA1500DCB059 /* Debug */,
+				65C5403C1DF5DA1500DCB059 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 65987D561DEDCB6D00868688 /* Project object */;
+}

--- a/Integrations/CocoaPods/TryProcedureKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Integrations/CocoaPods/TryProcedureKit.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:TryProcedureKit.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Integrations/CocoaPods/TryProcedureKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Integrations/CocoaPods/TryProcedureKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Integrations/CocoaPods/TryProcedureKit.xcodeproj/xcshareddata/xcschemes/TryProcedureKit.xcscheme
+++ b/Integrations/CocoaPods/TryProcedureKit.xcodeproj/xcshareddata/xcschemes/TryProcedureKit.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0940"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "65987D5D1DEDCB6D00868688"
+               BuildableName = "TryProcedureKit.app"
+               BlueprintName = "TryProcedureKit"
+               ReferencedContainer = "container:TryProcedureKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "65987D6E1DEDCB6D00868688"
+               BuildableName = "TryProcedureKitTests.xctest"
+               BlueprintName = "TryProcedureKitTests"
+               ReferencedContainer = "container:TryProcedureKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65987D5D1DEDCB6D00868688"
+            BuildableName = "TryProcedureKit.app"
+            BlueprintName = "TryProcedureKit"
+            ReferencedContainer = "container:TryProcedureKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65987D5D1DEDCB6D00868688"
+            BuildableName = "TryProcedureKit.app"
+            BlueprintName = "TryProcedureKit"
+            ReferencedContainer = "container:TryProcedureKit.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "65987D5D1DEDCB6D00868688"
+            BuildableName = "TryProcedureKit.app"
+            BlueprintName = "TryProcedureKit"
+            ReferencedContainer = "container:TryProcedureKit.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Integrations/CocoaPods/TryProcedureKit.xcworkspace/contents.xcworkspacedata
+++ b/Integrations/CocoaPods/TryProcedureKit.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:TryProcedureKit.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Integrations/CocoaPods/TryProcedureKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Integrations/CocoaPods/TryProcedureKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Integrations/CocoaPods/TryProcedureKit.xcworkspace/xcshareddata/TryProcedureKit.xcscmblueprint
+++ b/Integrations/CocoaPods/TryProcedureKit.xcworkspace/xcshareddata/TryProcedureKit.xcscmblueprint
@@ -1,0 +1,30 @@
+{
+  "DVTSourceControlWorkspaceBlueprintPrimaryRemoteRepositoryKey" : "677A2647FD1A6C6ABA9C1542D03C5F1CD3948081",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyRepositoryLocationsKey" : {
+
+  },
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyStatesKey" : {
+    "677A2647FD1A6C6ABA9C1542D03C5F1CD3948081" : 9223372036854775807,
+    "3A999A0044F026F7ADF66A6D83E1CB8EDCDF46AF" : 9223372036854775807
+  },
+  "DVTSourceControlWorkspaceBlueprintIdentifierKey" : "D50C1BA4-76D1-49CD-B697-2611133A9E56",
+  "DVTSourceControlWorkspaceBlueprintWorkingCopyPathsKey" : {
+    "677A2647FD1A6C6ABA9C1542D03C5F1CD3948081" : "TryProcedureKit\/",
+    "3A999A0044F026F7ADF66A6D83E1CB8EDCDF46AF" : "TryProcedureKit\/submodules\/ProcedureKit\/"
+  },
+  "DVTSourceControlWorkspaceBlueprintNameKey" : "TryProcedureKit",
+  "DVTSourceControlWorkspaceBlueprintVersion" : 204,
+  "DVTSourceControlWorkspaceBlueprintRelativePathToProjectKey" : "TryProcedureKit.xcworkspace",
+  "DVTSourceControlWorkspaceBlueprintRemoteRepositoriesKey" : [
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:ProcedureKit\/ProcedureKit.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "3A999A0044F026F7ADF66A6D83E1CB8EDCDF46AF"
+    },
+    {
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryURLKey" : "github.com:ProcedureKit\/TryProcedureKit.git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositorySystemKey" : "com.apple.dt.Xcode.sourcecontrol.Git",
+      "DVTSourceControlWorkspaceBlueprintRemoteRepositoryIdentifierKey" : "677A2647FD1A6C6ABA9C1542D03C5F1CD3948081"
+    }
+  ]
+}

--- a/Integrations/CocoaPods/TryProcedureKit/AppDelegate.swift
+++ b/Integrations/CocoaPods/TryProcedureKit/AppDelegate.swift
@@ -1,0 +1,11 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import Cocoa
+
+@NSApplicationMain
+class AppDelegate: NSObject, NSApplicationDelegate { }
+

--- a/Integrations/CocoaPods/TryProcedureKit/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Integrations/CocoaPods/TryProcedureKit/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,58 @@
+{
+  "images" : [
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "512x512",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Integrations/CocoaPods/TryProcedureKit/Base.lproj/Main.storyboard
+++ b/Integrations/CocoaPods/TryProcedureKit/Base.lproj/Main.storyboard
@@ -1,0 +1,693 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11134"/>
+    </dependencies>
+    <scenes>
+        <!--Application-->
+        <scene sceneID="JPo-4y-FX3">
+            <objects>
+                <application id="hnw-xV-0zn" sceneMemberID="viewController">
+                    <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
+                        <items>
+                            <menuItem title="TryProcedureKit" id="1Xt-HY-uBw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="TryProcedureKit" systemMenu="apple" id="uQy-DD-JDr">
+                                    <items>
+                                        <menuItem title="About TryProcedureKit" id="5kV-Vb-QxS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
+                                        <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
+                                        <menuItem title="Services" id="NMo-om-nkz">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
+                                        <menuItem title="Hide TryProcedureKit" keyEquivalent="h" id="Olw-nP-bQN">
+                                            <connections>
+                                                <action selector="hide:" target="Ady-hI-5gd" id="PnN-Uc-m68"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Hide Others" keyEquivalent="h" id="Vdr-fp-XzO">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="hideOtherApplications:" target="Ady-hI-5gd" id="VT4-aY-XCT"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Show All" id="Kd2-mp-pUS">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="unhideAllApplications:" target="Ady-hI-5gd" id="Dhg-Le-xox"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
+                                        <menuItem title="Quit TryProcedureKit" keyEquivalent="q" id="4sb-4s-VLi">
+                                            <connections>
+                                                <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="File" id="dMs-cI-mzQ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="File" id="bib-Uj-vzu">
+                                    <items>
+                                        <menuItem title="New" keyEquivalent="n" id="Was-JA-tGl">
+                                            <connections>
+                                                <action selector="newDocument:" target="Ady-hI-5gd" id="4Si-XN-c54"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open…" keyEquivalent="o" id="IAo-SY-fd9">
+                                            <connections>
+                                                <action selector="openDocument:" target="Ady-hI-5gd" id="bVn-NM-KNZ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Open Recent" id="tXI-mr-wws">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Open Recent" systemMenu="recentDocuments" id="oas-Oc-fiZ">
+                                                <items>
+                                                    <menuItem title="Clear Menu" id="vNY-rz-j42">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="clearRecentDocuments:" target="Ady-hI-5gd" id="Daa-9d-B3U"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="m54-Is-iLE"/>
+                                        <menuItem title="Close" keyEquivalent="w" id="DVo-aG-piG">
+                                            <connections>
+                                                <action selector="performClose:" target="Ady-hI-5gd" id="HmO-Ls-i7Q"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save…" keyEquivalent="s" id="pxx-59-PXV">
+                                            <connections>
+                                                <action selector="saveDocument:" target="Ady-hI-5gd" id="teZ-XB-qJY"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Save As…" keyEquivalent="S" id="Bw7-FT-i3A">
+                                            <connections>
+                                                <action selector="saveDocumentAs:" target="Ady-hI-5gd" id="mDf-zr-I0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Revert to Saved" keyEquivalent="r" id="KaW-ft-85H">
+                                            <connections>
+                                                <action selector="revertDocumentToSaved:" target="Ady-hI-5gd" id="iJ3-Pv-kwq"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="aJh-i4-bef"/>
+                                        <menuItem title="Page Setup…" keyEquivalent="P" id="qIS-W8-SiK">
+                                            <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="runPageLayout:" target="Ady-hI-5gd" id="Din-rz-gC5"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Print…" keyEquivalent="p" id="aTl-1u-JFS">
+                                            <connections>
+                                                <action selector="print:" target="Ady-hI-5gd" id="qaZ-4w-aoO"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Edit" id="5QF-Oa-p0T">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Edit" id="W48-6f-4Dl">
+                                    <items>
+                                        <menuItem title="Undo" keyEquivalent="z" id="dRJ-4n-Yzg">
+                                            <connections>
+                                                <action selector="undo:" target="Ady-hI-5gd" id="M6e-cu-g7V"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Redo" keyEquivalent="Z" id="6dh-zS-Vam">
+                                            <connections>
+                                                <action selector="redo:" target="Ady-hI-5gd" id="oIA-Rs-6OD"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="WRV-NI-Exz"/>
+                                        <menuItem title="Cut" keyEquivalent="x" id="uRl-iY-unG">
+                                            <connections>
+                                                <action selector="cut:" target="Ady-hI-5gd" id="YJe-68-I9s"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Copy" keyEquivalent="c" id="x3v-GG-iWU">
+                                            <connections>
+                                                <action selector="copy:" target="Ady-hI-5gd" id="G1f-GL-Joy"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste" keyEquivalent="v" id="gVA-U4-sdL">
+                                            <connections>
+                                                <action selector="paste:" target="Ady-hI-5gd" id="UvS-8e-Qdg"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Paste and Match Style" keyEquivalent="V" id="WeT-3V-zwk">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="pasteAsPlainText:" target="Ady-hI-5gd" id="cEh-KX-wJQ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Delete" id="pa3-QI-u2k">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="delete:" target="Ady-hI-5gd" id="0Mk-Ml-PaM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Select All" keyEquivalent="a" id="Ruw-6m-B2m">
+                                            <connections>
+                                                <action selector="selectAll:" target="Ady-hI-5gd" id="VNm-Mi-diN"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="uyl-h8-XO2"/>
+                                        <menuItem title="Find" id="4EN-yA-p0u">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Find" id="1b7-l0-nxx">
+                                                <items>
+                                                    <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="cD7-Qs-BN4"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="WD3-Gg-5AJ"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Next" tag="2" keyEquivalent="g" id="q09-fT-Sye">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="NDo-RZ-v9R"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Find Previous" tag="3" keyEquivalent="G" id="OwM-mh-QMV">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="HOh-sY-3ay"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Use Selection for Find" tag="7" keyEquivalent="e" id="buJ-ug-pKt">
+                                                        <connections>
+                                                            <action selector="performFindPanelAction:" target="Ady-hI-5gd" id="U76-nv-p5D"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Jump to Selection" keyEquivalent="j" id="S0p-oC-mLd">
+                                                        <connections>
+                                                            <action selector="centerSelectionInVisibleArea:" target="Ady-hI-5gd" id="IOG-6D-g5B"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Spelling and Grammar" id="Dv1-io-Yv7">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Spelling" id="3IN-sU-3Bg">
+                                                <items>
+                                                    <menuItem title="Show Spelling and Grammar" keyEquivalent=":" id="HFo-cy-zxI">
+                                                        <connections>
+                                                            <action selector="showGuessPanel:" target="Ady-hI-5gd" id="vFj-Ks-hy3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Document Now" keyEquivalent=";" id="hz2-CU-CR7">
+                                                        <connections>
+                                                            <action selector="checkSpelling:" target="Ady-hI-5gd" id="fz7-VC-reM"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="bNw-od-mp5"/>
+                                                    <menuItem title="Check Spelling While Typing" id="rbD-Rh-wIN">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleContinuousSpellChecking:" target="Ady-hI-5gd" id="7w6-Qz-0kB"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Check Grammar With Spelling" id="mK6-2p-4JG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleGrammarChecking:" target="Ady-hI-5gd" id="muD-Qn-j4w"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Correct Spelling Automatically" id="78Y-hA-62v">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticSpellingCorrection:" target="Ady-hI-5gd" id="2lM-Qi-WAP"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Substitutions" id="9ic-FL-obx">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Substitutions" id="FeM-D8-WVr">
+                                                <items>
+                                                    <menuItem title="Show Substitutions" id="z6F-FW-3nz">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="orderFrontSubstitutionsPanel:" target="Ady-hI-5gd" id="oku-mr-iSq"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="gPx-C9-uUO"/>
+                                                    <menuItem title="Smart Copy/Paste" id="9yt-4B-nSM">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleSmartInsertDelete:" target="Ady-hI-5gd" id="3IJ-Se-DZD"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Quotes" id="hQb-2v-fYv">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticQuoteSubstitution:" target="Ady-hI-5gd" id="ptq-xd-QOA"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Dashes" id="rgM-f4-ycn">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDashSubstitution:" target="Ady-hI-5gd" id="oCt-pO-9gS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Smart Links" id="cwL-P1-jid">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticLinkDetection:" target="Ady-hI-5gd" id="Gip-E3-Fov"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Data Detectors" id="tRr-pd-1PS">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticDataDetection:" target="Ady-hI-5gd" id="R1I-Nq-Kbl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Text Replacement" id="HFQ-gK-NFA">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleAutomaticTextReplacement:" target="Ady-hI-5gd" id="DvP-Fe-Py6"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Transformations" id="2oI-Rn-ZJC">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Transformations" id="c8a-y6-VQd">
+                                                <items>
+                                                    <menuItem title="Make Upper Case" id="vmV-6d-7jI">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="uppercaseWord:" target="Ady-hI-5gd" id="sPh-Tk-edu"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Make Lower Case" id="d9M-CD-aMd">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="lowercaseWord:" target="Ady-hI-5gd" id="iUZ-b5-hil"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Capitalize" id="UEZ-Bs-lqG">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="capitalizeWord:" target="Ady-hI-5gd" id="26H-TL-nsh"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Speech" id="xrE-MZ-jX0">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Speech" id="3rS-ZA-NoH">
+                                                <items>
+                                                    <menuItem title="Start Speaking" id="Ynk-f8-cLZ">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="startSpeaking:" target="Ady-hI-5gd" id="654-Ng-kyl"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Stop Speaking" id="Oyz-dy-DGm">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="stopSpeaking:" target="Ady-hI-5gd" id="dX8-6p-jy9"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Format" id="jxT-CU-nIS">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Format" id="GEO-Iw-cKr">
+                                    <items>
+                                        <menuItem title="Font" id="Gi5-1S-RQB">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Font" systemMenu="font" id="aXa-aM-Jaq">
+                                                <items>
+                                                    <menuItem title="Show Fonts" keyEquivalent="t" id="Q5e-8K-NDq"/>
+                                                    <menuItem title="Bold" tag="2" keyEquivalent="b" id="GB9-OM-e27"/>
+                                                    <menuItem title="Italic" tag="1" keyEquivalent="i" id="Vjx-xi-njq"/>
+                                                    <menuItem title="Underline" keyEquivalent="u" id="WRG-CD-K1S">
+                                                        <connections>
+                                                            <action selector="underline:" target="Ady-hI-5gd" id="FYS-2b-JAY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="5gT-KC-WSO"/>
+                                                    <menuItem title="Bigger" tag="3" keyEquivalent="+" id="Ptp-SP-VEL"/>
+                                                    <menuItem title="Smaller" tag="4" keyEquivalent="-" id="i1d-Er-qST"/>
+                                                    <menuItem isSeparatorItem="YES" id="kx3-Dk-x3B"/>
+                                                    <menuItem title="Kern" id="jBQ-r6-VK2">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Kern" id="tlD-Oa-oAM">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="GUa-eO-cwY">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardKerning:" target="Ady-hI-5gd" id="6dk-9l-Ckg"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="cDB-IK-hbR">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffKerning:" target="Ady-hI-5gd" id="U8a-gz-Maa"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Tighten" id="46P-cB-AYj">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="tightenKerning:" target="Ady-hI-5gd" id="hr7-Nz-8ro"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Loosen" id="ogc-rX-tC1">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="loosenKerning:" target="Ady-hI-5gd" id="8i4-f9-FKE"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Ligatures" id="o6e-r0-MWq">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Ligatures" id="w0m-vy-SC9">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="agt-UL-0e3">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useStandardLigatures:" target="Ady-hI-5gd" id="7uR-wd-Dx6"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use None" id="J7y-lM-qPV">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="turnOffLigatures:" target="Ady-hI-5gd" id="iX2-gA-Ilz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Use All" id="xQD-1f-W4t">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="useAllLigatures:" target="Ady-hI-5gd" id="KcB-kA-TuK"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem title="Baseline" id="OaQ-X3-Vso">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Baseline" id="ijk-EB-dga">
+                                                            <items>
+                                                                <menuItem title="Use Default" id="3Om-Ey-2VK">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="unscript:" target="Ady-hI-5gd" id="0vZ-95-Ywn"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Superscript" id="Rqc-34-cIF">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="superscript:" target="Ady-hI-5gd" id="3qV-fo-wpU"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Subscript" id="I0S-gh-46l">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="subscript:" target="Ady-hI-5gd" id="Q6W-4W-IGz"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Raise" id="2h7-ER-AoG">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="raiseBaseline:" target="Ady-hI-5gd" id="4sk-31-7Q9"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem title="Lower" id="1tx-W0-xDw">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="lowerBaseline:" target="Ady-hI-5gd" id="OF1-bc-KW4"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="Ndw-q3-faq"/>
+                                                    <menuItem title="Show Colors" keyEquivalent="C" id="bgn-CT-cEk">
+                                                        <connections>
+                                                            <action selector="orderFrontColorPanel:" target="Ady-hI-5gd" id="mSX-Xz-DV3"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="iMs-zA-UFJ"/>
+                                                    <menuItem title="Copy Style" keyEquivalent="c" id="5Vv-lz-BsD">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyFont:" target="Ady-hI-5gd" id="GJO-xA-L4q"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Style" keyEquivalent="v" id="vKC-jM-MkH">
+                                                        <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteFont:" target="Ady-hI-5gd" id="JfD-CL-leO"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                        <menuItem title="Text" id="Fal-I4-PZk">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <menu key="submenu" title="Text" id="d9c-me-L2H">
+                                                <items>
+                                                    <menuItem title="Align Left" keyEquivalent="{" id="ZM1-6Q-yy1">
+                                                        <connections>
+                                                            <action selector="alignLeft:" target="Ady-hI-5gd" id="zUv-R1-uAa"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Center" keyEquivalent="|" id="VIY-Ag-zcb">
+                                                        <connections>
+                                                            <action selector="alignCenter:" target="Ady-hI-5gd" id="spX-mk-kcS"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Justify" id="J5U-5w-g23">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="alignJustified:" target="Ady-hI-5gd" id="ljL-7U-jND"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Align Right" keyEquivalent="}" id="wb2-vD-lq4">
+                                                        <connections>
+                                                            <action selector="alignRight:" target="Ady-hI-5gd" id="r48-bG-YeY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="4s2-GY-VfK"/>
+                                                    <menuItem title="Writing Direction" id="H1b-Si-o9J">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <menu key="submenu" title="Writing Direction" id="8mr-sm-Yjd">
+                                                            <items>
+                                                                <menuItem title="Paragraph" enabled="NO" id="ZvO-Gk-QUH">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="YGs-j5-SAR">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionNatural:" target="Ady-hI-5gd" id="qtV-5e-UBP"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="Lbh-J2-qVU">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="S0X-9S-QSf"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="jFq-tB-4Kx">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeBaseWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="5fk-qB-AqJ"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem isSeparatorItem="YES" id="swp-gr-a21"/>
+                                                                <menuItem title="Selection" enabled="NO" id="cqv-fj-IhA">
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                </menuItem>
+                                                                <menuItem id="Nop-cj-93Q">
+                                                                    <string key="title">	Default</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionNatural:" target="Ady-hI-5gd" id="lPI-Se-ZHp"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="BgM-ve-c93">
+                                                                    <string key="title">	Left to Right</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionLeftToRight:" target="Ady-hI-5gd" id="caW-Bv-w94"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                                <menuItem id="RB4-Sm-HuC">
+                                                                    <string key="title">	Right to Left</string>
+                                                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                                                    <connections>
+                                                                        <action selector="makeTextWritingDirectionRightToLeft:" target="Ady-hI-5gd" id="EXD-6r-ZUu"/>
+                                                                    </connections>
+                                                                </menuItem>
+                                                            </items>
+                                                        </menu>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" id="fKy-g9-1gm"/>
+                                                    <menuItem title="Show Ruler" id="vLm-3I-IUL">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                        <connections>
+                                                            <action selector="toggleRuler:" target="Ady-hI-5gd" id="FOx-HJ-KwY"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Copy Ruler" keyEquivalent="c" id="MkV-Pr-PK5">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="copyRuler:" target="Ady-hI-5gd" id="71i-fW-3W2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                    <menuItem title="Paste Ruler" keyEquivalent="v" id="LVM-kO-fVI">
+                                                        <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                                        <connections>
+                                                            <action selector="pasteRuler:" target="Ady-hI-5gd" id="cSh-wd-qM2"/>
+                                                        </connections>
+                                                    </menuItem>
+                                                </items>
+                                            </menu>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="View" id="H8h-7b-M4v">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="View" id="HyV-fh-RgO">
+                                    <items>
+                                        <menuItem title="Show Toolbar" keyEquivalent="t" id="snW-S8-Cw5">
+                                            <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleToolbarShown:" target="Ady-hI-5gd" id="BXY-wc-z0C"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Customize Toolbar…" id="1UK-8n-QPP">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="runToolbarCustomizationPalette:" target="Ady-hI-5gd" id="pQI-g3-MTW"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="hB3-LF-h0Y"/>
+                                        <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleSourceList:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="toggleFullScreen:" target="Ady-hI-5gd" id="dU3-MA-1Rq"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Window" id="aUF-d1-5bR">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">
+                                    <items>
+                                        <menuItem title="Minimize" keyEquivalent="m" id="OY7-WF-poV">
+                                            <connections>
+                                                <action selector="performMiniaturize:" target="Ady-hI-5gd" id="VwT-WD-YPe"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Zoom" id="R4o-n2-Eq4">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="performZoom:" target="Ady-hI-5gd" id="DIl-cC-cCs"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
+                                        <menuItem title="Bring All to Front" id="LE2-aR-0XJ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="arrangeInFront:" target="Ady-hI-5gd" id="DRN-fu-gQh"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                            <menuItem title="Help" id="wpr-3q-Mcd">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
+                                    <items>
+                                        <menuItem title="TryProcedureKit Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                            <connections>
+                                                <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
+                        </items>
+                    </menu>
+                    <connections>
+                        <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
+                    </connections>
+                </application>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModuleProvider="target"/>
+                <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="0.0"/>
+        </scene>
+        <!--Window Controller-->
+        <scene sceneID="R2V-B0-nI4">
+            <objects>
+                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="196" y="240" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
+                    </window>
+                    <connections>
+                        <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
+                    </connections>
+                </windowController>
+                <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="250"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="hIz-AP-VOD">
+            <objects>
+                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" wantsLayer="YES" id="m2S-Jp-Qdl">
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="75" y="655"/>
+        </scene>
+    </scenes>
+</document>

--- a/Integrations/CocoaPods/TryProcedureKit/Info.plist
+++ b/Integrations/CocoaPods/TryProcedureKit/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2016 ProcedureKit. All rights reserved.</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/Integrations/CocoaPods/TryProcedureKit/ViewController.swift
+++ b/Integrations/CocoaPods/TryProcedureKit/ViewController.swift
@@ -1,0 +1,37 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import Cocoa
+import ProcedureKit
+
+class ViewController: NSViewController {
+
+    lazy var queue = ProcedureQueue()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        queue.addOperation(AsyncBlockProcedure { finishWithResult in
+            DispatchQueue.default.async {
+                print("Hello world")
+                finishWithResult(success)
+            }
+        })
+
+        getNetworkResource()
+    }
+
+    func getNetworkResource() {
+
+        let procedure = NetworkProcedure { NetworkDataProcedure(session: URLSession.shared, request: URLRequest(url: "http://www.apple.com")) }
+        procedure.log.severity = .info
+        procedure.addDidFinishBlockObserver { procedure, error in
+            guard let result = procedure.output.success else { return }
+            procedure.log.info.message("Received: \(result.response)")
+        }
+        queue.addOperation(procedure)
+    }
+}

--- a/Integrations/CocoaPods/TryProcedureKitTests/Info.plist
+++ b/Integrations/CocoaPods/TryProcedureKitTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Integrations/CocoaPods/TryProcedureKitTests/TryProcedureKitTests.swift
+++ b/Integrations/CocoaPods/TryProcedureKitTests/TryProcedureKitTests.swift
@@ -1,0 +1,19 @@
+//
+//  TryProcedureKitTests.swift
+//  TryProcedureKitTests
+//
+//  Created by Daniel Thorpe on 29/11/2016.
+//  Copyright © 2016 ProcedureKit. All rights reserved.
+//
+
+import XCTest
+import ProcedureKit
+import TestingProcedureKit
+@testable import TryProcedureKit
+
+class TestSuiteRuns: XCTestCase {
+
+    func test__suite_runs() {
+        XCTAssertTrue(true)
+    }
+}

--- a/Sources/ProcedureKitNetwork/NetworkData.swift
+++ b/Sources/ProcedureKitNetwork/NetworkData.swift
@@ -95,7 +95,7 @@ open class NetworkDataProcedure: Procedure, InputProcedure, OutputProcedure, Net
             strongSelf.finish(withResult: .success(http))
         }
 
-        log.notice(message: "Will make request: \(request)")
+        log.info.message("Will make request: \(request)")
         task?.resume()
     }
 }


### PR DESCRIPTION
At the moment, there are integration tests for CocoaPods in a different repository (https://github.com/procedurekit/tryprocedurekit) which causes difficulty in CI in some scenarios

- builds from 3rd party forks don't work
- it can be tricky to make changes in PK which need to be reflected in TryProcedureKit too in order to pass.

So, it would be better to just have an `integrations/` directory in here with some projects which integrated ProcedureKit from the local directory (i.e. `../`).