### PR TITLE
Failing to build in SPM due to missing Foundation import

### DIFF
--- a/.ci/buildkite/pipeline.sh
+++ b/.ci/buildkite/pipeline.sh
@@ -47,8 +47,13 @@ steps:
   name: "Test CocoaPods Integration"
   command: ".ci/scripts/test-cocoapods"  
   agents:
-    queue: "iOS-Simulator"
     xcode: "$XCODE"
+- 
+  name: "Test SPM Integration"
+  command: ".ci/scripts/test-spm"  
+  agents:
+    xcode: "$XCODE"
+    
 YAML
 
 cat <<-YAML

--- a/.ci/scripts/test-spm
+++ b/.ci/scripts/test-spm
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set +u
+source /usr/local/opt/chruby/share/chruby/chruby.sh
+chruby ruby
+set -u
+
+echo "cd Integrations/SPM"
+cd "Integrations/SPM"
+
+echo "--- SPM update"
+swift package update
+
+echo "--- swift build"
+swift build
+
+echo "--- swift test"
+swift test

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ docs
 .ci/xcodebuild-data/*
 .fastlane/README.md
 .ci/results/**
+/Integrations/SPM/Package.resolved

--- a/Integrations/SPM/.gitignore
+++ b/Integrations/SPM/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Integrations/SPM/Package.swift
+++ b/Integrations/SPM/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:4.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SPM-Integration-Check",
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+        // Add the current branch of ProcedureKit as a dependency
+        .package(path: "../..")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "SPM-Integration-Check",
+            dependencies: [
+                "ProcedureKit"
+            ]),
+        .testTarget(
+            name: "SPM-Integration-CheckTests",
+            dependencies: ["SPM-Integration-Check"]),
+    ]
+)

--- a/Integrations/SPM/Sources/SPM-Integration-Check/main.swift
+++ b/Integrations/SPM/Sources/SPM-Integration-Check/main.swift
@@ -1,0 +1,3 @@
+import ProcedureKit
+
+print("Hello, world!")

--- a/Integrations/SPM/Tests/SPM-Integration-CheckTests/SPM-Integration-CheckTests.swift
+++ b/Integrations/SPM/Tests/SPM-Integration-CheckTests/SPM-Integration-CheckTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+import class Foundation.Bundle
+import ProcedureKit
+
+final class SwiftPackageManagerTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        let fooBinary = productsDirectory.appendingPathComponent("SPM-Integration-Check")
+
+        let process = Process()
+        process.executableURL = fooBinary
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)
+
+        XCTAssertEqual(output, "Hello, world!\n")
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+      #else
+        return Bundle.main.bundleURL
+      #endif
+    }
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Sources/ProcedureKit/Block.swift
+++ b/Sources/ProcedureKit/Block.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2015-2018 ProcedureKit. All rights reserved.
 //
 
+import Foundation
+
 open class BlockProcedure: Procedure {
 
     public typealias SelfBlock = (BlockProcedure) -> Void


### PR DESCRIPTION
- [x] Adds missing `import Foundation` to `Block.swift`
- [x] Adds a CI step to build/test a dummy SPM package which imports the local ProcedureKit as a dependency.