### PR TITLE
Refactor BlockProcedure

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		65A72C2B1DA7F37C008597CA /* TestingProcedureKit.framework in Copy Dependencies */ = {isa = PBXBuildFile; fileRef = 65CFC6161D60900000CAD875 /* TestingProcedureKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		65AB7DDA209B95B400726796 /* Batch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AB7DD9209B95B400726796 /* Batch.swift */; };
 		65AEF19F20A3AE340089B6C8 /* ViewControllerContainment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65AEF19E20A3AE340089B6C8 /* ViewControllerContainment.swift */; };
+		65B9AF482116D1D4004DA82B /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B9AF472116D1D4004DA82B /* Result.swift */; };
 		65C7BBC22085CEF4009A6D6E /* CKAcceptSharesOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367DF1E1844F800D03E86 /* CKAcceptSharesOperation.swift */; };
 		65C7BBC32085CF21009A6D6E /* CKDatabaseOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E01E1844F800D03E86 /* CKDatabaseOperation.swift */; };
 		65C7BBC42085CF26009A6D6E /* CKDiscoverAllContactsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D367E11E1844F800D03E86 /* CKDiscoverAllContactsOperation.swift */; };
@@ -586,6 +587,7 @@
 		65A1923A20F8900100E0D42C /* TestableLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestableLogging.swift; sourceTree = "<group>"; };
 		65AB7DD9209B95B400726796 /* Batch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Batch.swift; sourceTree = "<group>"; };
 		65AEF19E20A3AE340089B6C8 /* ViewControllerContainment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerContainment.swift; sourceTree = "<group>"; };
+		65B9AF472116D1D4004DA82B /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		65C88D761DC4EB4300C8D4EB /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Warnings.xcconfig; path = "Supporting Files/Warnings.xcconfig"; sourceTree = "<group>"; };
 		65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ProcedureKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65CFC5F91D608A5500CAD875 /* ProcedureKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProcedureKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1351,6 +1353,7 @@
 				65D368761E184AA600D03E86 /* Map.swift */,
 				65D368831E184AA600D03E86 /* Reduce.swift */,
 				65D368841E184AA600D03E86 /* Repeat.swift */,
+				65B9AF472116D1D4004DA82B /* Result.swift */,
 				65D368851E184AA600D03E86 /* Retry.swift */,
 				65D368891E184AA600D03E86 /* Transform.swift */,
 			);
@@ -2303,6 +2306,7 @@
 				65D3689E1E184AA600D03E86 /* NoFailedDependenciesCondition.swift in Sources */,
 				65AB7DDA209B95B400726796 /* Batch.swift in Sources */,
 				65D368A41E184AA600D03E86 /* ProcedureResult.swift in Sources */,
