### PR TITLE
Add missing  parameter name in various functions

### DIFF
--- a/Sources/ProcedureKit/Procedure.swift
+++ b/Sources/ProcedureKit/Procedure.swift
@@ -996,7 +996,7 @@ open class Procedure: Operation, ProcedureProtocol {
 
      */
 
-    open func procedureDidCancel(with: Error?) {
+    open func procedureDidCancel(with error: Error?) {
         // no-op
     }
 
@@ -1115,9 +1115,9 @@ open class Procedure: Operation, ProcedureProtocol {
 
     // MARK: - Finishing
 
-    open func procedureWillFinish(with: Error?) { }
+    open func procedureWillFinish(with error: Error?) { }
 
-    open func procedureDidFinish(with: Error?) { }
+    open func procedureDidFinish(with error: Error?) { }
 
     /**
      Finish method which must be called eventually after an operation has

--- a/Sources/ProcedureKit/ProcedureObserver.swift
+++ b/Sources/ProcedureKit/ProcedureObserver.swift
@@ -58,7 +58,7 @@ public protocol ProcedureObserver {
 
      - parameter procedure: the observed `Procedure`.
      */
-    func did(cancel procedure: Procedure, with: Error?)
+    func did(cancel procedure: Procedure, with error: Error?)
 
     /**
      The procedure will add a new `Operation` instance to the
@@ -84,17 +84,17 @@ public protocol ProcedureObserver {
      The procedure will finish. Any errors that were encountered are collected here.
 
      - parameter procedure: the observed `Procedure`.
-     - parameter errors: an array of `Error`s.
+     - parameter errors: an Error.
      */
-    func will(finish procedure: Procedure, with: Error?, pendingFinish: PendingFinishEvent)
+    func will(finish procedure: Procedure, with error: Error?, pendingFinish: PendingFinishEvent)
 
     /**
      The procedure did finish. Any errors that were encountered are collected here.
 
      - parameter procedure: the observed `Procedure`.
-     - parameter errors: an array of `ErrorType`s.
+     - parameter error: an Error.
      */
-    func did(finish procedure: Procedure, with: Error?)
+    func did(finish procedure: Procedure, with error: Error?)
 
     /**
      Provide a queue onto which observer callbacks will be dispatched.
@@ -141,7 +141,7 @@ public extension ProcedureObserver {
     func did(execute procedure: Procedure) { }
 
     /// Do nothing.
-    func did(cancel procedure: Procedure, with: Error?) { }
+    func did(cancel procedure: Procedure, with error: Error?) { }
 
     /// Do nothing.
     func procedure(_ procedure: Procedure, willAdd newOperation: Operation) { }
@@ -150,10 +150,10 @@ public extension ProcedureObserver {
     func procedure(_ procedure: Procedure, didAdd newOperation: Operation) { }
 
     /// Do nothing.
-    func will(finish procedure: Procedure, with: Error?, pendingFinish: PendingFinishEvent) { }
+    func will(finish procedure: Procedure, with error: Error?, pendingFinish: PendingFinishEvent) { }
 
     /// Do nothing.
-    func did(finish procedure: Procedure, with: Error?) { }
+    func did(finish procedure: Procedure, with error: Error?) { }
 
     /// - Returns: nil
     var eventQueue: DispatchQueueProtocol? { return nil }

--- a/Sources/ProcedureKit/ProcedureProcotol.swift
+++ b/Sources/ProcedureKit/ProcedureProcotol.swift
@@ -34,17 +34,17 @@ public protocol ProcedureProtocol: class {
 
     // Cancelling
 
-    func cancel(with: Error?)
+    func cancel(with error: Error?)
 
-    func procedureDidCancel(with: Error?)
+    func procedureDidCancel(with error: Error?)
 
     // Finishing
 
-    func finish(with: Error?)
+    func finish(with error: Error?)
 
-    func procedureWillFinish(with: Error?)
+    func procedureWillFinish(with error: Error?)
 
-    func procedureDidFinish(with: Error?)
+    func procedureDidFinish(with error: Error?)
 
     // Observers
 
@@ -82,11 +82,11 @@ public extension ProcedureProtocol {
         return error != nil
     }
 
-    func procedureDidCancel(with: Error?) { }
+    func procedureDidCancel(with error: Error?) { }
 
-    func procedureWillFinish(with: Error?) { }
+    func procedureWillFinish(with error: Error?) { }
 
-    func procedureDidFinish(with: Error?) { }
+    func procedureDidFinish(with error: Error?) { }
 
     // Deprecations
 


### PR DESCRIPTION
There is a missing `error` parameter name in various functions.
It's needed as the code looks weird without it:

Before:
```swift
override func procedureDidFinish(with: Error?) {
      guard with == nil else { return }
       ...
}
```

After:
```swift
override func procedureDidFinish(with error: Error?) {
      guard error == nil else { return }
       ...
}
```