### PR TITLE
Refactors InsertManagedObjectsProcedure

### DIFF
--- a/ProcedureKit.xcodeproj/project.pbxproj
+++ b/ProcedureKit.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		653CA0741D60AB1B0070B7A2 /* ProcedureKitCloud.h in Headers */ = {isa = PBXBuildFile; fileRef = 653CA0731D60AB1B0070B7A2 /* ProcedureKitCloud.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		653CA0781D60ABC90070B7A2 /* ProcedureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */; };
 		653CA07B1D60ABD30070B7A2 /* TestingProcedureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65CFC6161D60900000CAD875 /* TestingProcedureKit.framework */; };
+		6573A4FC21787D0000FDA362 /* ProcessManagedObjectContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6573A4FB21787D0000FDA362 /* ProcessManagedObjectContext.swift */; };
 		658BE06F20BC69170021F11B /* ProcedureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65CFC5F01D608A5500CAD875 /* ProcedureKit.framework */; };
 		658BE07020BC69170021F11B /* TestingProcedureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65CFC6161D60900000CAD875 /* TestingProcedureKit.framework */; };
 		658BE07220BC72540021F11B /* MakeFetchedResultController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658BE07120BC72540021F11B /* MakeFetchedResultController.swift */; };
@@ -561,6 +562,7 @@
 		653CA0621D60AA990070B7A2 /* ProcedureKitCloudTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ProcedureKitCloudTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		653CA0731D60AB1B0070B7A2 /* ProcedureKitCloud.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProcedureKitCloud.h; path = "Supporting Files/ProcedureKitCloud.h"; sourceTree = "<group>"; };
 		653CA0751D60AB2B0070B7A2 /* ProcedureKitCloud.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = ProcedureKitCloud.xcconfig; path = "Supporting Files/ProcedureKitCloud.xcconfig"; sourceTree = "<group>"; };
+		6573A4FB21787D0000FDA362 /* ProcessManagedObjectContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessManagedObjectContext.swift; sourceTree = "<group>"; };
 		658BE07120BC72540021F11B /* MakeFetchedResultController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeFetchedResultController.swift; sourceTree = "<group>"; };
 		658BE07320BC77AD0021F11B /* MakeFetchedResultsControllerProcedureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeFetchedResultsControllerProcedureTests.swift; sourceTree = "<group>"; };
 		658BE07520BC99100021F11B /* InsertManagedObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertManagedObjects.swift; sourceTree = "<group>"; };
@@ -1018,11 +1020,12 @@
 		65A0E4B020B851D4002D6C8C /* ProcedureKitCoreData */ = {
 			isa = PBXGroup;
 			children = (
-				65068FAC20C62AE300B0A0A3 /* MakesBackgroundManagedObjectContext.swift */,
 				651E670420C610D800BE520E /* CoreDataHelpers.swift */,
 				658BE07520BC99100021F11B /* InsertManagedObjects.swift */,
 				65A0E4B120B85213002D6C8C /* LoadCoreData.swift */,
 				658BE07120BC72540021F11B /* MakeFetchedResultController.swift */,
+				65068FAC20C62AE300B0A0A3 /* MakesBackgroundManagedObjectContext.swift */,
+				6573A4FB21787D0000FDA362 /* ProcessManagedObjectContext.swift */,
 				65A0E4C420BB2E51002D6C8C /* SaveManagedObjectContext.swift */,
 			);
 			name = ProcedureKitCoreData;
@@ -2332,6 +2335,7 @@
 				658BE07620BC99100021F11B /* InsertManagedObjects.swift in Sources */,
 				658BE07220BC72540021F11B /* MakeFetchedResultController.swift in Sources */,
 				65A0E4C520BB2E51002D6C8C /* SaveManagedObjectContext.swift in Sources */,
+				6573A4FC21787D0000FDA362 /* ProcessManagedObjectContext.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/ProcedureKitCoreData/ProcessManagedObjectContext.swift
+++ b/Sources/ProcedureKitCoreData/ProcessManagedObjectContext.swift
@@ -1,0 +1,47 @@
+//
+//  ProcedureKit
+//
+//  Copyright © 2015-2018 ProcedureKit. All rights reserved.
+//
+
+#if SWIFT_PACKAGE
+import ProcedureKit
+import Foundation
+#endif
+
+import CoreData
+
+protocol ManagedObjectContextProcessing: class {
+
+    var managedObjectContext: Pending<NSManagedObjectContext> { get set }
+}
+
+internal final class ProcessManagedObjectContext: GroupProcedure {
+
+    init<Processing: Procedure>(dispatchQueue underlyingQueue: DispatchQueue?, do processing: Processing, in makesManagedObjectContext: MakesBackgroundManagedObjectContext, save shouldSaveManagedObjectContext: Bool) where Processing: ManagedObjectContextProcessing {
+
+        var operations: [Operation] = []
+
+        // 1. Create MOC
+        let create = ResultProcedure { makesManagedObjectContext.newBackgroundContext() }
+        create.addWillFinishBlockObserver { (procedure, error, _) in
+            if let moc = procedure.output.success {
+                processing.managedObjectContext = .ready(moc)
+            }
+        }
+        processing.addDependency(create)
+        operations.append(create)
+
+        // 2. Perform processing
+        operations.append(processing)
+
+        // 3. Save MOC
+        if shouldSaveManagedObjectContext {
+            let save = SaveManagedObjectContext().injectResult(from: create)
+            save.addDependency(processing)
+            operations.append(save)
+        }
+
+        super.init(dispatchQueue: underlyingQueue, operations: operations)
+    }
+}

--- a/Tests/ProcedureKitCoreDataTests/InsertManagedObjectsProcedureTests.swift
+++ b/Tests/ProcedureKitCoreDataTests/InsertManagedObjectsProcedureTests.swift
@@ -66,7 +66,5 @@ final class InsertManagedObjectsProcedureTests: ProcedureKitCoreDataTestCase {
         }
 
         XCTAssertEqual(names.count, 0)
-        XCTAssertTrue(insert.managedObjectContext.hasChanges)
-
     }
 }

--- a/Tests/ProcedureKitCoreDataTests/ProcedureKitCoreDataTests.swift
+++ b/Tests/ProcedureKitCoreDataTests/ProcedureKitCoreDataTests.swift
@@ -21,7 +21,6 @@ open class ProcedureKitCoreDataTestCase: ProcedureKitTestCase {
 
         let shouldSave: Bool
         let download: ResultProcedure<[Item]>
-        var managedObjectContext: NSManagedObjectContext!
 
         init(items: [Item], andSave shouldSave: Bool = true) {
             self.shouldSave = shouldSave
@@ -57,8 +56,6 @@ open class ProcedureKitCoreDataTestCase: ProcedureKitTestCase {
             }
 
             addChild(insert)
-
-            self.managedObjectContext = insert.managedObjectContext
 
             super.execute()
         }


### PR DESCRIPTION
Following discussion in #903.

This ticket introduces a (currently) internal class to perform MOC processing. Essentially it's a `GroupProcedure` subclass which will create an MOC, set it on a "processing" class (via protocol conformance), and then save the MOC.

This means, that the `InsertManagedObjectsProcedure` public class, is just a thin wrapper responsible for defining the "processing" class.

One benefit of this, is that all the handling of the MOC is entirely inside the class on the same `DispatchQueue`.