+				65B9AF482116D1D4004DA82B /* Result.swift in Sources */,
 				65D368A81E184AA600D03E86 /* Repeat.swift in Sources */,
 				65D368AB1E184AA600D03E86 /* Support.swift in Sources */,
 				65D368911E184AA600D03E86 /* Composed.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The `development` branch, or the _bleeding edge_ is the current state of Procedu
   - [x] Swift 4.2 & Xcode 10 support (on `xcode/10.0/development` branch)
   - [ ] Documentation, guides & sample code (currently published to http://procedure.kit.run/development/)
   - [x] Errors & easier error handling (breaking changes on `development` branch)
-  - [ ] Improved debugging & logging
-  - [ ] Simplified BlockProcedure API
+  - [x] Improved debugging & logging
+  - [x] Simplified BlockProcedure API
   - [x] Simplified _ProcedureKitNetwork_ classes (this was done a while ago, the generic session has been removed)
 
 

--- a/Sources/ProcedureKit/Block.swift
+++ b/Sources/ProcedureKit/Block.swift
@@ -4,111 +4,78 @@
 //  Copyright © 2015-2018 ProcedureKit. All rights reserved.
 //
 
-open class ResultProcedure<Output>: Procedure, OutputProcedure {
+open class BlockProcedure: Procedure {
 
-    public typealias ThrowingOutputBlock = () throws -> Output
+    public typealias SelfBlock = (BlockProcedure) -> Void
+    public typealias ThrowingVoidBlock = () throws -> Void
 
-    public var output: Pending<ProcedureResult<Output>> = .pending
+    public enum BlockStorage {
+        case asSelf(SelfBlock)
+        case asVoid(ThrowingVoidBlock)
+    }
 
-    public let block: ThrowingOutputBlock
+    public static var defaultTimeoutInterval: TimeInterval = 3.0
 
-    public init(block: @escaping ThrowingOutputBlock) {
-        self.block = block
+    public let storage: BlockStorage
+
+    public init(block: @escaping SelfBlock) {
+        self.storage = .asSelf(block)
+        super.init()
+        addObserver(TimeoutObserver(by: BlockProcedure.defaultTimeoutInterval))
+    }
+
+    public init(block: @escaping ThrowingVoidBlock) {
+        self.storage = .asVoid(block)
         super.init()
     }
 
     open override func execute() {
-        defer { finish(with: output.error) }
-        do { output = .ready(.success(try block())) }
-        catch { output = .ready(.failure(error)) }
+        switch storage {
+        case let .asSelf(block):
+            block(self)
+        case let .asVoid(block):
+            do {
+                try block()
+                finish()
+            }
+            catch { finish(with: error) }
+        }
+    }
+
+    open override func procedureDidCancel(with error: Error?) {
+        if let procedureKitError = error as? ProcedureKitError {
+            if case .timedOut(.by(BlockProcedure.defaultTimeoutInterval)) = procedureKitError.context {
+                log.warning.message("Block not finished after \(BlockProcedure.defaultTimeoutInterval) seconds. This is likely a mistake, check that this block calls .finish() on all code paths.")
+            }
+        }
     }
 }
-
-open class BlockProcedure: ResultProcedure<Void> { }
-
-open class AsyncResultProcedure<Output>: Procedure, OutputProcedure {
-
-    public typealias FinishingBlock = (ProcedureResult<Output>) -> Void
-    public typealias Block = (@escaping FinishingBlock) -> Void
-
-    public let block: Block
-
-    public var output: Pending<ProcedureResult<Output>> = .pending
-
-    public init(block: @escaping Block) {
-        self.block = block
-        super.init()
-    }
-
-    open override func execute() {
-        block { [weak self] in self?.finish(withResult: $0) }
-    }
-}
-
-open class AsyncBlockProcedure: AsyncResultProcedure<Void> { }
-
-open class CancellableResultProcedure<Output>: Procedure, OutputProcedure {
-
-    /// A block that receives a closure (that returns the current value of `isCancelled`
-    /// for the CancellableResultProcedure), and returns a value (which is set as the
-    /// CancellableResultProcedure's `output`).
-    public typealias ThrowingCancellableOutputBlock = (() -> Bool) throws -> Output
-
-    public var output: Pending<ProcedureResult<Output>> = .pending
-
-    public let block: ThrowingCancellableOutputBlock
-
-    public init(cancellableBlock: @escaping ThrowingCancellableOutputBlock) {
-        self.block = cancellableBlock
-        super.init()
-    }
-
-    open override func execute() {
-        defer { finish(with: output.error) }
-        do { output = .ready(.success(try block({[unowned self] in return self.isCancelled }))) }
-        catch { output = .ready(.failure(error)) }
-    }
-}
-
-open class CancellableBlockProcedure: CancellableResultProcedure<Void> { }
 
 /*
  A block based procedure which execute the provided block on the UI/main thread.
  */
