### PR TITLE
Make auto layout containment strategy block property public

### DIFF
--- a/Sources/ProcedureKitMobile/ViewControllerContainment.swift
+++ b/Sources/ProcedureKitMobile/ViewControllerContainment.swift
@@ -28,7 +28,7 @@ public enum SetAutolayoutConstraints {
     // Provide a custom block
     case custom(SetAutolayoutConstraintsBlockType)
 
-    var block: SetAutolayoutConstraintsBlockType {
+    public var block: SetAutolayoutConstraintsBlockType {
         switch self {
         case .pinnedToParent:
             return { views in


### PR DESCRIPTION
At the moment, it has defaulted to internal - so not possible for framework consumers to use.