### PR TITLE
Open network recovery

### DIFF
--- a/Sources/ProcedureKitNetwork/Network.swift
+++ b/Sources/ProcedureKitNetwork/Network.swift
@@ -97,22 +97,22 @@ class NetworkReachabilityWaitProcedure: Procedure {
     }
 }
 
-class NetworkRecovery<T: Procedure> where T: NetworkOperation {
+open class NetworkRecovery<T: Procedure> where T: NetworkOperation {
 
     let resilience: NetworkResilience
     let connectivity: Reachability.Connectivity
-    var reachability: SystemReachability = Reachability.Manager.shared
+    fileprivate var reachability: SystemReachability = Reachability.Manager.shared
 
     var max: Int { return resilience.maximumNumberOfAttempts }
 
     var wait: WaitStrategy { return resilience.backoffStrategy }
 
-    init(resilience: NetworkResilience, connectivity: Reachability.Connectivity) {
+    public init(resilience: NetworkResilience, connectivity: Reachability.Connectivity) {
         self.resilience = resilience
         self.connectivity = connectivity
     }
 
-    func recover(withInfo info: RetryFailureInfo<T>, payload: RepeatProcedurePayload<T>) -> RepeatProcedurePayload<T>? {
+    open func recover(withInfo info: RetryFailureInfo<T>, payload: RepeatProcedurePayload<T>) -> RepeatProcedurePayload<T>? {
 
         let networkResponse = info.operation.makeNetworkResponse()
 
@@ -135,7 +135,7 @@ class NetworkRecovery<T: Procedure> where T: NetworkOperation {
         return networkError.waitForReachabilityChangeBeforeRetrying
     }
 
-    func shouldRetry(givenNetworkResponse networkResponse: ProcedureKitNetworkResponse) -> Bool {
+    open func shouldRetry(givenNetworkResponse networkResponse: ProcedureKitNetworkResponse) -> Bool {
 
         // Check that we've actually got a network error & suggested delay
         if let networkError = networkResponse.error {
@@ -165,12 +165,16 @@ open class NetworkProcedure<T: Procedure>: RetryProcedure<T> where T: NetworkOpe
         set { recovery.reachability = newValue }
     }
 
-    public init<OperationIterator>(dispatchQueue: DispatchQueue? = nil, resilience: NetworkResilience = DefaultNetworkResilience(), connectivity: Reachability.Connectivity = .any, iterator base: OperationIterator) where OperationIterator: IteratorProtocol, OperationIterator.Element == T {
-        recovery = NetworkRecovery<T>(resilience: resilience, connectivity: connectivity)
+    public init<OperationIterator>(dispatchQueue: DispatchQueue? = nil, recovery: NetworkRecovery<T>, iterator base: OperationIterator) where OperationIterator: IteratorProtocol, OperationIterator.Element == T {
+        self.recovery = recovery
         super.init(dispatchQueue: dispatchQueue, max: recovery.max, wait: recovery.wait, iterator: base, retry: recovery.recover(withInfo:payload:))
-        if let timeout = resilience.requestTimeout {
+        if let timeout = recovery.resilience.requestTimeout {
             appendConfigureBlock { $0.addObserver(TimeoutObserver(by: timeout)) }
         }
+    }
+
+    public convenience init<OperationIterator>(dispatchQueue: DispatchQueue? = nil, resilience: NetworkResilience = DefaultNetworkResilience(), connectivity: Reachability.Connectivity = .any, iterator base: OperationIterator) where OperationIterator: IteratorProtocol, OperationIterator.Element == T {
+        self.init(dispatchQueue: dispatchQueue, recovery: NetworkRecovery<T>(resilience: resilience, connectivity: connectivity), iterator: base)
     }
 
     public convenience init(dispatchQueue: DispatchQueue = DispatchQueue.default, resilience: NetworkResilience = DefaultNetworkResilience(), connectivity: Reachability.Connectivity = .any, body: @escaping () -> T?) {

--- a/Sources/ProcedureKitNetwork/NetworkSupport.swift
+++ b/Sources/ProcedureKitNetwork/NetworkSupport.swift
@@ -135,7 +135,7 @@ struct ProcedureKitNetworkError: Error {
     }
 }
 
-struct ProcedureKitNetworkResponse {
+public struct ProcedureKitNetworkResponse {
 
     let response: HTTPURLResponse?
     let error: ProcedureKitNetworkError?
@@ -144,7 +144,7 @@ struct ProcedureKitNetworkResponse {
         return response?.code
     }
 
-    init(response: HTTPURLResponse? = nil, error: Error? = nil) {
+    public init(response: HTTPURLResponse? = nil, error: Error? = nil) {
         self.response = response
         self.error = error.map { ProcedureKitNetworkError(error: $0) }
     }
@@ -288,9 +288,9 @@ public extension HTTPURLResponse {
     }
 }
 
-extension NetworkOperation {
+public extension NetworkOperation {
 
-    func makeNetworkResponse() -> ProcedureKitNetworkResponse {
+    public func makeNetworkResponse() -> ProcedureKitNetworkResponse {
         return ProcedureKitNetworkResponse(response: urlResponse, error: error)
     }
 }

--- a/Sources/ProcedureKitNetwork/NetworkSupport.swift
+++ b/Sources/ProcedureKitNetwork/NetworkSupport.swift
@@ -98,15 +98,15 @@ public struct HTTPPayloadRequest<Payload: Equatable>: Equatable {
 
 // MARK: - Error Handling
 
-struct ProcedureKitNetworkError: Error {
+public struct ProcedureKitNetworkError: Error {
 
-    let underlyingError: Error
+    public let underlyingError: Error
 
-    var errorCode: Int {
+    public var errorCode: Int {
         return (underlyingError as NSError).code
     }
 
-    var isTransientError: Bool {
+    public var isTransientError: Bool {
         switch errorCode {
         case NSURLErrorNetworkConnectionLost:
             return true
@@ -115,7 +115,7 @@ struct ProcedureKitNetworkError: Error {
         }
     }
 
-    var isTimeoutError: Bool {
+    public var isTimeoutError: Bool {
         guard let procedureKitError = underlyingError as? ProcedureKitError else { return false }
         guard case .timedOut(with: _) = procedureKitError.context else { return false }
         return true
@@ -137,10 +137,10 @@ struct ProcedureKitNetworkError: Error {
 
 public struct ProcedureKitNetworkResponse {
 
-    let response: HTTPURLResponse?
-    let error: ProcedureKitNetworkError?
+    public let response: HTTPURLResponse?
+    public let error: ProcedureKitNetworkError?
 
-    var httpStatusCode: HTTPStatusCode? {
+    public var httpStatusCode: HTTPStatusCode? {
         return response?.code
     }
 


### PR DESCRIPTION
This merge request opens the NetworkRecovery<T> class, allowing customized recovery logic when network procedures fail. 

This makes handling cases when network procedures fail, and are recoverable, but require additional configuration, for example requests that have failed (401) using Oauth, which are possibly recoverable using a refresh token:

```swift
class AuthenticatedNetworkRecovery: NetworkRecovery<SecuredNetworkProcedure> {
    let authManager: AuthManager

    init(authManager: AuthManager) {
        self.authManager = authManager
        super.init(resilience: DefaultNetworkResilience(), connectivity: .any)
    }

    override func recover(withInfo info: RetryFailureInfo<SecuredNetworkProcedure>, payload: RepeatProcedurePayload<SecuredNetworkProcedure>) -> RepeatProcedurePayload<SecuredNetworkProcedure>? {
        let recovery = super.recover(withInfo: info, payload: payload)

        let response = info.operation.makeNetworkResponse()
        if let recoveryOp = recovery?.operation, response.httpStatusCode == .unauthorized {
            let login = TokenRefresh(currentToken: info.operation.accessTokenUsed, 
                                     authManager: authManager)
            recoveryOp.addDependency(login)
            recoveryOp.addCondition(NoFailedDependenciesCondition())
            info.addOperations(login)

            return RepeatProcedurePayload(operation: recoveryOp, delay: nil, configure: nil)
        }

        return recovery
    }

    override func shouldRetry(givenNetworkResponse networkResponse: ProcedureKitNetworkResponse) -> Bool {
        if networkResponse.httpStatusCode == .unauthorized {
            return true
        }

        return super.shouldRetry(givenNetworkResponse: networkResponse)
    }
}
```

Handling cases such as these currently, requires significantly more code/effort, especially if you want to utilize all of the code written to handle reachability, transient errors, et all. From what I can tell, there was currently no way to implement logic where a failed network operation should be retried, but only after an additional dependancy completes successfully first.

As a side effect of opening the NetworkRecovery<T> class, the ProcedureKitNetworkResponse and ProcedureKitNetworkError structs also had to be exposed.

In general, this change won't effect current users of the NetworkProcedure<T>, however, it does allow any cases requiring more complex or custom recovery logic to be handled quite easily.