-open class UIBlockProcedure: AsyncBlockProcedure {
-
-    public typealias ThrowingOutputBlock = () throws -> Output
-
-    public init(block: @escaping ThrowingOutputBlock) {
-        super.init { (finishWithResult) in
-
-            func go(_ finishingBlock: FinishingBlock) {
-                do {
-                    try block()
-                    finishingBlock(success)
-                }
-                catch {
-                    finishingBlock(.failure(error))
-                }
-            }
+open class UIBlockProcedure: BlockProcedure {
+    public override init(block: @escaping ThrowingVoidBlock) {
+        super.init { (procedure) in
 
             guard DispatchQueue.isMainDispatchQueue == false else {
-                go(finishWithResult)
+                do {
+                    try block()
+                    procedure.finish()
+                }
+                catch { procedure.finish(with: error) }
                 return
             }
 
-            let sub = AsyncBlockProcedure { finishWithResult in
-                go(finishWithResult)
-            }
-
+            let sub = BlockProcedure(block: block)
             sub.log.enabled = false
             sub.system.enabled = false
 
             sub.addDidFinishBlockObserver { (_, error) in
                 if let error = error {
-                    finishWithResult(.failure(ProcedureKitError.dependency(finishedWithError: error)))
+                    procedure.finish(with: ProcedureKitError.dependency(finishedWithError: error))
                 } else {
-                    finishWithResult(success)
+                    procedure.finish()
                 }
             }
 
@@ -116,3 +83,40 @@ open class UIBlockProcedure: AsyncBlockProcedure {
         }
     }
 }
+
+
+@available(*, deprecated: 5.0, message: "Use BlockProcedure directly and call .finish() on the block argument instead.")
+open class AsyncBlockProcedure: BlockProcedure {
+
+    public typealias Output = Void
+    public typealias FinishingBlock = (ProcedureResult<Output>) -> Void
+    public typealias Block = (@escaping FinishingBlock) -> Void
+
+    public init(block: @escaping Block) {
+        super.init { (procedure) in
+            block { result in
+                procedure.finish(with: result.error)
+            }
+        }
+    }
+}
+
+@available(*, deprecated: 5.0, message: "Use BlockProcedure directly and query the procedure argument inside your block.")
+open class CancellableBlockProcedure: BlockProcedure {
+
+    /// A block that receives a closure (that returns the current value of `isCancelled`
+    /// for the CancellableResultProcedure), and returns a value (which is set as the
+    /// CancellableResultProcedure's `output`).
+    public typealias ThrowingCancellableBlock = (() -> Bool) throws -> Void
+
+    public init(cancellableBlock: @escaping ThrowingCancellableBlock) {
+        super.init { (procedure) in
+            do {
+                try cancellableBlock { procedure.isCancelled }
+                procedure.finish()
+            }
+            catch { procedure.finish(with: error) }
+        }
+    }
+}
+

--- a/Sources/ProcedureKit/Block.swift
+++ b/Sources/ProcedureKit/Block.swift
@@ -9,14 +9,14 @@ open class BlockProcedure: Procedure {
     public typealias SelfBlock = (BlockProcedure) -> Void
     public typealias ThrowingVoidBlock = () throws -> Void
 
-    public enum BlockStorage {
+    enum BlockStorage {
         case asSelf(SelfBlock)
         case asVoid(ThrowingVoidBlock)
     }
 
     public static var defaultTimeoutInterval: TimeInterval = 3.0
 
-    public let storage: BlockStorage
+    let storage: BlockStorage
 
     public init(block: @escaping SelfBlock) {
         self.storage = .asSelf(block)

--- a/Sources/ProcedureKit/Result.swift
+++ b/Sources/ProcedureKit/Result.swift
@@ -1,0 +1,72 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2015-2018 ProcedureKit. All rights reserved.
+//
+
+open class ResultProcedure<Output>: BlockProcedure, OutputProcedure {
+
+    public typealias ThrowingOutputBlock = (ResultProcedure<Output>) throws -> Output
+
+    public var output: Pending<ProcedureResult<Output>> = .pending
+
+    public override init(block: @escaping SelfBlock) {
+        super.init(block: block)
+    }
+
+    public init(block: @escaping ThrowingOutputBlock) {
+        super.init { (procedure) in
+            var outputProcedure = procedure as! ResultProcedure<Output>
+            defer {
+                if false == outputProcedure.isFinished {
+                    outputProcedure.finish(with: outputProcedure.output.error)
+                }
+            }
+            do {
+                outputProcedure.output = .ready(.success(try block(outputProcedure)))
+            }
+            catch {
+                outputProcedure.output = .ready(.failure(error))
+            }
+        }
+    }
+
+    public init(block: @escaping () throws -> Output) {
+        super.init { (procedure) in
+            var outputProcedure = procedure as! ResultProcedure<Output>
+            defer { outputProcedure.finish(with: outputProcedure.output.error) }
+            do { outputProcedure.output = .ready(.success(try block())) }
+            catch { outputProcedure.output = .ready(.failure(error)) }
+        }
+    }
+}
+
+open class AsyncResultProcedure<Output>: ResultProcedure<Output> {
+
+    public typealias FinishingBlock = (ProcedureResult<Output>) -> Void
+    public typealias Block = (@escaping FinishingBlock) -> Void
+
+    public init(block: @escaping Block) {
+        super.init { (procedure) in
+            block { result in
+                let outputProcedure = procedure as! ResultProcedure<Output>
+                outputProcedure.finish(withResult: result)
+            }
+        }
+    }
+}
+
+@available(*, deprecated: 5.0, message: "Use ResultProcedure directly and query the procedure argument inside your block.")
+open class CancellableResultProcedure<Output>: ResultProcedure<Output> {
+
+    /// A block that receives a closure (that returns the current value of `isCancelled`
+    /// for the CancellableResultProcedure), and returns a value (which is set as the
+    /// CancellableResultProcedure's `output`).
+    public typealias ThrowingCancellableOutputBlock = (() -> Bool) throws -> Output
+
+    public init(cancellableBlock: @escaping ThrowingCancellableOutputBlock) {
+        super.init { (resultProcedure) -> Output in
+            return try cancellableBlock { resultProcedure.isCancelled }
+        }
+    }
+}

--- a/Tests/ProcedureKitTests/BlockProcedureTests.swift
+++ b/Tests/ProcedureKitTests/BlockProcedureTests.swift
@@ -10,9 +10,21 @@ import TestingProcedureKit
 
 class BlockProcedureTests: ProcedureKitTestCase {
 
-    func test__block_executes() {
+    func test__void_block_procedure() {
         var blockDidExecute = false
         let block = BlockProcedure { blockDidExecute = true }
+        wait(for: block)
+        XCTAssertTrue(blockDidExecute)
+        PKAssertProcedureFinished(block)
+    }
+
+    func test__self_block_procedure() {
+        var blockDidExecute = false
+        let block = BlockProcedure { (procedure) in
+            blockDidExecute = true
+            procedure.log.debug.message("Hello world")
+            procedure.finish()
+        }
         wait(for: block)
         XCTAssertTrue(blockDidExecute)
         PKAssertProcedureFinished(block)
@@ -121,6 +133,16 @@ class UIBlockProcedureTests: ProcedureKitTestCase {
         }
         wait(for: block)
         XCTAssertTrue(blockDidExecute)
+        PKAssertProcedureFinished(block)
+    }
+
+    func test__block_executes_on_main_queue() {
+        var blockDidExecuteOnMainQueue = false
+        let block = UIBlockProcedure {
+            blockDidExecuteOnMainQueue = DispatchQueue.isMainDispatchQueue
+        }
+        wait(for: block)
+        XCTAssertTrue(blockDidExecuteOnMainQueue)
         PKAssertProcedureFinished(block)
     }
 


### PR DESCRIPTION
- [x] Remove API complexity with `BlockProcedure` and `AsyncProcedure`
- [x] Support accessing `self` inside the block, to expose `log` etc
- [x] Maintain existing APIs with deprecation warnings
