### PR TITLE
Adds public accessor modifiers to LaunchRequest

### DIFF
--- a/Sources/ProcedureKitMac/Process.swift
+++ b/Sources/ProcedureKitMac/Process.swift
@@ -15,25 +15,25 @@ open class ProcessProcedure: Procedure, InputProcedure, OutputProcedure {
 
     public struct LaunchRequest {
         /// (Read-only) The path to the executable to be launched.
-        let executableURL: URL
+        public let executableURL: URL
 
         /// (Read-only) The command arguments that should be used to launch the executable.
-        let arguments: [String]?
+        public let arguments: [String]?
 
         /// (Read-only) The current directory to be used when launching the executable.
-        let currentDirectoryURL: URL?
+        public let currentDirectoryURL: URL?
 
         /// (Read-only) The environment to be used when launching the executable.
-        let environment: [String : String]?
+        public let environment: [String : String]?
 
         /// (Read-only) The standard error (FileHandle or Pipe object).
-        let standardError: Any?
+        public let standardError: Any?
 
         /// (Read-only) The standard input (FileHandle or Pipe object).
-        let standardInput: Any?
+        public let standardInput: Any?
 
         /// (Read-only) The standard output (FileHandle or Pipe object).
-        let standardOutput: Any?
+        public let standardOutput: Any?
 
         /// Initialize a request to launch a Process.
         ///
@@ -52,7 +52,7 @@ open class ProcessProcedure: Procedure, InputProcedure, OutputProcedure {
         ///   - standardError: (optional) the standard error (FileHandle or Pipe object)
         ///   - standardInput: (optional) the standard input (FileHandle or Pipe object)
         ///   - standardOutput: (optional) the standard output (FileHandle or Pipe object)
-        init(executableURL: URL, arguments: [String]? = nil, currentDirectoryURL: URL? = nil, environment: [String : String]? = nil, standardError: Any? = nil, standardInput: Any? = nil, standardOutput: Any? = nil) {
+        public init(executableURL: URL, arguments: [String]? = nil, currentDirectoryURL: URL? = nil, environment: [String : String]? = nil, standardError: Any? = nil, standardInput: Any? = nil, standardOutput: Any? = nil) {
             self.executableURL = executableURL
             self.arguments = arguments
             self.currentDirectoryURL = currentDirectoryURL


### PR DESCRIPTION
Without a public init method, a LaunchRequest cannot be created, but is required by the designated initializer.