### PR TITLE
Fix bug with UIProcedure

### DIFF
--- a/Sources/ProcedureKit/Block.swift
+++ b/Sources/ProcedureKit/Block.swift
@@ -85,10 +85,10 @@ open class UIBlockProcedure: AsyncBlockProcedure {
             func go(_ finishingBlock: FinishingBlock) {
                 do {
                     try block()
-                    finishWithResult(success)
+                    finishingBlock(success)
                 }
                 catch {
-                    finishWithResult(.failure(error))
+                    finishingBlock(.failure(error))
                 }
             }
 

--- a/Tests/ProcedureKitTests/BlockProcedureTests.swift
+++ b/Tests/ProcedureKitTests/BlockProcedureTests.swift
@@ -112,3 +112,36 @@ class AsyncBlockProcedureTests: ProcedureKitTestCase {
     }
 }
 
+class UIBlockProcedureTests: ProcedureKitTestCase {
+
+    func test__block_executes() {
+        var blockDidExecute = false
+        let block = UIBlockProcedure {
+            blockDidExecute = true
+        }
+        wait(for: block)
+        XCTAssertTrue(blockDidExecute)
+        PKAssertProcedureFinished(block)
+    }
+
+    func test__didFinishObserversCalled() {
+        var blockDidExecute = false
+        var observerDidExecute = false
+        let block = UIBlockProcedure {
+            blockDidExecute = true
+        }
+        block.addDidFinishBlockObserver { (_, error) in
+            observerDidExecute = true
+        }
+        var dependencyDidExecute = false
+        let dep = BlockProcedure {
+            dependencyDidExecute = true
+        }
+        wait(for: block, dep)
+        XCTAssertTrue(blockDidExecute)
+        XCTAssertTrue(observerDidExecute)
+        XCTAssertTrue(dependencyDidExecute)
+        PKAssertProcedureFinished(block)
+        PKAssertProcedureFinished(dep)
+    }
+}


### PR DESCRIPTION
The `sub` procedure never properly finishes due to a typo with finishing block names.